### PR TITLE
Handle NSNull for secondary indexed column when adding a row.

### DIFF
--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
@@ -394,7 +394,7 @@
 	for (YapDatabaseSecondaryIndexColumn *column in secondaryIndexConnection->secondaryIndex->setup)
 	{
 		id columnValue = [secondaryIndexConnection->blockDict objectForKey:column.name];
-		if (columnValue)
+		if (columnValue && columnValue != [NSNull null])
 		{
 			if (column.type == YapDatabaseSecondaryIndexTypeInteger)
 			{


### PR DESCRIPTION
When deserializing JSON which can return NSNull values for secondary indexed columns, we get 'Unable to bind value for column' warnings. Instead we should not set the column value rather than display the warning when the value is NSNull.
