### PR TITLE
Add SQLCipher support

### DIFF
--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -6,16 +6,32 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
-  s.library      = 'sqlite3'
   s.author       = { "Robbie Hanson" => "robbiehanson@deusty.com" }
   s.source       = { :git => "https://github.com/yaptv/YapDatabase.git", :tag => s.version.to_s }
 
-  s.source_files = 'YapDatabase/**/*.{h,m,mm}'
-  s.xcconfig     = { 'OTHER_LDFLAGS' => '-weak_library /usr/lib/libc++.dylib' }
+  s.default_subspec = 'standard'
 
-  s.private_header_files = 'YapDatabase/**/Internal/*.h'
-  s.dependency 'CocoaLumberjack', '~> 1.6.3'
+  s.subspec 'common' do |ss|
+    ss.source_files = 'YapDatabase/**/*.{h,m,mm}'
+    ss.xcconfig     = { 'OTHER_LDFLAGS' => '-weak_library /usr/lib/libc++.dylib' }
 
-  s.requires_arc = true
+    ss.private_header_files = 'YapDatabase/**/Internal/*.h'
+    ss.dependency 'CocoaLumberjack', '~> 1.6.3'
+
+    ss.requires_arc = true
+  end
+
+  # use a builtin version of sqlite3
+  s.subspec 'standard' do |ss|
+    ss.library = 'sqlite3'
+    ss.dependency 'YapDatabase/common'
+  end
+
+  # use SQLCipher and enable -DSQLITE_HAS_CODEC flag
+  s.subspec 'SQLCipher' do |ss|
+    ss.dependency 'SQLCipher'
+    ss.dependency 'YapDatabase/common'
+    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC' }
+  end
 
 end

--- a/YapDatabase/Internal/YapDatabasePrivate.h
+++ b/YapDatabase/Internal/YapDatabasePrivate.h
@@ -156,6 +156,13 @@ extern NSString *const YapDatabaseNotificationKey;
 **/
 - (void)asyncCheckpoint:(uint64_t)maxCheckpointableSnapshot;
 
+#ifdef SQLITE_HAS_CODEC
+/**
+ * Configures database encryption via SQLCipher.
+ **/
+- (BOOL)configureEncryptionForDatabase:(sqlite3*)sqlite;
+#endif
+
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -211,6 +211,11 @@
 				// And in all my testing, I've only seen the busy_handler called once per db.
 				
 				sqlite3_busy_timeout(db, 50); // milliseconds
+                
+#ifdef SQLITE_HAS_CODEC
+                // Configure SQLCipher encryption for the new database connection.
+                [database configureEncryptionForDatabase:db];
+#endif
 			}
 		}
 		

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -25,6 +25,9 @@ typedef enum {
 	YapDatabasePragmaSynchronous_Full   = 2,
 } YapDatabasePragmaSynchronous;
 
+#ifdef SQLITE_HAS_CODEC
+typedef NSString* (^YapDatabaseOptionsPassphraseBlock)(void);
+#endif
 
 @interface YapDatabaseOptions : NSObject <NSCopying>
 
@@ -60,6 +63,17 @@ typedef enum {
 **/
 @property (nonatomic, assign, readwrite) YapDatabasePragmaSynchronous pragmaSynchronous;
 
-
+#ifdef SQLITE_HAS_CODEC
+/**
+ * Set a block here that returns the passphrase for the SQLCipher
+ * database. This way you can fetch the passphrase from the keychain
+ * (or elsewhere) only when you need it, instead of persisting 
+ * it in memory.
+ *
+ * You must use the 'YapDatabase/SQLCipher' subspec
+ * in your Podfile for this option to take effect.
+ **/
+@property (nonatomic, copy) YapDatabaseOptionsPassphraseBlock passphraseBlock;
+#endif
 
 @end

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -32,7 +32,9 @@
 	YapDatabaseOptions *copy = [[[self class] alloc] init];
 	copy->corruptAction = corruptAction;
 	copy->pragmaSynchronous = pragmaSynchronous;
-	
+#ifdef SQLITE_HAS_CODEC
+    copy.passphraseBlock = _passphraseBlock;
+#endif
 	return copy;
 }
 


### PR DESCRIPTION
SQLCipher support has been added as a subspec, and it is very easy to setup. Following fmdb's example, just change your Podfile to:

```
pod 'YapDatabase/SQLCipher'
```

If you aren't using the SQLCipher subspec, your project won't even compile the encryption configuration options to prevent the case of accidentally trying to use encryption when support is not available.

``` obj-c
YapDatabaseOptions *options = [[YapDatabaseOptions alloc] init];
options.corruptAction = YapDatabaseCorruptAction_Fail;
options.passphraseBlock = ^{
    // You can also do things like fetch from the keychain in here
    return @"super secure passphrase";
};

self.database = [[YapDatabase alloc] initWithPath:databasePath
                                 objectSerializer:NULL
                               objectDeserializer:NULL
                               metadataSerializer:NULL
                             metadataDeserializer:NULL
                                  objectSanitizer:NULL
                                metadataSanitizer:NULL
                                          options:options];
```

I implemented the passphrase as a block to help prevent storing the credentials in memory any longer than necessary. This block will be executed on database setup, and when new connections are made to the database.

This pull request resolves issue #4.
