### PR TITLE
Tweak Swift behavior of YapDatabaseQuery.

### DIFF
--- a/YapDatabase/Utilities/YapDatabaseQuery.h
+++ b/YapDatabase/Utilities/YapDatabaseQuery.h
@@ -35,6 +35,17 @@
 **/
 + (instancetype)queryWithFormat:(NSString *)format, ...;
 
+/**
+ * Shim that allows YapDatabaseQuery to be used from Swift.
+ *
+ * Define the following somewhere in your Swift code:
+ *
+ * extension YapDatabaseQuery {
+ *     class func queryWithFormat(format: String, _ arguments: CVarArgType...) -> YapDatabaseQuery? {
+ *         return withVaList(arguments, { YapDatabaseQuery(format: format, arguments: $0) })
+ *     }
+ * }
+ **/
 + (instancetype)queryWithFormat:(NSString *)format arguments:(va_list)arguments;
 
 /**
@@ -47,16 +58,3 @@
 @property (nonatomic, strong, readonly) NSArray *queryParameters;
 
 @end
-
-/**
- * Shim that allows YapDatabaseQuery to be used from Swift.
- *
- * Define the following somewhere in your Swift code:
- *
- * extension YapDatabaseQuery {
- *     class func queryWithFormat(format: String, _ arguments: CVarArgType...) -> YapDatabaseQuery? {
- *         return withVaList(arguments, { __YapDatabaseQuerySwift(format, $0) })
- *     }
- * }
-**/
-YapDatabaseQuery *__YapDatabaseQuerySwift(NSString *format, va_list arguments);

--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -57,6 +57,17 @@
     return query;
 }
 
+/**
+ * Shim that allows YapDatabaseQuery to be used from Swift.
+ *
+ * Define the following somewhere in your Swift code:
+ *
+ * extension YapDatabaseQuery {
+ *     class func queryWithFormat(format: String, _ arguments: CVarArgType...) -> YapDatabaseQuery? {
+ *         return withVaList(arguments, { YapDatabaseQuery(format: format, arguments: $0) })
+ *     }
+ * }
+ **/
 + (instancetype)queryWithFormat:(NSString *)format arguments:(va_list)args
 {
 	if (format == nil) return nil;
@@ -167,18 +178,3 @@
 @synthesize queryParameters;
 
 @end
-
-/**
- * Shim that allows YapDatabaseQuery to be used from Swift.
- *
- * Define the following somewhere in your Swift code:
- *
- * extension YapDatabaseQuery {
- *     class func queryWithFormat(format: String, _ arguments: CVarArgType...) -> YapDatabaseQuery? {
- *         return withVaList(arguments, { __YapDatabaseQuerySwift(format, $0) })
- *     }
- * }
- **/
-YapDatabaseQuery *__YapDatabaseQuerySwift(NSString *format, va_list arguments) {
-    return [YapDatabaseQuery queryWithFormat:format arguments:arguments];
-}


### PR DESCRIPTION
I'm back!

It bugged me that I needed a shim function with exactly the same signature of the class function. I thought that for some reason the class function wasn't imported into Swift due to some incompatibility, when in fact it is imported as an initializer. So, no more weird function name!

- Remove need for special function since `queryWithFormat:arguments:` is imported as an initializer.