### PR TITLE
[Bugfix] Reverse enumeration issues with range spanning in to multiple pages

### DIFF
--- a/YapDatabase/Internal/YapDatabaseOrder.m
+++ b/YapDatabase/Internal/YapDatabaseOrder.m
@@ -1643,7 +1643,6 @@
 	if (block == NULL) return;
 	
 	NSEnumerationOptions options = (inOptions & NSEnumerationReverse); // We only support NSEnumerationReverse
-	BOOL forwardEnumeration = (options == NSEnumerationReverse);
 	
 	
 	__block NSUInteger pageOffset;


### PR DESCRIPTION
Say I have a ordered collection with keys 0 to 105

I reverse enumerating through a collection using enumerateKeysInRange:withOptions:...
With NSEnumerationReverse and range (95,0)

I would get this:

Key 199,
Key 198,
Key 197,
Key 196,
Key 195,
Key 4, 
Key 3, 
Key 2, 
Key 1, 
Key 0,

The pageOffset wasn't getting computed when transitioning between pages, also for above if I use NSEnumerationConcurrent, I'd get the following error:

enumerateKeysInRange:withOptions:usingBlock:transaction:: Range out of bounds: range(95, 10) >= numberOfKeys(206)
