### PR TITLE
Converts enum typedefs to NS_ENUM or NS_OPTIONS as appropriate

### DIFF
--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.h
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.h
@@ -44,12 +44,12 @@ typedef void (^YapDatabaseFullTextSearchWithRowBlock)      \
 /**
  * Use this enum to specify what kind of block you're passing.
 **/
-typedef enum {
+typedef NS_ENUM(NSInteger, YapDatabaseFullTextSearchBlockType) {
 	YapDatabaseFullTextSearchBlockTypeWithKey       = 201,
 	YapDatabaseFullTextSearchBlockTypeWithObject    = 202,
 	YapDatabaseFullTextSearchBlockTypeWithMetadata  = 203,
 	YapDatabaseFullTextSearchBlockTypeWithRow       = 204
-} YapDatabaseFullTextSearchBlockType;
+};
 
 @interface YapDatabaseFullTextSearch : YapDatabaseExtension
 

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndex.h
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndex.h
@@ -48,12 +48,12 @@ typedef void (^YapDatabaseSecondaryIndexWithRowBlock)      \
 /**
  * Use this enum to specify what kind of block you're passing.
 **/
-typedef enum {
+typedef NS_ENUM(NSInteger, YapDatabaseSecondaryIndexBlockType) {
 	YapDatabaseSecondaryIndexBlockTypeWithKey       = 1031,
 	YapDatabaseSecondaryIndexBlockTypeWithObject    = 1032,
 	YapDatabaseSecondaryIndexBlockTypeWithMetadata  = 1033,
 	YapDatabaseSecondaryIndexBlockTypeWithRow       = 1034
-} YapDatabaseSecondaryIndexBlockType;
+};
 
 
 @interface YapDatabaseSecondaryIndex : YapDatabaseExtension

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexSetup.h
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexSetup.h
@@ -2,12 +2,11 @@
 
 @class YapDatabaseSecondaryIndexColumn;
 
-typedef enum {
+typedef NS_ENUM(NSInteger, YapDatabaseSecondaryIndexType) {
 	YapDatabaseSecondaryIndexTypeInteger,
 	YapDatabaseSecondaryIndexTypeReal,
 	YapDatabaseSecondaryIndexTypeText
-} YapDatabaseSecondaryIndexType;
-
+};
 
 @interface YapDatabaseSecondaryIndexSetup : NSObject <NSCopying, NSFastEnumeration>
 

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.h
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.h
@@ -1,20 +1,18 @@
 #import <Foundation/Foundation.h>
 #import "YapCollectionKey.h"
 
-typedef enum {
+typedef NS_ENUM(NSInteger, YapDatabaseViewChangeType) {
 	YapDatabaseViewChangeInsert = 1,
 	YapDatabaseViewChangeDelete = 2,
 	YapDatabaseViewChangeMove   = 3,
 	YapDatabaseViewChangeUpdate = 4,
-	
-} YapDatabaseViewChangeType;
+};
 
-typedef enum {
+typedef NS_OPTIONS(NSInteger, YapDatabaseViewChangesBitMask) {
 	YapDatabaseViewChangedObject     = 1 << 0, // 0001
 	YapDatabaseViewChangedMetadata   = 1 << 1, // 0010
 	YapDatabaseViewChangedDependency = 1 << 2, // 0100
-	
-} YapDatabaseViewChangesBitMask;
+};
 
 
 /**

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewRangeOptions.h
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewRangeOptions.h
@@ -7,25 +7,23 @@
  * @see fixedRangeWithLength:offset:from:
  * @see flexibleRangeWithStartingLength:startingOffset:from:
 **/
-typedef enum {
+typedef NS_ENUM(NSInteger, YapDatabaseViewPin) {
 	YapDatabaseViewBeginning = 0, // index == 0
 	YapDatabaseViewEnd       = 1, // index == last
-	
-} YapDatabaseViewPin;
+};
 
 /**
  * Grow options allow you to specify in which direction flexible ranges can grow.
  *
  * @see growOptions
 **/
-typedef enum {
+typedef NS_OPTIONS(NSInteger, YapDatabaseViewGrowOptions) {
 	YapDatabaseViewGrowPinSide    = 1 << 0,
 	YapDatabaseViewGrowNonPinSide = 1 << 1,
 	
 	YapDatabaseViewGrowInRangeOnly = 0,
-	YapDatabaseViewGrowOnBothSides = (YapDatabaseViewGrowPinSide | YapDatabaseViewGrowNonPinSide)
-	
-} YapDatabaseViewGrowOptions;
+	YapDatabaseViewGrowOnBothSides = (YapDatabaseViewGrowPinSide | YapDatabaseViewGrowNonPinSide)	
+};
 
 /**
  * Range options allow you to specify a particular range of a group.

--- a/YapDatabase/YapDatabaseConnection.h
+++ b/YapDatabase/YapDatabaseConnection.h
@@ -29,21 +29,19 @@
  * But for conncurrent access between multiple threads you must use multiple connections.
 **/
 
-enum  {
-	YapDatabaseConnectionFlushMemoryFlags_None       = 0,
-	YapDatabaseConnectionFlushMemoryFlags_Caches     = 1 << 0,
-	YapDatabaseConnectionFlushMemoryFlags_Statements = 1 << 1,
-	YapDatabaseConnectionFlushMemoryFlags_All        = (YapDatabaseConnectionFlushMemoryFlags_Caches |
-	                                                    YapDatabaseConnectionFlushMemoryFlags_Statements),
+typedef NS_OPTIONS(NSInteger, YapDatabaseConnectionFlushMemoryFlags) {
+    YapDatabaseConnectionFlushMemoryFlags_None       = 0,
+    YapDatabaseConnectionFlushMemoryFlags_Caches     = 1 << 0,
+    YapDatabaseConnectionFlushMemoryFlags_Statements = 1 << 1,
+    YapDatabaseConnectionFlushMemoryFlags_All        = (YapDatabaseConnectionFlushMemoryFlags_Caches |
+                                                        YapDatabaseConnectionFlushMemoryFlags_Statements),
 };
-typedef int YapDatabaseConnectionFlushMemoryFlags;
 
-typedef enum {
+typedef NS_ENUM(NSInteger, YapDatabasePolicy) {
 	YapDatabasePolicyContainment = 0,
 	YapDatabasePolicyShare       = 1,
 	YapDatabasePolicyCopy        = 2,
-} YapDatabasePolicy;
-
+};
 
 @interface YapDatabaseConnection : NSObject
 

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -13,17 +13,17 @@
  * The configuration options provided by this class are advanced (beyond the basic setup options).
 **/
 
-typedef enum {
-	YapDatabaseCorruptAction_Fail   = 0,
-	YapDatabaseCorruptAction_Rename = 1,
-	YapDatabaseCorruptAction_Delete = 2,
-} YapDatabaseCorruptAction;
+typedef NS_ENUM(NSInteger, YapDatabaseCorruptAction) {
+    YapDatabaseCorruptAction_Fail   = 0,
+    YapDatabaseCorruptAction_Rename = 1,
+    YapDatabaseCorruptAction_Delete = 2,
+};
 
-typedef enum {
+typedef NS_ENUM(NSInteger, YapDatabasePragmaSynchronous) {
 	YapDatabasePragmaSynchronous_Off    = 0,
 	YapDatabasePragmaSynchronous_Normal = 1,
 	YapDatabasePragmaSynchronous_Full   = 2,
-} YapDatabasePragmaSynchronous;
+};
 
 #ifdef SQLITE_HAS_CODEC
 typedef NSString* (^YapDatabaseOptionsPassphraseBlock)(void);


### PR DESCRIPTION
Without this, they cannot be inferred by the Swift compiler.
