### PR TITLE
Fix 'No previous prototype for function' compiler warning

### DIFF
--- a/YapDatabase/Internal/YapDatabaseLogging.m
+++ b/YapDatabase/Internal/YapDatabaseLogging.m
@@ -1,6 +1,8 @@
 #import "YapDatabaseLogging.h"
 
 
+#if YapDatabaseLoggingTechnique != YapDatabaseLoggingTechnique_Lumberjack
+
 /**
  * This method is based on CocoaLumberjack's DDExtractFileNameWithoutExtension function.
  * The copy option has been removed, as we only use __FILE__ as the filePath parameter.
@@ -67,3 +69,5 @@ NSString *YDBExtractFileNameWithoutExtension(const char *filePath)
 	                                    encoding:NSUTF8StringEncoding
 	                                freeWhenDone:NO];
 }
+
+#endif


### PR DESCRIPTION
`YDBExtractFileNameWithoutExtension()` function in `YapDatabaseLogging.m` has prototype only when CocoaLumberjack isn't used, so for other case the compiler will issue a warning. 
