### PR TITLE
Less strict CocoaLumberjack subspec versioning

### DIFF
--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     ss.xcconfig     = { 'OTHER_LDFLAGS' => '-weak_library /usr/lib/libc++.dylib' }
 
     ss.private_header_files = 'YapDatabase/**/Internal/*.h'
-    ss.dependency 'CocoaLumberjack', '~> 1.6.3'
+    ss.dependency 'CocoaLumberjack', '~> 1'
     ss.requires_arc = true
   end
 


### PR DESCRIPTION
Hi Robbie,

we're currently migrating over to Yap and had some issues with the CocoaLumberjack version clashing with the one we're using. Switching to a less strict version would solve the issue.

Best regards
Jan
