### PR TITLE
Imports required for dynamic framework.

### DIFF
--- a/Vendor/CocoaLumberjack/CLI/CLIColor.h
+++ b/Vendor/CocoaLumberjack/CLI/CLIColor.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 /**
  Simple NSColor replacement for CLI projects that don't link with AppKit

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
@@ -3,6 +3,10 @@
 #import "YapDatabaseViewMappingsPrivate.h"
 #import "YapDatabaseLogging.h"
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.m
@@ -4,6 +4,10 @@
 #import "YapDatabasePrivate.h"
 #import "YapDatabaseLogging.h"
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif

--- a/YapDatabase/Extensions/Views/YapDatabaseViewTransaction.m
+++ b/YapDatabase/Extensions/Views/YapDatabaseViewTransaction.m
@@ -11,6 +11,10 @@
 #import "YapDatabaseString.h"
 #import "YapDatabaseLogging.h"
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif

--- a/YapDatabase/Internal/YapRowidSet.h
+++ b/YapDatabase/Internal/YapRowidSet.h
@@ -2,6 +2,8 @@
  * Wrapper for C++ code (std::unordered_set<int64_t>)
 **/
 
+#import <Foundation/Foundation.h>
+
 #ifndef YapDatabase_YapRowidSet_h
 #define YapDatabase_YapRowidSet_h
 

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -1,3 +1,4 @@
+
 #import "YapDatabaseConnection.h"
 #import "YapDatabaseConnectionState.h"
 #import "YapDatabasePrivate.h"
@@ -14,6 +15,10 @@
 
 #import <objc/runtime.h>
 #import <libkern/OSAtomic.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).


### PR DESCRIPTION
When creating a dynamic iOS 8 framework & OSX 10.9 framework these imports are needed in order to get things running.
