### PR TITLE
Renamed some local variables to fix shadowed variable warnings.

### DIFF
--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -1180,12 +1180,12 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 {
 	__block NSNumber *result = nil;
 	
-	[relationshipConnection->deletedInfo enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+	[relationshipConnection->deletedInfo enumerateKeysAndObjectsUsingBlock:^(id nextKey, id nextObj, BOOL *stop){
 		
-		__unsafe_unretained NSNumber *rowidNumber = (NSNumber *)key;
-		__unsafe_unretained YapCollectionKey *collectionKey = (YapCollectionKey *)obj;
+		__unsafe_unretained NSNumber *rowidNumber = (NSNumber *)nextKey;
+		__unsafe_unretained YapCollectionKey *collectionKey = (YapCollectionKey *)nextObj;
 		
-		if ([collectionKey.key isEqualToString:key] && [collectionKey.collection isEqualToString:collection])
+		if ([collectionKey.key isEqualToString:nextKey] && [collectionKey.collection isEqualToString:collection])
 		{
 			result = rowidNumber;
 			*stop = YES;

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
@@ -450,12 +450,12 @@
 						
 						while (prevRowCount > 0)
 						{
-							YapDatabaseViewRowChange *rowChange =
+							YapDatabaseViewRowChange *deleteRowChange =
 							    [YapDatabaseViewRowChange deleteKey:nil
 							                                inGroup:sectionChange->group
 							                                atIndex:(prevRowOffset+prevRowCount-1)];
 							
-							[rowChanges addObject:rowChange];
+							[rowChanges addObject:deleteRowChange];
 							prevRowCount--;
 						}
 						
@@ -548,10 +548,10 @@
 				
 				if (dependencyIndex < groupCount)
 				{
-					int changes = YapDatabaseViewChangedDependency;
+					int flags = YapDatabaseViewChangedDependency;
 					
 					YapDatabaseViewRowChange *rowChange =
-					    [YapDatabaseViewRowChange updateKey:nil changes:changes inGroup:group atIndex:dependencyIndex];
+					    [YapDatabaseViewRowChange updateKey:nil changes:flags inGroup:group atIndex:dependencyIndex];
 					
 					[rowChanges addObject:rowChange];
 				}
@@ -1712,7 +1712,7 @@
 			//
 			// Note: This code path is only taken if using a flexibleRange
 			
-			NSUInteger i = 0;
+			NSUInteger j = 0;
 			NSUInteger count = 0;
 			
 			NSUInteger index;
@@ -1721,7 +1721,7 @@
 			else
 				index = finalRangeLength - 1;
 			
-			while ((count < numberOfInsertOperationsToManuallyAdd) && (i < flexibleRangePinSideInsertDiff))
+			while ((count < numberOfInsertOperationsToManuallyAdd) && (j < flexibleRangePinSideInsertDiff))
 			{
 				// We need to be careful not to step on existing rowChanges.
 				// If there is an existing insert for this index, we need to continue onto the next index.
@@ -1770,7 +1770,7 @@
 				else
 					index--;
 				
-				i++;
+				j++;
 			}
 			
 			numberOfInsertOperationsToManuallyAdd -= count;

--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -1753,23 +1753,23 @@
 				const void *blob = sqlite3_column_blob(statement, 1);
 				int blobSize = sqlite3_column_bytes(statement, 1);
 				
-				NSString *key = [[NSString alloc] initWithBytes:text length:textSize encoding:NSUTF8StringEncoding];
-				NSUInteger keyIndex = [[keyIndexDict objectForKey:key] unsignedIntegerValue];
+				NSString *nextKey = [[NSString alloc] initWithBytes:text length:textSize encoding:NSUTF8StringEncoding];
+				NSUInteger nextKeyIndex = [[keyIndexDict objectForKey:nextKey] unsignedIntegerValue];
 				
 				NSData *data = [NSData dataWithBytesNoCopy:(void *)blob length:blobSize freeWhenDone:NO];
 				
-				id metadata = data ? connection->database->metadataDeserializer(collection, key, data) : nil;
+				id metadata = data ? connection->database->metadataDeserializer(collection, nextKey, data) : nil;
 				
 				if (metadata)
 				{
-					YapCollectionKey *cacheKey = [[YapCollectionKey alloc] initWithCollection:collection key:key];
+					YapCollectionKey *cacheKey = [[YapCollectionKey alloc] initWithCollection:collection key:nextKey];
 					
 					[connection->metadataCache setObject:metadata forKey:cacheKey];
 				}
 				
-				block(keyIndex, metadata, &stop);
+				block(nextKeyIndex, metadata, &stop);
 				
-				[keyIndexDict removeObjectForKey:key];
+				[keyIndexDict removeObjectForKey:nextKey];
 				
 				if (stop || isMutated) break;
 				
@@ -1960,21 +1960,21 @@
 				const void *blob = sqlite3_column_blob(statement, 1);
 				int blobSize = sqlite3_column_bytes(statement, 1);
 				
-				NSString *key = [[NSString alloc] initWithBytes:text length:textSize encoding:NSUTF8StringEncoding];
-				NSUInteger keyIndex = [[keyIndexDict objectForKey:key] unsignedIntegerValue];
+				NSString *nextKey = [[NSString alloc] initWithBytes:text length:textSize encoding:NSUTF8StringEncoding];
+				NSUInteger nextKeyIndex = [[keyIndexDict objectForKey:nextKey] unsignedIntegerValue];
 				
 				NSData *objectData = [NSData dataWithBytesNoCopy:(void *)blob length:blobSize freeWhenDone:NO];
-				id object = connection->database->objectDeserializer(collection, key, objectData);
+				id object = connection->database->objectDeserializer(collection, nextKey, objectData);
 				
 				if (object)
 				{
-					YapCollectionKey *cacheKey = [[YapCollectionKey alloc] initWithCollection:collection key:key];
+					YapCollectionKey *cacheKey = [[YapCollectionKey alloc] initWithCollection:collection key:nextKey];
 					[connection->objectCache setObject:object forKey:cacheKey];
 				}
 				
-				block(keyIndex, object, &stop);
+				block(nextKeyIndex, object, &stop);
 				
-				[keyIndexDict removeObjectForKey:key];
+				[keyIndexDict removeObjectForKey:nextKey];
 				
 				if (stop || isMutated) break;
 				
@@ -2173,10 +2173,10 @@
 				const unsigned char *text = sqlite3_column_text(statement, 0);
 				int textSize = sqlite3_column_bytes(statement, 0);
 				
-				NSString *key = [[NSString alloc] initWithBytes:text length:textSize encoding:NSUTF8StringEncoding];
-				NSUInteger keyIndex = [[keyIndexDict objectForKey:key] unsignedIntegerValue];
+				NSString *nextKey = [[NSString alloc] initWithBytes:text length:textSize encoding:NSUTF8StringEncoding];
+				NSUInteger nextKeyIndex = [[keyIndexDict objectForKey:nextKey] unsignedIntegerValue];
 				
-				YapCollectionKey *cacheKey = [[YapCollectionKey alloc] initWithCollection:collection key:key];
+				YapCollectionKey *cacheKey = [[YapCollectionKey alloc] initWithCollection:collection key:nextKey];
 				
 				id object = [connection->objectCache objectForKey:cacheKey];
 				if (object == nil)
@@ -2185,7 +2185,7 @@
 					int oBlobSize = sqlite3_column_bytes(statement, 1);
 					
 					NSData *oData = [NSData dataWithBytesNoCopy:(void *)oBlob length:oBlobSize freeWhenDone:NO];
-					object = connection->database->objectDeserializer(collection, key, oData);
+					object = connection->database->objectDeserializer(collection, nextKey, oData);
 					
 					if (object)
 						[connection->objectCache setObject:object forKey:cacheKey];
@@ -2205,7 +2205,7 @@
 					if (mBlobSize > 0)
 					{
 						NSData *mData = [NSData dataWithBytesNoCopy:(void *)mBlob length:mBlobSize freeWhenDone:NO];
-						metadata = connection->database->metadataDeserializer(collection, key, mData);
+						metadata = connection->database->metadataDeserializer(collection, nextKey, mData);
 					}
 					
 					if (metadata)
@@ -2214,9 +2214,9 @@
 						[connection->metadataCache setObject:[YapNull null] forKey:cacheKey];
 				}
 				
-				block(keyIndex, object, metadata, &stop);
+				block(nextKeyIndex, object, metadata, &stop);
 				
-				[keyIndexDict removeObjectForKey:key];
+				[keyIndexDict removeObjectForKey:nextKey];
 				
 				if (stop || isMutated) break;
 				


### PR DESCRIPTION
I have the warning for shadowed variables enabled in my project and there were a few instances where YapDatabase was showing warnings. I renamed the shadowed variables as best I could, but I'm definitely open to better naming suggestions.
