### PR TITLE
Small bug fix for section changes consolidation crashing

### DIFF
--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
@@ -1041,6 +1041,8 @@
 					i++;
 				}
 			}
+            
+            [indexSet removeAllIndexes];
 		}
 	}
 }


### PR DESCRIPTION
YapDatabase now doesn’t crash when replacing all section&rows.

I was trying to replace all my dynamic sections (groups) using a View with simple Mapping. My code simply deleted old data and replaced them with fresh objects in a collection (all in a single transaction).

However, when `yapDatabaseModified:` was called, YapDatabase crashed due to an out of bounds exception in `consolidateSectionChanges:` (`YapDatabaseViewChange.m`).

Looking at the code, I saw `indexSet` not being cleared. So, I found same pattern (calling `[indexSet removeAllIndexes];`) in `consolidateRowChanges:`, and added the same one-liner to the bugged method. Actually it works.

I hope I've got it right :+1: 
