### PR TITLE
Adds support for NSArray parameters to YapDatabaseQuery

### DIFF
--- a/Testing/UnitTesting/TestYapDatabaseQuery.m
+++ b/Testing/UnitTesting/TestYapDatabaseQuery.m
@@ -1,0 +1,46 @@
+#import <XCTest/XCTest.h>
+
+#import "YapDatabaseQuery.h"
+
+@interface TestYapDatabaseQuery : XCTestCase
+@end
+
+@implementation TestYapDatabaseQuery
+
+- (void)test1
+{
+	YapDatabaseQuery *query = [YapDatabaseQuery queryWithFormat:@"WHERE col > 5"];
+	XCTAssertTrue([query.queryString isEqualToString:@"WHERE col > 5"], @"Incorrect queryString");
+	
+	query = [YapDatabaseQuery queryWithFormat:@"WHERE col > ?", @(5)];
+	NSArray *expectedArguments = @[@(5)];
+	XCTAssertTrue([query.queryString isEqualToString:@"WHERE col > ?"], @"Incorrect queryString");
+	XCTAssertTrue([query.queryParameters isEqualToArray:@[@(5)]], @"Incorrect queryParameters");
+	
+	query = [YapDatabaseQuery queryWithFormat:@"WHERE col > ? AND col < ?", @(1), @(5)];
+	expectedArguments = @[@(1), @(5)];
+	XCTAssertTrue([query.queryString isEqualToString:@"WHERE col > ? AND col < ?"], @"Incorrect queryString");
+	XCTAssertTrue([query.queryParameters isEqualToArray:expectedArguments], @"Incorrect queryParameters");
+	
+	query = [YapDatabaseQuery queryWithFormat:@"WHERE col > ? AND col < ?", @(1), @(5)];
+	expectedArguments = @[@(1), @(5)];
+	XCTAssertTrue([query.queryString isEqualToString:@"WHERE col > ? AND col < ?"], @"Incorrect queryString");
+	XCTAssertTrue([query.queryParameters isEqualToArray:expectedArguments], @"Incorrect queryParameters");
+	
+	query = [YapDatabaseQuery queryWithFormat:@"WHERE col IN (?)", @[@(1), @(5)]];
+	expectedArguments = @[@(1), @(5)];
+	XCTAssertTrue([query.queryString isEqualToString:@"WHERE col IN (?,?)"], @"Incorrect queryString");
+	XCTAssertTrue([query.queryParameters isEqualToArray:expectedArguments], @"Incorrect queryParameters");
+	
+	query = [YapDatabaseQuery queryWithFormat:@"WHERE col IN (?) AND col2 <> ?", @[@(1), @(5)], @"test"];
+	expectedArguments = @[@(1), @(5), @"test"];
+	XCTAssertTrue([query.queryString isEqualToString:@"WHERE col IN (?,?) AND col2 <> ?"], @"Incorrect queryString");
+	XCTAssertTrue([query.queryParameters isEqualToArray:expectedArguments], @"Incorrect queryParameters");
+	
+	query = [YapDatabaseQuery queryWithFormat:@"WHERE col2 <> ? AND col IN (?)", @"test", @[@(1), @(5)]];
+	expectedArguments = @[@"test", @(1), @(5)];
+	XCTAssertTrue([query.queryString isEqualToString:@"WHERE col2 <> ? AND col IN (?,?)"], @"Incorrect queryString");
+	XCTAssertTrue([query.queryParameters isEqualToArray:expectedArguments], @"Incorrect queryParameters");
+}
+
+@end

--- a/Testing/UnitTesting/TestYapDatabaseSecondaryIndex.m
+++ b/Testing/UnitTesting/TestYapDatabaseSecondaryIndex.m
@@ -152,6 +152,17 @@
 		}];
 		
 		XCTAssertTrue(count == 4, @"Incorrect count: %lu", (unsigned long)count);
+		
+		count = 0;
+		query = [YapDatabaseQuery queryWithFormat:@"WHERE someInt IN (?)",
+																															@[@(2), @(4), @(5.5), @(9)]];
+		[[transaction ext:@"idx"] enumerateKeysMatchingQuery:query
+																							usingBlock:^(NSString *collection, NSString *key, BOOL *stop) {
+																								
+			count++;
+		}];
+		
+		XCTAssertTrue(count == 3, @"Incorrect count: %lu", (unsigned long)count);
 	}];
 	
 	//

--- a/Testing/Xcode-mobile/YapDatabase.xcodeproj/project.pbxproj
+++ b/Testing/Xcode-mobile/YapDatabase.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5EC2813F19E378D20036CC87 /* TestYapDatabaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EC2813E19E378D20036CC87 /* TestYapDatabaseQuery.m */; };
 		DC005BC11774C666002E57DE /* TestViewChangeLogic.m in Sources */ = {isa = PBXBuildFile; fileRef = DC005BC01774C666002E57DE /* TestViewChangeLogic.m */; };
 		DC00E87C19DC6D3400905481 /* YapDatabaseFullTextSearchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = DC00E87B19DC6D3400905481 /* YapDatabaseFullTextSearchHandler.m */; };
 		DC00E87F19DC8ECC00905481 /* YapDatabaseSecondaryIndexHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = DC00E87E19DC8ECC00905481 /* YapDatabaseSecondaryIndexHandler.m */; };
@@ -176,6 +177,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5EC2813E19E378D20036CC87 /* TestYapDatabaseQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestYapDatabaseQuery.m; path = ../../UnitTesting/TestYapDatabaseQuery.m; sourceTree = "<group>"; };
 		DC005BC01774C666002E57DE /* TestViewChangeLogic.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestViewChangeLogic.m; path = ../../UnitTesting/TestViewChangeLogic.m; sourceTree = "<group>"; };
 		DC00E87A19DC6D3400905481 /* YapDatabaseFullTextSearchHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchHandler.h; sourceTree = "<group>"; };
 		DC00E87B19DC6D3400905481 /* YapDatabaseFullTextSearchHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchHandler.m; sourceTree = "<group>"; };
@@ -396,6 +398,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5EC2813D19E376680036CC87 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				5EC2813E19E378D20036CC87 /* TestYapDatabaseQuery.m */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
 		DC059BB818EF864C0088574E /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -835,6 +845,7 @@
 			children = (
 				DC3D2F251673FFEC00DFAFAA /* TestObject.h */,
 				DC3D2F261673FFEC00DFAFAA /* TestObject.m */,
+				5EC2813D19E376680036CC87 /* Utilities */,
 				DC5BAD8A174E75B000DF9465 /* Database */,
 				DC5BAD8B174E75C500DF9465 /* Views */,
 				DC49734117E7ED0000489267 /* FullTextSearch */,
@@ -1132,6 +1143,7 @@
 				DC005BC11774C666002E57DE /* TestViewChangeLogic.m in Sources */,
 				DCEE835017AAC7F3009BF81D /* TestViewMappingsLogic.m in Sources */,
 				DC8E6043183F0A3D0091633D /* TestYapDatabaseFilteredView.m in Sources */,
+				5EC2813F19E378D20036CC87 /* TestYapDatabaseQuery.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -58,9 +58,13 @@
 	NSRange searchRange = NSMakeRange(0, formatLength);
 	NSRange paramRange = [format rangeOfString:@"?" options:0 range:searchRange];
 	
+	NSMutableArray *paramLocations = [NSMutableArray array];
+	
 	while (paramRange.location != NSNotFound)
 	{
 		paramCount++;
+		
+		[paramLocations addObject:@(paramRange.location)];
 		
 		searchRange.location = paramRange.location + 1;
 		searchRange.length = formatLength - searchRange.location;
@@ -79,11 +83,41 @@
 	
 	@try
 	{
+		NSMutableDictionary *paramIndexToElementCountMap = [NSMutableDictionary dictionary];
 		for (NSUInteger i = 0; i < paramCount; i++)
 		{
 			id param = va_arg(args, id);
+			if ([param isKindOfClass:[NSArray class]])
+			{
+				paramIndexToElementCountMap[@(i)] = @([param count]);
+				[queryParameters addObjectsFromArray:param];
+			}
+			else
+			{
+				[queryParameters addObject:param];
+			}
+		}
+		
+		if (paramIndexToElementCountMap.count > 0)
+		{
+			NSUInteger unpackingOffset = 0;
+			NSString *queryString = [format copy];
+			NSRange range;
+			for (NSNumber *index in paramIndexToElementCountMap)
+			{
+				NSInteger elementCount = [paramIndexToElementCountMap[index] intValue];
+				NSMutableArray *unpackedParams = [NSMutableArray array];
+				for (NSUInteger i = 0; i < elementCount; i++)
+				{
+					[unpackedParams addObject:@"?"];
+				}
+				NSString *unpackedParamsStr = [unpackedParams componentsJoinedByString:@","];
+				range = NSMakeRange([paramLocations[[index intValue]] intValue] + unpackingOffset, 1);
+				queryString = [queryString stringByReplacingCharactersInRange:range
+																													 withString:unpackedParamsStr];
+			}
 			
-			[queryParameters addObject:param];
+			format = [queryString copy];
 		}
 	}
 	@catch (NSException *exception)


### PR DESCRIPTION
Example:
[YapDatabaseQuery queryWithFormat:@"WHERE col IN (?)", anArray];
- Adds unit tests for YapDatabaseQuery
- Adds new unit test for YapDatabaseSecondaryIndex since it makes use of YapDatabaseQuery

Addresses issue #119
