### PR TITLE
YapDatabaseQuery Swift Compatibility

### DIFF
--- a/YapDatabase/Utilities/YapDatabaseQuery.h
+++ b/YapDatabase/Utilities/YapDatabaseQuery.h
@@ -35,6 +35,8 @@
 **/
 + (instancetype)queryWithFormat:(NSString *)format, ...;
 
++ (instancetype)queryWithFormat:(NSString *)format arguments:(va_list)arguments;
+
 /**
  * Shorthand for a query with no 'WHERE' clause.
  * Equivalent to [YapDatabaseQuery queryWithFormat:@""].

--- a/YapDatabase/Utilities/YapDatabaseQuery.h
+++ b/YapDatabase/Utilities/YapDatabaseQuery.h
@@ -47,3 +47,16 @@
 @property (nonatomic, strong, readonly) NSArray *queryParameters;
 
 @end
+
+/**
+ * Shim that allows YapDatabaseQuery to be used from Swift.
+ *
+ * Define the following somewhere in your Swift code:
+ *
+ * extension YapDatabaseQuery {
+ *     class func queryWithFormat(format: String, _ arguments: CVarArgType...) -> YapDatabaseQuery? {
+ *         return withVaList(arguments, { __YapDatabaseQuerySwift(format, $0) })
+ *     }
+ * }
+**/
+YapDatabaseQuery *__YapDatabaseQuerySwift(NSString *format, va_list arguments);

--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -22,6 +22,32 @@
 	NSArray *queryParameters;
 }
 
+/**
+ * A YapDatabaseQuery is everything after the SELECT clause of a query.
+ * Methods that take YapDatabaseQuery parameters will prefix your query string similarly to:
+ *
+ * fullQuery = @"SELECT rowid FROM 'database' " + [yapDatabaseQuery queryString];
+ *
+ * Example 1:
+ *
+ * query = [YapDatabaseQuery queryWithFormat:@"WHERE jid = ?", message.jid];
+ * [secondaryIndex enumerateKeysAndObjectsMatchingQuery:query
+ *                                           usingBlock:^(NSString *key, id object, BOOL *stop){
+ *     ...
+ * }];
+ *
+ * Please note that you can ONLY pass objective-c objects as parameters.
+ * Primitive types such as int, float, double, etc are NOT supported.
+ * You MUST wrap these using NSNumber.
+ *
+ * Example 2:
+ *
+ * query = [YapDatabaseQuery queryWithFormat:@"WHERE department = ? AND salary >= ?", dept, @(minSalary)];
+ * [secondaryIndex enumerateKeysAndObjectsMatchingQuery:query
+ *                                           usingBlock:^(NSString *key, id object, BOOL *stop){
+ *     ...
+ * }];
+ **/
 + (instancetype)queryWithFormat:(NSString *)format, ...
 {
     va_list arguments;
@@ -118,6 +144,10 @@
 	}
 }
 
+/**
+ * Shorthand for a query with no 'WHERE' clause.
+ * Equivalent to [YapDatabaseQuery queryWithFormat:@""].
+ **/
 + (instancetype)queryMatchingAll
 {
 	return [[YapDatabaseQuery alloc] initWithQueryString:@"" queryParameters:nil];
@@ -138,6 +168,17 @@
 
 @end
 
+/**
+ * Shim that allows YapDatabaseQuery to be used from Swift.
+ *
+ * Define the following somewhere in your Swift code:
+ *
+ * extension YapDatabaseQuery {
+ *     class func queryWithFormat(format: String, _ arguments: CVarArgType...) -> YapDatabaseQuery? {
+ *         return withVaList(arguments, { __YapDatabaseQuerySwift(format, $0) })
+ *     }
+ * }
+ **/
 YapDatabaseQuery *__YapDatabaseQuerySwift(NSString *format, va_list arguments) {
     return [YapDatabaseQuery queryWithFormat:format arguments:arguments];
 }

--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -22,33 +22,16 @@
 	NSArray *queryParameters;
 }
 
-/**
- * A YapDatabaseQuery is everything after the SELECT clause of a query.
- * Methods that take YapDatabaseQuery parameters will prefix your query string similarly to:
- *
- * fullQuery = @"SELECT rowid FROM 'database' " + [yapDatabaseQuery queryString];
- *
- * Example 1:
- *
- * query = [YapDatabaseQuery queryWithFormat:@"WHERE jid = ?", message.jid];
- * [secondaryIndex enumerateKeysAndObjectsMatchingQuery:query
- *                                           usingBlock:^(NSString *key, id object, BOOL *stop){
- *     ...
- * }];
- *
- * Please note that you can ONLY pass objective-c objects as parameters.
- * Primitive types such as int, float, double, etc are NOT supported.
- * You MUST wrap these using NSNumber.
- *
- * Example 2:
- *
- * query = [YapDatabaseQuery queryWithFormat:@"WHERE department = ? AND salary >= ?", dept, @(minSalary)];
- * [secondaryIndex enumerateKeysAndObjectsMatchingQuery:query
- *                                           usingBlock:^(NSString *key, id object, BOOL *stop){
- *     ...
- * }];
-**/
 + (instancetype)queryWithFormat:(NSString *)format, ...
+{
+    va_list arguments;
+    va_start(arguments, format);
+    id query = [self queryWithFormat:format arguments:arguments];
+    va_end(arguments);
+    return query;
+}
+
++ (instancetype)queryWithFormat:(NSString *)format arguments:(va_list)args
 {
 	if (format == nil) return nil;
 	
@@ -77,9 +60,6 @@
 	// You MUST wrap these using NSNumber.
 	
 	NSMutableArray *queryParameters = [NSMutableArray arrayWithCapacity:paramCount];
-	
-	va_list args;
-	va_start(args, format);
 	
 	@try
 	{
@@ -128,8 +108,6 @@
 		queryParameters = nil;
 	}
 	
-	va_end(args);
-	
 	if (queryParameters || (paramCount == 0))
 	{
 		return [[YapDatabaseQuery alloc] initWithQueryString:format queryParameters:queryParameters];
@@ -140,11 +118,6 @@
 	}
 }
 
-
-/**
- * Shorthand for a query with no 'WHERE' clause.
- * Equivalent to [YapDatabaseQuery queryWithFormat:@""].
-**/
 + (instancetype)queryMatchingAll
 {
 	return [[YapDatabaseQuery alloc] initWithQueryString:@"" queryParameters:nil];

--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -137,3 +137,7 @@
 @synthesize queryParameters;
 
 @end
+
+YapDatabaseQuery *__YapDatabaseQuerySwift(NSString *format, va_list arguments) {
+    return [YapDatabaseQuery queryWithFormat:format arguments:arguments];
+}


### PR DESCRIPTION
This pull request adds `+[YapDatabaseQuery queryWithFormat:arguments:]` and `__YapDatabaseQuerySwift(NSString *, va_list)` so that the class can be used from Swift. I'm open to suggestions for the Swift shim name. I named it such that it would be clear that it is not intended for standard use.

Fixes #136.