### PR TITLE
Fix SearchResultsExample compile failure

### DIFF
--- a/Examples/SearchResultsExample/SearchResultsExample.xcodeproj/project.pbxproj
+++ b/Examples/SearchResultsExample/SearchResultsExample.xcodeproj/project.pbxproj
@@ -7,6 +7,51 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D80C9C4C1AB208FB00AF7F29 /* NSDictionary+YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C371AB208FB00AF7F29 /* NSDictionary+YapDatabase.m */; };
+		D80C9C4D1AB208FB00AF7F29 /* YapDatabaseConnectionDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C391AB208FB00AF7F29 /* YapDatabaseConnectionDefaults.m */; };
+		D80C9C4E1AB208FB00AF7F29 /* YapDatabaseConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C3B1AB208FB00AF7F29 /* YapDatabaseConnectionState.m */; };
+		D80C9C4F1AB208FB00AF7F29 /* YapDatabaseLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C3D1AB208FB00AF7F29 /* YapDatabaseLogging.m */; };
+		D80C9C501AB208FB00AF7F29 /* YapDatabaseManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C3F1AB208FB00AF7F29 /* YapDatabaseManager.m */; };
+		D80C9C511AB208FB00AF7F29 /* YapDatabaseStatement.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C421AB208FB00AF7F29 /* YapDatabaseStatement.m */; };
+		D80C9C521AB208FB00AF7F29 /* YapMemoryTable.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C451AB208FB00AF7F29 /* YapMemoryTable.m */; };
+		D80C9C531AB208FB00AF7F29 /* YapNull.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C471AB208FB00AF7F29 /* YapNull.m */; };
+		D80C9C541AB208FB00AF7F29 /* YapRowidSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C491AB208FB00AF7F29 /* YapRowidSet.mm */; };
+		D80C9C551AB208FB00AF7F29 /* YapTouch.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C4B1AB208FB00AF7F29 /* YapTouch.m */; };
+		D80C9C601AB2090A00AF7F29 /* YapCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C571AB2090A00AF7F29 /* YapCache.m */; };
+		D80C9C611AB2090A00AF7F29 /* YapCollectionKey.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C591AB2090A00AF7F29 /* YapCollectionKey.m */; };
+		D80C9C621AB2090A00AF7F29 /* YapDatabaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C5B1AB2090A00AF7F29 /* YapDatabaseQuery.m */; };
+		D80C9C631AB2090A00AF7F29 /* YapSet.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C5D1AB2090A00AF7F29 /* YapSet.m */; };
+		D80C9C641AB2090A00AF7F29 /* YapWhitelistBlacklist.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C5F1AB2090A00AF7F29 /* YapWhitelistBlacklist.m */; };
+		D80C9C6D1AB2091A00AF7F29 /* YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C661AB2091A00AF7F29 /* YapDatabase.m */; };
+		D80C9C6E1AB2091A00AF7F29 /* YapDatabaseConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C681AB2091A00AF7F29 /* YapDatabaseConnection.m */; };
+		D80C9C6F1AB2091A00AF7F29 /* YapDatabaseOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C6A1AB2091A00AF7F29 /* YapDatabaseOptions.m */; };
+		D80C9C701AB2091A00AF7F29 /* YapDatabaseTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C6C1AB2091A00AF7F29 /* YapDatabaseTransaction.m */; };
+		D80C9C791AB2092D00AF7F29 /* YapDatabaseFilteredView.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C721AB2092D00AF7F29 /* YapDatabaseFilteredView.m */; };
+		D80C9C7A1AB2092D00AF7F29 /* YapDatabaseFilteredViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C741AB2092D00AF7F29 /* YapDatabaseFilteredViewConnection.m */; };
+		D80C9C7B1AB2092D00AF7F29 /* YapDatabaseFilteredViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C761AB2092D00AF7F29 /* YapDatabaseFilteredViewTransaction.m */; };
+		D80C9C7C1AB2092D00AF7F29 /* YapDatabaseFilteredViewTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C781AB2092D00AF7F29 /* YapDatabaseFilteredViewTypes.m */; };
+		D80C9C881AB2094F00AF7F29 /* YapDatabaseFullTextSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C7F1AB2094F00AF7F29 /* YapDatabaseFullTextSearch.m */; };
+		D80C9C891AB2094F00AF7F29 /* YapDatabaseFullTextSearchConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C811AB2094F00AF7F29 /* YapDatabaseFullTextSearchConnection.m */; };
+		D80C9C8A1AB2094F00AF7F29 /* YapDatabaseFullTextSearchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C831AB2094F00AF7F29 /* YapDatabaseFullTextSearchHandler.m */; };
+		D80C9C8B1AB2094F00AF7F29 /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C851AB2094F00AF7F29 /* YapDatabaseFullTextSearchSnippetOptions.m */; };
+		D80C9C8C1AB2094F00AF7F29 /* YapDatabaseFullTextSearchTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C871AB2094F00AF7F29 /* YapDatabaseFullTextSearchTransaction.m */; };
+		D80C9C991AB2099700AF7F29 /* YapDatabaseSecondaryIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C8E1AB2099700AF7F29 /* YapDatabaseSecondaryIndex.m */; };
+		D80C9C9A1AB2099700AF7F29 /* YapDatabaseSecondaryIndexConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C901AB2099700AF7F29 /* YapDatabaseSecondaryIndexConnection.m */; };
+		D80C9C9B1AB2099700AF7F29 /* YapDatabaseSecondaryIndexHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C921AB2099700AF7F29 /* YapDatabaseSecondaryIndexHandler.m */; };
+		D80C9C9C1AB2099700AF7F29 /* YapDatabaseSecondaryIndexOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C941AB2099700AF7F29 /* YapDatabaseSecondaryIndexOptions.m */; };
+		D80C9C9D1AB2099700AF7F29 /* YapDatabaseSecondaryIndexSetup.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C961AB2099700AF7F29 /* YapDatabaseSecondaryIndexSetup.m */; };
+		D80C9C9E1AB2099700AF7F29 /* YapDatabaseSecondaryIndexTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9C981AB2099700AF7F29 /* YapDatabaseSecondaryIndexTransaction.m */; };
+		D80C9CA91AB209B000AF7F29 /* YapDatabaseViewPage.mm in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CA21AB209B000AF7F29 /* YapDatabaseViewPage.mm */; };
+		D80C9CAA1AB209B000AF7F29 /* YapDatabaseViewPageMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CA41AB209B000AF7F29 /* YapDatabaseViewPageMetadata.m */; };
+		D80C9CAB1AB209B000AF7F29 /* YapDatabaseViewState.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CA81AB209B000AF7F29 /* YapDatabaseViewState.m */; };
+		D80C9CB21AB209BD00AF7F29 /* YapDatabaseViewChange.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CAD1AB209BD00AF7F29 /* YapDatabaseViewChange.m */; };
+		D80C9CB31AB209BD00AF7F29 /* YapDatabaseViewMappings.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CAF1AB209BD00AF7F29 /* YapDatabaseViewMappings.m */; };
+		D80C9CB41AB209BD00AF7F29 /* YapDatabaseViewRangeOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CB11AB209BD00AF7F29 /* YapDatabaseViewRangeOptions.m */; };
+		D80C9CBF1AB209D000AF7F29 /* YapDatabaseView.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CB61AB209D000AF7F29 /* YapDatabaseView.m */; };
+		D80C9CC01AB209D000AF7F29 /* YapDatabaseViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CB81AB209D000AF7F29 /* YapDatabaseViewConnection.m */; };
+		D80C9CC11AB209D000AF7F29 /* YapDatabaseViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CBA1AB209D000AF7F29 /* YapDatabaseViewOptions.m */; };
+		D80C9CC21AB209D000AF7F29 /* YapDatabaseViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CBC1AB209D000AF7F29 /* YapDatabaseViewTransaction.m */; };
+		D80C9CC31AB209D000AF7F29 /* YapDatabaseViewTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = D80C9CBE1AB209D000AF7F29 /* YapDatabaseViewTypes.m */; };
 		DC882B491926C445004C3166 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC882B481926C445004C3166 /* Foundation.framework */; };
 		DC882B4B1926C445004C3166 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC882B4A1926C445004C3166 /* CoreGraphics.framework */; };
 		DC882B4D1926C445004C3166 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC882B4C1926C445004C3166 /* UIKit.framework */; };
@@ -22,13 +67,6 @@
 		DC882B931926C469004C3166 /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882B861926C469004C3166 /* DDLog.m */; };
 		DC882B941926C469004C3166 /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882B881926C469004C3166 /* DDTTYLogger.m */; };
 		DC882B971926C469004C3166 /* README.txt in Resources */ = {isa = PBXBuildFile; fileRef = DC882B8E1926C469004C3166 /* README.txt */; };
-		DC882C251926C4C3004C3166 /* YapDatabaseFilteredView.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882B9F1926C4C2004C3166 /* YapDatabaseFilteredView.m */; };
-		DC882C261926C4C3004C3166 /* YapDatabaseFilteredViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BA11926C4C2004C3166 /* YapDatabaseFilteredViewConnection.m */; };
-		DC882C271926C4C3004C3166 /* YapDatabaseFilteredViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BA31926C4C2004C3166 /* YapDatabaseFilteredViewTransaction.m */; };
-		DC882C281926C4C3004C3166 /* YapDatabaseFullTextSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BA91926C4C2004C3166 /* YapDatabaseFullTextSearch.m */; };
-		DC882C291926C4C3004C3166 /* YapDatabaseFullTextSearchConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BAB1926C4C2004C3166 /* YapDatabaseFullTextSearchConnection.m */; };
-		DC882C2A1926C4C3004C3166 /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BAD1926C4C2004C3166 /* YapDatabaseFullTextSearchSnippetOptions.m */; };
-		DC882C2B1926C4C3004C3166 /* YapDatabaseFullTextSearchTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BAF1926C4C2004C3166 /* YapDatabaseFullTextSearchTransaction.m */; };
 		DC882C2C1926C4C3004C3166 /* YapDatabaseExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BB41926C4C2004C3166 /* YapDatabaseExtension.m */; };
 		DC882C2D1926C4C3004C3166 /* YapDatabaseExtensionConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BB61926C4C2004C3166 /* YapDatabaseExtensionConnection.m */; };
 		DC882C2E1926C4C3004C3166 /* YapDatabaseExtensionTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BB81926C4C2004C3166 /* YapDatabaseExtensionTransaction.m */; };
@@ -42,48 +80,112 @@
 		DC882C361926C4C3004C3166 /* YapDatabaseSearchResultsViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BD11926C4C2004C3166 /* YapDatabaseSearchResultsViewConnection.m */; };
 		DC882C371926C4C3004C3166 /* YapDatabaseSearchResultsViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BD31926C4C2004C3166 /* YapDatabaseSearchResultsViewOptions.m */; };
 		DC882C381926C4C3004C3166 /* YapDatabaseSearchResultsViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BD51926C4C2004C3166 /* YapDatabaseSearchResultsViewTransaction.m */; };
-		DC882C391926C4C3004C3166 /* YapDatabaseSecondaryIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BDB1926C4C2004C3166 /* YapDatabaseSecondaryIndex.m */; };
-		DC882C3A1926C4C3004C3166 /* YapDatabaseSecondaryIndexConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BDD1926C4C2004C3166 /* YapDatabaseSecondaryIndexConnection.m */; };
-		DC882C3B1926C4C3004C3166 /* YapDatabaseSecondaryIndexSetup.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BDF1926C4C2004C3166 /* YapDatabaseSecondaryIndexSetup.m */; };
-		DC882C3C1926C4C3004C3166 /* YapDatabaseSecondaryIndexTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BE11926C4C2004C3166 /* YapDatabaseSecondaryIndexTransaction.m */; };
-		DC882C3D1926C4C3004C3166 /* YapDatabaseViewPage.mm in Sources */ = {isa = PBXBuildFile; fileRef = DC882BE71926C4C2004C3166 /* YapDatabaseViewPage.mm */; };
-		DC882C3E1926C4C3004C3166 /* YapDatabaseViewPageMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BE91926C4C2004C3166 /* YapDatabaseViewPageMetadata.m */; };
-		DC882C3F1926C4C3004C3166 /* YapDatabaseViewChange.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BEE1926C4C2004C3166 /* YapDatabaseViewChange.m */; };
-		DC882C401926C4C3004C3166 /* YapDatabaseViewMappings.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BF01926C4C2004C3166 /* YapDatabaseViewMappings.m */; };
-		DC882C411926C4C3004C3166 /* YapDatabaseViewRangeOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BF21926C4C2004C3166 /* YapDatabaseViewRangeOptions.m */; };
-		DC882C421926C4C3004C3166 /* YapDatabaseView.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BF41926C4C2004C3166 /* YapDatabaseView.m */; };
-		DC882C431926C4C3004C3166 /* YapDatabaseViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BF61926C4C2004C3166 /* YapDatabaseViewConnection.m */; };
-		DC882C441926C4C3004C3166 /* YapDatabaseViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BF81926C4C2004C3166 /* YapDatabaseViewOptions.m */; };
-		DC882C451926C4C3004C3166 /* YapDatabaseViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BFA1926C4C2004C3166 /* YapDatabaseViewTransaction.m */; };
-		DC882C461926C4C3004C3166 /* NSDictionary+YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882BFE1926C4C2004C3166 /* NSDictionary+YapDatabase.m */; };
-		DC882C471926C4C3004C3166 /* YapCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C001926C4C2004C3166 /* YapCache.m */; };
-		DC882C481926C4C3004C3166 /* YapDatabaseConnectionDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C021926C4C2004C3166 /* YapDatabaseConnectionDefaults.m */; };
-		DC882C491926C4C3004C3166 /* YapDatabaseConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C041926C4C2004C3166 /* YapDatabaseConnectionState.m */; };
-		DC882C4A1926C4C3004C3166 /* YapDatabaseLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C061926C4C3004C3166 /* YapDatabaseLogging.m */; };
-		DC882C4B1926C4C3004C3166 /* YapDatabaseManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C081926C4C3004C3166 /* YapDatabaseManager.m */; };
-		DC882C4C1926C4C3004C3166 /* YapDatabaseStatement.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C0B1926C4C3004C3166 /* YapDatabaseStatement.m */; };
-		DC882C4D1926C4C3004C3166 /* YapMemoryTable.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C0E1926C4C3004C3166 /* YapMemoryTable.m */; };
-		DC882C4E1926C4C3004C3166 /* YapNull.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C101926C4C3004C3166 /* YapNull.m */; };
-		DC882C4F1926C4C3004C3166 /* YapRowidSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = DC882C121926C4C3004C3166 /* YapRowidSet.mm */; };
-		DC882C501926C4C3004C3166 /* YapTouch.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C141926C4C3004C3166 /* YapTouch.m */; };
-		DC882C521926C4C3004C3166 /* YapCollectionKey.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C181926C4C3004C3166 /* YapCollectionKey.m */; };
-		DC882C531926C4C3004C3166 /* YapDatabaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C1A1926C4C3004C3166 /* YapDatabaseQuery.m */; };
-		DC882C541926C4C3004C3166 /* YapSet.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C1C1926C4C3004C3166 /* YapSet.m */; };
-		DC882C551926C4C3004C3166 /* YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C1E1926C4C3004C3166 /* YapDatabase.m */; };
-		DC882C561926C4C3004C3166 /* YapDatabaseConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C201926C4C3004C3166 /* YapDatabaseConnection.m */; };
-		DC882C571926C4C3004C3166 /* YapDatabaseOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C221926C4C3004C3166 /* YapDatabaseOptions.m */; };
-		DC882C581926C4C3004C3166 /* YapDatabaseTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C241926C4C3004C3166 /* YapDatabaseTransaction.m */; };
 		DC882C5A1926C538004C3166 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = DC882C591926C538004C3166 /* libsqlite3.dylib */; };
 		DC882C5C1926D46C004C3166 /* names.json in Resources */ = {isa = PBXBuildFile; fileRef = DC882C5B1926D46C004C3166 /* names.json */; };
 		DC882C601926D63A004C3166 /* Person.m in Sources */ = {isa = PBXBuildFile; fileRef = DC882C5F1926D63A004C3166 /* Person.m */; };
 		DCA2AE211962124800B5E7CA /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA2AE1C1962124800B5E7CA /* DDContextFilterLogFormatter.m */; };
 		DCA2AE221962124800B5E7CA /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA2AE1E1962124800B5E7CA /* DDDispatchQueueLogFormatter.m */; };
 		DCA2AE231962124800B5E7CA /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA2AE201962124800B5E7CA /* DDMultiFormatter.m */; };
-		DCA2AE261962127200B5E7CA /* YapDatabaseSecondaryIndexOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA2AE251962127200B5E7CA /* YapDatabaseSecondaryIndexOptions.m */; };
-		DCA2AE291962129600B5E7CA /* YapDatabaseViewState.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA2AE281962129600B5E7CA /* YapDatabaseViewState.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D80C9C361AB208FB00AF7F29 /* NSDictionary+YapDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+YapDatabase.h"; sourceTree = "<group>"; };
+		D80C9C371AB208FB00AF7F29 /* NSDictionary+YapDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+YapDatabase.m"; sourceTree = "<group>"; };
+		D80C9C381AB208FB00AF7F29 /* YapDatabaseConnectionDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionDefaults.h; sourceTree = "<group>"; };
+		D80C9C391AB208FB00AF7F29 /* YapDatabaseConnectionDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionDefaults.m; sourceTree = "<group>"; };
+		D80C9C3A1AB208FB00AF7F29 /* YapDatabaseConnectionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionState.h; sourceTree = "<group>"; };
+		D80C9C3B1AB208FB00AF7F29 /* YapDatabaseConnectionState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionState.m; sourceTree = "<group>"; };
+		D80C9C3C1AB208FB00AF7F29 /* YapDatabaseLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseLogging.h; sourceTree = "<group>"; };
+		D80C9C3D1AB208FB00AF7F29 /* YapDatabaseLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseLogging.m; sourceTree = "<group>"; };
+		D80C9C3E1AB208FB00AF7F29 /* YapDatabaseManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseManager.h; sourceTree = "<group>"; };
+		D80C9C3F1AB208FB00AF7F29 /* YapDatabaseManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseManager.m; sourceTree = "<group>"; };
+		D80C9C401AB208FB00AF7F29 /* YapDatabasePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabasePrivate.h; sourceTree = "<group>"; };
+		D80C9C411AB208FB00AF7F29 /* YapDatabaseStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseStatement.h; sourceTree = "<group>"; };
+		D80C9C421AB208FB00AF7F29 /* YapDatabaseStatement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseStatement.m; sourceTree = "<group>"; };
+		D80C9C431AB208FB00AF7F29 /* YapDatabaseString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseString.h; sourceTree = "<group>"; };
+		D80C9C441AB208FB00AF7F29 /* YapMemoryTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapMemoryTable.h; sourceTree = "<group>"; };
+		D80C9C451AB208FB00AF7F29 /* YapMemoryTable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapMemoryTable.m; sourceTree = "<group>"; };
+		D80C9C461AB208FB00AF7F29 /* YapNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapNull.h; sourceTree = "<group>"; };
+		D80C9C471AB208FB00AF7F29 /* YapNull.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapNull.m; sourceTree = "<group>"; };
+		D80C9C481AB208FB00AF7F29 /* YapRowidSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapRowidSet.h; sourceTree = "<group>"; };
+		D80C9C491AB208FB00AF7F29 /* YapRowidSet.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YapRowidSet.mm; sourceTree = "<group>"; };
+		D80C9C4A1AB208FB00AF7F29 /* YapTouch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapTouch.h; sourceTree = "<group>"; };
+		D80C9C4B1AB208FB00AF7F29 /* YapTouch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapTouch.m; sourceTree = "<group>"; };
+		D80C9C561AB2090A00AF7F29 /* YapCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapCache.h; sourceTree = "<group>"; };
+		D80C9C571AB2090A00AF7F29 /* YapCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapCache.m; sourceTree = "<group>"; };
+		D80C9C581AB2090A00AF7F29 /* YapCollectionKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapCollectionKey.h; sourceTree = "<group>"; };
+		D80C9C591AB2090A00AF7F29 /* YapCollectionKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapCollectionKey.m; sourceTree = "<group>"; };
+		D80C9C5A1AB2090A00AF7F29 /* YapDatabaseQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseQuery.h; sourceTree = "<group>"; };
+		D80C9C5B1AB2090A00AF7F29 /* YapDatabaseQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseQuery.m; sourceTree = "<group>"; };
+		D80C9C5C1AB2090A00AF7F29 /* YapSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapSet.h; sourceTree = "<group>"; };
+		D80C9C5D1AB2090A00AF7F29 /* YapSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapSet.m; sourceTree = "<group>"; };
+		D80C9C5E1AB2090A00AF7F29 /* YapWhitelistBlacklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapWhitelistBlacklist.h; sourceTree = "<group>"; };
+		D80C9C5F1AB2090A00AF7F29 /* YapWhitelistBlacklist.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapWhitelistBlacklist.m; sourceTree = "<group>"; };
+		D80C9C651AB2091A00AF7F29 /* YapDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabase.h; sourceTree = "<group>"; };
+		D80C9C661AB2091A00AF7F29 /* YapDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabase.m; sourceTree = "<group>"; };
+		D80C9C671AB2091A00AF7F29 /* YapDatabaseConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnection.h; sourceTree = "<group>"; };
+		D80C9C681AB2091A00AF7F29 /* YapDatabaseConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnection.m; sourceTree = "<group>"; };
+		D80C9C691AB2091A00AF7F29 /* YapDatabaseOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseOptions.h; sourceTree = "<group>"; };
+		D80C9C6A1AB2091A00AF7F29 /* YapDatabaseOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseOptions.m; sourceTree = "<group>"; };
+		D80C9C6B1AB2091A00AF7F29 /* YapDatabaseTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseTransaction.h; sourceTree = "<group>"; };
+		D80C9C6C1AB2091A00AF7F29 /* YapDatabaseTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseTransaction.m; sourceTree = "<group>"; };
+		D80C9C711AB2092D00AF7F29 /* YapDatabaseFilteredView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredView.h; sourceTree = "<group>"; };
+		D80C9C721AB2092D00AF7F29 /* YapDatabaseFilteredView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredView.m; sourceTree = "<group>"; };
+		D80C9C731AB2092D00AF7F29 /* YapDatabaseFilteredViewConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewConnection.h; sourceTree = "<group>"; };
+		D80C9C741AB2092D00AF7F29 /* YapDatabaseFilteredViewConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewConnection.m; sourceTree = "<group>"; };
+		D80C9C751AB2092D00AF7F29 /* YapDatabaseFilteredViewTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTransaction.h; sourceTree = "<group>"; };
+		D80C9C761AB2092D00AF7F29 /* YapDatabaseFilteredViewTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewTransaction.m; sourceTree = "<group>"; };
+		D80C9C771AB2092D00AF7F29 /* YapDatabaseFilteredViewTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTypes.h; sourceTree = "<group>"; };
+		D80C9C781AB2092D00AF7F29 /* YapDatabaseFilteredViewTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewTypes.m; sourceTree = "<group>"; };
+		D80C9C7D1AB2093D00AF7F29 /* YapDatabaseFilteredViewPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewPrivate.h; sourceTree = "<group>"; };
+		D80C9C7E1AB2094F00AF7F29 /* YapDatabaseFullTextSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearch.h; sourceTree = "<group>"; };
+		D80C9C7F1AB2094F00AF7F29 /* YapDatabaseFullTextSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearch.m; sourceTree = "<group>"; };
+		D80C9C801AB2094F00AF7F29 /* YapDatabaseFullTextSearchConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchConnection.h; sourceTree = "<group>"; };
+		D80C9C811AB2094F00AF7F29 /* YapDatabaseFullTextSearchConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchConnection.m; sourceTree = "<group>"; };
+		D80C9C821AB2094F00AF7F29 /* YapDatabaseFullTextSearchHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchHandler.h; sourceTree = "<group>"; };
+		D80C9C831AB2094F00AF7F29 /* YapDatabaseFullTextSearchHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchHandler.m; sourceTree = "<group>"; };
+		D80C9C841AB2094F00AF7F29 /* YapDatabaseFullTextSearchSnippetOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchSnippetOptions.h; sourceTree = "<group>"; };
+		D80C9C851AB2094F00AF7F29 /* YapDatabaseFullTextSearchSnippetOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchSnippetOptions.m; sourceTree = "<group>"; };
+		D80C9C861AB2094F00AF7F29 /* YapDatabaseFullTextSearchTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchTransaction.h; sourceTree = "<group>"; };
+		D80C9C871AB2094F00AF7F29 /* YapDatabaseFullTextSearchTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchTransaction.m; sourceTree = "<group>"; };
+		D80C9C8D1AB2099700AF7F29 /* YapDatabaseSecondaryIndex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndex.h; sourceTree = "<group>"; };
+		D80C9C8E1AB2099700AF7F29 /* YapDatabaseSecondaryIndex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndex.m; sourceTree = "<group>"; };
+		D80C9C8F1AB2099700AF7F29 /* YapDatabaseSecondaryIndexConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexConnection.h; sourceTree = "<group>"; };
+		D80C9C901AB2099700AF7F29 /* YapDatabaseSecondaryIndexConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexConnection.m; sourceTree = "<group>"; };
+		D80C9C911AB2099700AF7F29 /* YapDatabaseSecondaryIndexHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexHandler.h; sourceTree = "<group>"; };
+		D80C9C921AB2099700AF7F29 /* YapDatabaseSecondaryIndexHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexHandler.m; sourceTree = "<group>"; };
+		D80C9C931AB2099700AF7F29 /* YapDatabaseSecondaryIndexOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexOptions.h; sourceTree = "<group>"; };
+		D80C9C941AB2099700AF7F29 /* YapDatabaseSecondaryIndexOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexOptions.m; sourceTree = "<group>"; };
+		D80C9C951AB2099700AF7F29 /* YapDatabaseSecondaryIndexSetup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexSetup.h; sourceTree = "<group>"; };
+		D80C9C961AB2099700AF7F29 /* YapDatabaseSecondaryIndexSetup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexSetup.m; sourceTree = "<group>"; };
+		D80C9C971AB2099700AF7F29 /* YapDatabaseSecondaryIndexTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexTransaction.h; sourceTree = "<group>"; };
+		D80C9C981AB2099700AF7F29 /* YapDatabaseSecondaryIndexTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexTransaction.m; sourceTree = "<group>"; };
+		D80C9C9F1AB209B000AF7F29 /* YapDatabaseViewChangePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChangePrivate.h; sourceTree = "<group>"; };
+		D80C9CA01AB209B000AF7F29 /* YapDatabaseViewMappingsPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappingsPrivate.h; sourceTree = "<group>"; };
+		D80C9CA11AB209B000AF7F29 /* YapDatabaseViewPage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPage.h; sourceTree = "<group>"; };
+		D80C9CA21AB209B000AF7F29 /* YapDatabaseViewPage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YapDatabaseViewPage.mm; sourceTree = "<group>"; };
+		D80C9CA31AB209B000AF7F29 /* YapDatabaseViewPageMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPageMetadata.h; sourceTree = "<group>"; };
+		D80C9CA41AB209B000AF7F29 /* YapDatabaseViewPageMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewPageMetadata.m; sourceTree = "<group>"; };
+		D80C9CA51AB209B000AF7F29 /* YapDatabaseViewPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPrivate.h; sourceTree = "<group>"; };
+		D80C9CA61AB209B000AF7F29 /* YapDatabaseViewRangeOptionsPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptionsPrivate.h; sourceTree = "<group>"; };
+		D80C9CA71AB209B000AF7F29 /* YapDatabaseViewState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewState.h; sourceTree = "<group>"; };
+		D80C9CA81AB209B000AF7F29 /* YapDatabaseViewState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewState.m; sourceTree = "<group>"; };
+		D80C9CAC1AB209BD00AF7F29 /* YapDatabaseViewChange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChange.h; sourceTree = "<group>"; };
+		D80C9CAD1AB209BD00AF7F29 /* YapDatabaseViewChange.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewChange.m; sourceTree = "<group>"; };
+		D80C9CAE1AB209BD00AF7F29 /* YapDatabaseViewMappings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappings.h; sourceTree = "<group>"; };
+		D80C9CAF1AB209BD00AF7F29 /* YapDatabaseViewMappings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewMappings.m; sourceTree = "<group>"; };
+		D80C9CB01AB209BD00AF7F29 /* YapDatabaseViewRangeOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptions.h; sourceTree = "<group>"; };
+		D80C9CB11AB209BD00AF7F29 /* YapDatabaseViewRangeOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewRangeOptions.m; sourceTree = "<group>"; };
+		D80C9CB51AB209D000AF7F29 /* YapDatabaseView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseView.h; sourceTree = "<group>"; };
+		D80C9CB61AB209D000AF7F29 /* YapDatabaseView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseView.m; sourceTree = "<group>"; };
+		D80C9CB71AB209D000AF7F29 /* YapDatabaseViewConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewConnection.h; sourceTree = "<group>"; };
+		D80C9CB81AB209D000AF7F29 /* YapDatabaseViewConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewConnection.m; sourceTree = "<group>"; };
+		D80C9CB91AB209D000AF7F29 /* YapDatabaseViewOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewOptions.h; sourceTree = "<group>"; };
+		D80C9CBA1AB209D000AF7F29 /* YapDatabaseViewOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewOptions.m; sourceTree = "<group>"; };
+		D80C9CBB1AB209D000AF7F29 /* YapDatabaseViewTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTransaction.h; sourceTree = "<group>"; };
+		D80C9CBC1AB209D000AF7F29 /* YapDatabaseViewTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewTransaction.m; sourceTree = "<group>"; };
+		D80C9CBD1AB209D000AF7F29 /* YapDatabaseViewTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTypes.h; sourceTree = "<group>"; };
+		D80C9CBE1AB209D000AF7F29 /* YapDatabaseViewTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewTypes.m; sourceTree = "<group>"; };
 		DC882B451926C445004C3166 /* SearchResultsExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SearchResultsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC882B481926C445004C3166 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		DC882B4A1926C445004C3166 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -110,23 +212,7 @@
 		DC882B871926C469004C3166 /* DDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDTTYLogger.h; sourceTree = "<group>"; };
 		DC882B881926C469004C3166 /* DDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDTTYLogger.m; sourceTree = "<group>"; };
 		DC882B8E1926C469004C3166 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
-		DC882B9D1926C4C2004C3166 /* YapDatabaseFilteredViewPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewPrivate.h; sourceTree = "<group>"; };
-		DC882B9E1926C4C2004C3166 /* YapDatabaseFilteredView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredView.h; sourceTree = "<group>"; };
-		DC882B9F1926C4C2004C3166 /* YapDatabaseFilteredView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredView.m; sourceTree = "<group>"; };
-		DC882BA01926C4C2004C3166 /* YapDatabaseFilteredViewConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewConnection.h; sourceTree = "<group>"; };
-		DC882BA11926C4C2004C3166 /* YapDatabaseFilteredViewConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewConnection.m; sourceTree = "<group>"; };
-		DC882BA21926C4C2004C3166 /* YapDatabaseFilteredViewTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTransaction.h; sourceTree = "<group>"; };
-		DC882BA31926C4C2004C3166 /* YapDatabaseFilteredViewTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewTransaction.m; sourceTree = "<group>"; };
-		DC882BA41926C4C2004C3166 /* YapDatabaseFilteredViewTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTypes.h; sourceTree = "<group>"; };
 		DC882BA71926C4C2004C3166 /* YapDatabaseFullTextSearchPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchPrivate.h; sourceTree = "<group>"; };
-		DC882BA81926C4C2004C3166 /* YapDatabaseFullTextSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearch.h; sourceTree = "<group>"; };
-		DC882BA91926C4C2004C3166 /* YapDatabaseFullTextSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearch.m; sourceTree = "<group>"; };
-		DC882BAA1926C4C2004C3166 /* YapDatabaseFullTextSearchConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchConnection.h; sourceTree = "<group>"; };
-		DC882BAB1926C4C2004C3166 /* YapDatabaseFullTextSearchConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchConnection.m; sourceTree = "<group>"; };
-		DC882BAC1926C4C2004C3166 /* YapDatabaseFullTextSearchSnippetOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchSnippetOptions.h; sourceTree = "<group>"; };
-		DC882BAD1926C4C2004C3166 /* YapDatabaseFullTextSearchSnippetOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchSnippetOptions.m; sourceTree = "<group>"; };
-		DC882BAE1926C4C2004C3166 /* YapDatabaseFullTextSearchTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchTransaction.h; sourceTree = "<group>"; };
-		DC882BAF1926C4C2004C3166 /* YapDatabaseFullTextSearchTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchTransaction.m; sourceTree = "<group>"; };
 		DC882BB21926C4C2004C3166 /* YapDatabaseExtensionPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionPrivate.h; sourceTree = "<group>"; };
 		DC882BB31926C4C2004C3166 /* YapDatabaseExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtension.h; sourceTree = "<group>"; };
 		DC882BB41926C4C2004C3166 /* YapDatabaseExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseExtension.m; sourceTree = "<group>"; };
@@ -160,76 +246,6 @@
 		DC882BD41926C4C2004C3166 /* YapDatabaseSearchResultsViewTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewTransaction.h; sourceTree = "<group>"; };
 		DC882BD51926C4C2004C3166 /* YapDatabaseSearchResultsViewTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsViewTransaction.m; sourceTree = "<group>"; };
 		DC882BD81926C4C2004C3166 /* YapDatabaseSecondaryIndexPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexPrivate.h; sourceTree = "<group>"; };
-		DC882BD91926C4C2004C3166 /* YapDatabaseSecondaryIndexSetupPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexSetupPrivate.h; sourceTree = "<group>"; };
-		DC882BDA1926C4C2004C3166 /* YapDatabaseSecondaryIndex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndex.h; sourceTree = "<group>"; };
-		DC882BDB1926C4C2004C3166 /* YapDatabaseSecondaryIndex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndex.m; sourceTree = "<group>"; };
-		DC882BDC1926C4C2004C3166 /* YapDatabaseSecondaryIndexConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexConnection.h; sourceTree = "<group>"; };
-		DC882BDD1926C4C2004C3166 /* YapDatabaseSecondaryIndexConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexConnection.m; sourceTree = "<group>"; };
-		DC882BDE1926C4C2004C3166 /* YapDatabaseSecondaryIndexSetup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexSetup.h; sourceTree = "<group>"; };
-		DC882BDF1926C4C2004C3166 /* YapDatabaseSecondaryIndexSetup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexSetup.m; sourceTree = "<group>"; };
-		DC882BE01926C4C2004C3166 /* YapDatabaseSecondaryIndexTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexTransaction.h; sourceTree = "<group>"; };
-		DC882BE11926C4C2004C3166 /* YapDatabaseSecondaryIndexTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexTransaction.m; sourceTree = "<group>"; };
-		DC882BE41926C4C2004C3166 /* YapDatabaseViewChangePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChangePrivate.h; sourceTree = "<group>"; };
-		DC882BE51926C4C2004C3166 /* YapDatabaseViewMappingsPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappingsPrivate.h; sourceTree = "<group>"; };
-		DC882BE61926C4C2004C3166 /* YapDatabaseViewPage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPage.h; sourceTree = "<group>"; };
-		DC882BE71926C4C2004C3166 /* YapDatabaseViewPage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YapDatabaseViewPage.mm; sourceTree = "<group>"; };
-		DC882BE81926C4C2004C3166 /* YapDatabaseViewPageMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPageMetadata.h; sourceTree = "<group>"; };
-		DC882BE91926C4C2004C3166 /* YapDatabaseViewPageMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewPageMetadata.m; sourceTree = "<group>"; };
-		DC882BEA1926C4C2004C3166 /* YapDatabaseViewPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPrivate.h; sourceTree = "<group>"; };
-		DC882BEB1926C4C2004C3166 /* YapDatabaseViewRangeOptionsPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptionsPrivate.h; sourceTree = "<group>"; };
-		DC882BED1926C4C2004C3166 /* YapDatabaseViewChange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChange.h; sourceTree = "<group>"; };
-		DC882BEE1926C4C2004C3166 /* YapDatabaseViewChange.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewChange.m; sourceTree = "<group>"; };
-		DC882BEF1926C4C2004C3166 /* YapDatabaseViewMappings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappings.h; sourceTree = "<group>"; };
-		DC882BF01926C4C2004C3166 /* YapDatabaseViewMappings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewMappings.m; sourceTree = "<group>"; };
-		DC882BF11926C4C2004C3166 /* YapDatabaseViewRangeOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptions.h; sourceTree = "<group>"; };
-		DC882BF21926C4C2004C3166 /* YapDatabaseViewRangeOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewRangeOptions.m; sourceTree = "<group>"; };
-		DC882BF31926C4C2004C3166 /* YapDatabaseView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseView.h; sourceTree = "<group>"; };
-		DC882BF41926C4C2004C3166 /* YapDatabaseView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseView.m; sourceTree = "<group>"; };
-		DC882BF51926C4C2004C3166 /* YapDatabaseViewConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewConnection.h; sourceTree = "<group>"; };
-		DC882BF61926C4C2004C3166 /* YapDatabaseViewConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewConnection.m; sourceTree = "<group>"; };
-		DC882BF71926C4C2004C3166 /* YapDatabaseViewOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewOptions.h; sourceTree = "<group>"; };
-		DC882BF81926C4C2004C3166 /* YapDatabaseViewOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewOptions.m; sourceTree = "<group>"; };
-		DC882BF91926C4C2004C3166 /* YapDatabaseViewTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTransaction.h; sourceTree = "<group>"; };
-		DC882BFA1926C4C2004C3166 /* YapDatabaseViewTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewTransaction.m; sourceTree = "<group>"; };
-		DC882BFB1926C4C2004C3166 /* YapDatabaseViewTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTypes.h; sourceTree = "<group>"; };
-		DC882BFD1926C4C2004C3166 /* NSDictionary+YapDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+YapDatabase.h"; sourceTree = "<group>"; };
-		DC882BFE1926C4C2004C3166 /* NSDictionary+YapDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+YapDatabase.m"; sourceTree = "<group>"; };
-		DC882BFF1926C4C2004C3166 /* YapCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapCache.h; sourceTree = "<group>"; };
-		DC882C001926C4C2004C3166 /* YapCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapCache.m; sourceTree = "<group>"; };
-		DC882C011926C4C2004C3166 /* YapDatabaseConnectionDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionDefaults.h; sourceTree = "<group>"; };
-		DC882C021926C4C2004C3166 /* YapDatabaseConnectionDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionDefaults.m; sourceTree = "<group>"; };
-		DC882C031926C4C2004C3166 /* YapDatabaseConnectionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionState.h; sourceTree = "<group>"; };
-		DC882C041926C4C2004C3166 /* YapDatabaseConnectionState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionState.m; sourceTree = "<group>"; };
-		DC882C051926C4C3004C3166 /* YapDatabaseLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseLogging.h; sourceTree = "<group>"; };
-		DC882C061926C4C3004C3166 /* YapDatabaseLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseLogging.m; sourceTree = "<group>"; };
-		DC882C071926C4C3004C3166 /* YapDatabaseManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseManager.h; sourceTree = "<group>"; };
-		DC882C081926C4C3004C3166 /* YapDatabaseManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseManager.m; sourceTree = "<group>"; };
-		DC882C091926C4C3004C3166 /* YapDatabasePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabasePrivate.h; sourceTree = "<group>"; };
-		DC882C0A1926C4C3004C3166 /* YapDatabaseStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseStatement.h; sourceTree = "<group>"; };
-		DC882C0B1926C4C3004C3166 /* YapDatabaseStatement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseStatement.m; sourceTree = "<group>"; };
-		DC882C0C1926C4C3004C3166 /* YapDatabaseString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseString.h; sourceTree = "<group>"; };
-		DC882C0D1926C4C3004C3166 /* YapMemoryTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapMemoryTable.h; sourceTree = "<group>"; };
-		DC882C0E1926C4C3004C3166 /* YapMemoryTable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapMemoryTable.m; sourceTree = "<group>"; };
-		DC882C0F1926C4C3004C3166 /* YapNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapNull.h; sourceTree = "<group>"; };
-		DC882C101926C4C3004C3166 /* YapNull.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapNull.m; sourceTree = "<group>"; };
-		DC882C111926C4C3004C3166 /* YapRowidSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapRowidSet.h; sourceTree = "<group>"; };
-		DC882C121926C4C3004C3166 /* YapRowidSet.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YapRowidSet.mm; sourceTree = "<group>"; };
-		DC882C131926C4C3004C3166 /* YapTouch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapTouch.h; sourceTree = "<group>"; };
-		DC882C141926C4C3004C3166 /* YapTouch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapTouch.m; sourceTree = "<group>"; };
-		DC882C171926C4C3004C3166 /* YapCollectionKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapCollectionKey.h; sourceTree = "<group>"; };
-		DC882C181926C4C3004C3166 /* YapCollectionKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapCollectionKey.m; sourceTree = "<group>"; };
-		DC882C191926C4C3004C3166 /* YapDatabaseQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseQuery.h; sourceTree = "<group>"; };
-		DC882C1A1926C4C3004C3166 /* YapDatabaseQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseQuery.m; sourceTree = "<group>"; };
-		DC882C1B1926C4C3004C3166 /* YapSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapSet.h; sourceTree = "<group>"; };
-		DC882C1C1926C4C3004C3166 /* YapSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapSet.m; sourceTree = "<group>"; };
-		DC882C1D1926C4C3004C3166 /* YapDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabase.h; sourceTree = "<group>"; };
-		DC882C1E1926C4C3004C3166 /* YapDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabase.m; sourceTree = "<group>"; };
-		DC882C1F1926C4C3004C3166 /* YapDatabaseConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnection.h; sourceTree = "<group>"; };
-		DC882C201926C4C3004C3166 /* YapDatabaseConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnection.m; sourceTree = "<group>"; };
-		DC882C211926C4C3004C3166 /* YapDatabaseOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseOptions.h; sourceTree = "<group>"; };
-		DC882C221926C4C3004C3166 /* YapDatabaseOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseOptions.m; sourceTree = "<group>"; };
-		DC882C231926C4C3004C3166 /* YapDatabaseTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseTransaction.h; sourceTree = "<group>"; };
-		DC882C241926C4C3004C3166 /* YapDatabaseTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseTransaction.m; sourceTree = "<group>"; };
 		DC882C591926C538004C3166 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
 		DC882C5B1926D46C004C3166 /* names.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = names.json; path = SearchResultsExample/names.json; sourceTree = "<group>"; };
 		DC882C5E1926D63A004C3166 /* Person.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Person.h; sourceTree = "<group>"; };
@@ -240,10 +256,6 @@
 		DCA2AE1E1962124800B5E7CA /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
 		DCA2AE1F1962124800B5E7CA /* DDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDMultiFormatter.h; sourceTree = "<group>"; };
 		DCA2AE201962124800B5E7CA /* DDMultiFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDMultiFormatter.m; sourceTree = "<group>"; };
-		DCA2AE241962127200B5E7CA /* YapDatabaseSecondaryIndexOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexOptions.h; sourceTree = "<group>"; };
-		DCA2AE251962127200B5E7CA /* YapDatabaseSecondaryIndexOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexOptions.m; sourceTree = "<group>"; };
-		DCA2AE271962129600B5E7CA /* YapDatabaseViewState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewState.h; sourceTree = "<group>"; };
-		DCA2AE281962129600B5E7CA /* YapDatabaseViewState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewState.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -357,14 +369,14 @@
 			children = (
 				DC882BFC1926C4C2004C3166 /* Internal */,
 				DC882C161926C4C3004C3166 /* Utilities */,
-				DC882C1D1926C4C3004C3166 /* YapDatabase.h */,
-				DC882C1E1926C4C3004C3166 /* YapDatabase.m */,
-				DC882C1F1926C4C3004C3166 /* YapDatabaseConnection.h */,
-				DC882C201926C4C3004C3166 /* YapDatabaseConnection.m */,
-				DC882C211926C4C3004C3166 /* YapDatabaseOptions.h */,
-				DC882C221926C4C3004C3166 /* YapDatabaseOptions.m */,
-				DC882C231926C4C3004C3166 /* YapDatabaseTransaction.h */,
-				DC882C241926C4C3004C3166 /* YapDatabaseTransaction.m */,
+				D80C9C651AB2091A00AF7F29 /* YapDatabase.h */,
+				D80C9C661AB2091A00AF7F29 /* YapDatabase.m */,
+				D80C9C671AB2091A00AF7F29 /* YapDatabaseConnection.h */,
+				D80C9C681AB2091A00AF7F29 /* YapDatabaseConnection.m */,
+				D80C9C691AB2091A00AF7F29 /* YapDatabaseOptions.h */,
+				D80C9C6A1AB2091A00AF7F29 /* YapDatabaseOptions.m */,
+				D80C9C6B1AB2091A00AF7F29 /* YapDatabaseTransaction.h */,
+				D80C9C6C1AB2091A00AF7F29 /* YapDatabaseTransaction.m */,
 				DC882B9A1926C4C2004C3166 /* Extensions */,
 			);
 			name = YapDatabase;
@@ -389,13 +401,14 @@
 			isa = PBXGroup;
 			children = (
 				DC882B9C1926C4C2004C3166 /* Internal */,
-				DC882B9E1926C4C2004C3166 /* YapDatabaseFilteredView.h */,
-				DC882B9F1926C4C2004C3166 /* YapDatabaseFilteredView.m */,
-				DC882BA01926C4C2004C3166 /* YapDatabaseFilteredViewConnection.h */,
-				DC882BA11926C4C2004C3166 /* YapDatabaseFilteredViewConnection.m */,
-				DC882BA21926C4C2004C3166 /* YapDatabaseFilteredViewTransaction.h */,
-				DC882BA31926C4C2004C3166 /* YapDatabaseFilteredViewTransaction.m */,
-				DC882BA41926C4C2004C3166 /* YapDatabaseFilteredViewTypes.h */,
+				D80C9C711AB2092D00AF7F29 /* YapDatabaseFilteredView.h */,
+				D80C9C721AB2092D00AF7F29 /* YapDatabaseFilteredView.m */,
+				D80C9C731AB2092D00AF7F29 /* YapDatabaseFilteredViewConnection.h */,
+				D80C9C741AB2092D00AF7F29 /* YapDatabaseFilteredViewConnection.m */,
+				D80C9C751AB2092D00AF7F29 /* YapDatabaseFilteredViewTransaction.h */,
+				D80C9C761AB2092D00AF7F29 /* YapDatabaseFilteredViewTransaction.m */,
+				D80C9C771AB2092D00AF7F29 /* YapDatabaseFilteredViewTypes.h */,
+				D80C9C781AB2092D00AF7F29 /* YapDatabaseFilteredViewTypes.m */,
 			);
 			path = FilteredViews;
 			sourceTree = "<group>";
@@ -403,7 +416,7 @@
 		DC882B9C1926C4C2004C3166 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				DC882B9D1926C4C2004C3166 /* YapDatabaseFilteredViewPrivate.h */,
+				D80C9C7D1AB2093D00AF7F29 /* YapDatabaseFilteredViewPrivate.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -412,14 +425,16 @@
 			isa = PBXGroup;
 			children = (
 				DC882BA61926C4C2004C3166 /* Internal */,
-				DC882BA81926C4C2004C3166 /* YapDatabaseFullTextSearch.h */,
-				DC882BA91926C4C2004C3166 /* YapDatabaseFullTextSearch.m */,
-				DC882BAA1926C4C2004C3166 /* YapDatabaseFullTextSearchConnection.h */,
-				DC882BAB1926C4C2004C3166 /* YapDatabaseFullTextSearchConnection.m */,
-				DC882BAC1926C4C2004C3166 /* YapDatabaseFullTextSearchSnippetOptions.h */,
-				DC882BAD1926C4C2004C3166 /* YapDatabaseFullTextSearchSnippetOptions.m */,
-				DC882BAE1926C4C2004C3166 /* YapDatabaseFullTextSearchTransaction.h */,
-				DC882BAF1926C4C2004C3166 /* YapDatabaseFullTextSearchTransaction.m */,
+				D80C9C7E1AB2094F00AF7F29 /* YapDatabaseFullTextSearch.h */,
+				D80C9C7F1AB2094F00AF7F29 /* YapDatabaseFullTextSearch.m */,
+				D80C9C801AB2094F00AF7F29 /* YapDatabaseFullTextSearchConnection.h */,
+				D80C9C811AB2094F00AF7F29 /* YapDatabaseFullTextSearchConnection.m */,
+				D80C9C821AB2094F00AF7F29 /* YapDatabaseFullTextSearchHandler.h */,
+				D80C9C831AB2094F00AF7F29 /* YapDatabaseFullTextSearchHandler.m */,
+				D80C9C841AB2094F00AF7F29 /* YapDatabaseFullTextSearchSnippetOptions.h */,
+				D80C9C851AB2094F00AF7F29 /* YapDatabaseFullTextSearchSnippetOptions.m */,
+				D80C9C861AB2094F00AF7F29 /* YapDatabaseFullTextSearchTransaction.h */,
+				D80C9C871AB2094F00AF7F29 /* YapDatabaseFullTextSearchTransaction.m */,
 			);
 			path = FullTextSearch;
 			sourceTree = "<group>";
@@ -491,10 +506,10 @@
 				DC882BCD1926C4C2004C3166 /* YapDatabaseSearchQueuePrivate.h */,
 				DC882BCE1926C4C2004C3166 /* YapDatabaseSearchResultsView.h */,
 				DC882BCF1926C4C2004C3166 /* YapDatabaseSearchResultsView.m */,
-				DC882BD21926C4C2004C3166 /* YapDatabaseSearchResultsViewOptions.h */,
-				DC882BD31926C4C2004C3166 /* YapDatabaseSearchResultsViewOptions.m */,
 				DC882BD01926C4C2004C3166 /* YapDatabaseSearchResultsViewConnection.h */,
 				DC882BD11926C4C2004C3166 /* YapDatabaseSearchResultsViewConnection.m */,
+				DC882BD21926C4C2004C3166 /* YapDatabaseSearchResultsViewOptions.h */,
+				DC882BD31926C4C2004C3166 /* YapDatabaseSearchResultsViewOptions.m */,
 				DC882BD41926C4C2004C3166 /* YapDatabaseSearchResultsViewTransaction.h */,
 				DC882BD51926C4C2004C3166 /* YapDatabaseSearchResultsViewTransaction.m */,
 			);
@@ -513,16 +528,18 @@
 			isa = PBXGroup;
 			children = (
 				DC882BD71926C4C2004C3166 /* Internal */,
-				DC882BDA1926C4C2004C3166 /* YapDatabaseSecondaryIndex.h */,
-				DC882BDB1926C4C2004C3166 /* YapDatabaseSecondaryIndex.m */,
-				DC882BDE1926C4C2004C3166 /* YapDatabaseSecondaryIndexSetup.h */,
-				DC882BDF1926C4C2004C3166 /* YapDatabaseSecondaryIndexSetup.m */,
-				DCA2AE241962127200B5E7CA /* YapDatabaseSecondaryIndexOptions.h */,
-				DCA2AE251962127200B5E7CA /* YapDatabaseSecondaryIndexOptions.m */,
-				DC882BDC1926C4C2004C3166 /* YapDatabaseSecondaryIndexConnection.h */,
-				DC882BDD1926C4C2004C3166 /* YapDatabaseSecondaryIndexConnection.m */,
-				DC882BE01926C4C2004C3166 /* YapDatabaseSecondaryIndexTransaction.h */,
-				DC882BE11926C4C2004C3166 /* YapDatabaseSecondaryIndexTransaction.m */,
+				D80C9C8D1AB2099700AF7F29 /* YapDatabaseSecondaryIndex.h */,
+				D80C9C8E1AB2099700AF7F29 /* YapDatabaseSecondaryIndex.m */,
+				D80C9C8F1AB2099700AF7F29 /* YapDatabaseSecondaryIndexConnection.h */,
+				D80C9C901AB2099700AF7F29 /* YapDatabaseSecondaryIndexConnection.m */,
+				D80C9C911AB2099700AF7F29 /* YapDatabaseSecondaryIndexHandler.h */,
+				D80C9C921AB2099700AF7F29 /* YapDatabaseSecondaryIndexHandler.m */,
+				D80C9C931AB2099700AF7F29 /* YapDatabaseSecondaryIndexOptions.h */,
+				D80C9C941AB2099700AF7F29 /* YapDatabaseSecondaryIndexOptions.m */,
+				D80C9C951AB2099700AF7F29 /* YapDatabaseSecondaryIndexSetup.h */,
+				D80C9C961AB2099700AF7F29 /* YapDatabaseSecondaryIndexSetup.m */,
+				D80C9C971AB2099700AF7F29 /* YapDatabaseSecondaryIndexTransaction.h */,
+				D80C9C981AB2099700AF7F29 /* YapDatabaseSecondaryIndexTransaction.m */,
 			);
 			path = SecondaryIndex;
 			sourceTree = "<group>";
@@ -531,7 +548,6 @@
 			isa = PBXGroup;
 			children = (
 				DC882BD81926C4C2004C3166 /* YapDatabaseSecondaryIndexPrivate.h */,
-				DC882BD91926C4C2004C3166 /* YapDatabaseSecondaryIndexSetupPrivate.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -541,15 +557,16 @@
 			children = (
 				DC882BE31926C4C2004C3166 /* Internal */,
 				DC882BEC1926C4C2004C3166 /* Utilities */,
-				DC882BF31926C4C2004C3166 /* YapDatabaseView.h */,
-				DC882BF41926C4C2004C3166 /* YapDatabaseView.m */,
-				DC882BF51926C4C2004C3166 /* YapDatabaseViewConnection.h */,
-				DC882BF61926C4C2004C3166 /* YapDatabaseViewConnection.m */,
-				DC882BF71926C4C2004C3166 /* YapDatabaseViewOptions.h */,
-				DC882BF81926C4C2004C3166 /* YapDatabaseViewOptions.m */,
-				DC882BF91926C4C2004C3166 /* YapDatabaseViewTransaction.h */,
-				DC882BFA1926C4C2004C3166 /* YapDatabaseViewTransaction.m */,
-				DC882BFB1926C4C2004C3166 /* YapDatabaseViewTypes.h */,
+				D80C9CB51AB209D000AF7F29 /* YapDatabaseView.h */,
+				D80C9CB61AB209D000AF7F29 /* YapDatabaseView.m */,
+				D80C9CB71AB209D000AF7F29 /* YapDatabaseViewConnection.h */,
+				D80C9CB81AB209D000AF7F29 /* YapDatabaseViewConnection.m */,
+				D80C9CB91AB209D000AF7F29 /* YapDatabaseViewOptions.h */,
+				D80C9CBA1AB209D000AF7F29 /* YapDatabaseViewOptions.m */,
+				D80C9CBB1AB209D000AF7F29 /* YapDatabaseViewTransaction.h */,
+				D80C9CBC1AB209D000AF7F29 /* YapDatabaseViewTransaction.m */,
+				D80C9CBD1AB209D000AF7F29 /* YapDatabaseViewTypes.h */,
+				D80C9CBE1AB209D000AF7F29 /* YapDatabaseViewTypes.m */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -557,16 +574,16 @@
 		DC882BE31926C4C2004C3166 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				DC882BEA1926C4C2004C3166 /* YapDatabaseViewPrivate.h */,
-				DCA2AE271962129600B5E7CA /* YapDatabaseViewState.h */,
-				DCA2AE281962129600B5E7CA /* YapDatabaseViewState.m */,
-				DC882BE61926C4C2004C3166 /* YapDatabaseViewPage.h */,
-				DC882BE71926C4C2004C3166 /* YapDatabaseViewPage.mm */,
-				DC882BE81926C4C2004C3166 /* YapDatabaseViewPageMetadata.h */,
-				DC882BE91926C4C2004C3166 /* YapDatabaseViewPageMetadata.m */,
-				DC882BE41926C4C2004C3166 /* YapDatabaseViewChangePrivate.h */,
-				DC882BE51926C4C2004C3166 /* YapDatabaseViewMappingsPrivate.h */,
-				DC882BEB1926C4C2004C3166 /* YapDatabaseViewRangeOptionsPrivate.h */,
+				D80C9C9F1AB209B000AF7F29 /* YapDatabaseViewChangePrivate.h */,
+				D80C9CA01AB209B000AF7F29 /* YapDatabaseViewMappingsPrivate.h */,
+				D80C9CA11AB209B000AF7F29 /* YapDatabaseViewPage.h */,
+				D80C9CA21AB209B000AF7F29 /* YapDatabaseViewPage.mm */,
+				D80C9CA31AB209B000AF7F29 /* YapDatabaseViewPageMetadata.h */,
+				D80C9CA41AB209B000AF7F29 /* YapDatabaseViewPageMetadata.m */,
+				D80C9CA51AB209B000AF7F29 /* YapDatabaseViewPrivate.h */,
+				D80C9CA61AB209B000AF7F29 /* YapDatabaseViewRangeOptionsPrivate.h */,
+				D80C9CA71AB209B000AF7F29 /* YapDatabaseViewState.h */,
+				D80C9CA81AB209B000AF7F29 /* YapDatabaseViewState.m */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -574,12 +591,12 @@
 		DC882BEC1926C4C2004C3166 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				DC882BED1926C4C2004C3166 /* YapDatabaseViewChange.h */,
-				DC882BEE1926C4C2004C3166 /* YapDatabaseViewChange.m */,
-				DC882BEF1926C4C2004C3166 /* YapDatabaseViewMappings.h */,
-				DC882BF01926C4C2004C3166 /* YapDatabaseViewMappings.m */,
-				DC882BF11926C4C2004C3166 /* YapDatabaseViewRangeOptions.h */,
-				DC882BF21926C4C2004C3166 /* YapDatabaseViewRangeOptions.m */,
+				D80C9CAC1AB209BD00AF7F29 /* YapDatabaseViewChange.h */,
+				D80C9CAD1AB209BD00AF7F29 /* YapDatabaseViewChange.m */,
+				D80C9CAE1AB209BD00AF7F29 /* YapDatabaseViewMappings.h */,
+				D80C9CAF1AB209BD00AF7F29 /* YapDatabaseViewMappings.m */,
+				D80C9CB01AB209BD00AF7F29 /* YapDatabaseViewRangeOptions.h */,
+				D80C9CB11AB209BD00AF7F29 /* YapDatabaseViewRangeOptions.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -587,30 +604,28 @@
 		DC882BFC1926C4C2004C3166 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				DC882BFD1926C4C2004C3166 /* NSDictionary+YapDatabase.h */,
-				DC882BFE1926C4C2004C3166 /* NSDictionary+YapDatabase.m */,
-				DC882BFF1926C4C2004C3166 /* YapCache.h */,
-				DC882C001926C4C2004C3166 /* YapCache.m */,
-				DC882C011926C4C2004C3166 /* YapDatabaseConnectionDefaults.h */,
-				DC882C021926C4C2004C3166 /* YapDatabaseConnectionDefaults.m */,
-				DC882C031926C4C2004C3166 /* YapDatabaseConnectionState.h */,
-				DC882C041926C4C2004C3166 /* YapDatabaseConnectionState.m */,
-				DC882C051926C4C3004C3166 /* YapDatabaseLogging.h */,
-				DC882C061926C4C3004C3166 /* YapDatabaseLogging.m */,
-				DC882C071926C4C3004C3166 /* YapDatabaseManager.h */,
-				DC882C081926C4C3004C3166 /* YapDatabaseManager.m */,
-				DC882C091926C4C3004C3166 /* YapDatabasePrivate.h */,
-				DC882C0A1926C4C3004C3166 /* YapDatabaseStatement.h */,
-				DC882C0B1926C4C3004C3166 /* YapDatabaseStatement.m */,
-				DC882C0C1926C4C3004C3166 /* YapDatabaseString.h */,
-				DC882C0D1926C4C3004C3166 /* YapMemoryTable.h */,
-				DC882C0E1926C4C3004C3166 /* YapMemoryTable.m */,
-				DC882C0F1926C4C3004C3166 /* YapNull.h */,
-				DC882C101926C4C3004C3166 /* YapNull.m */,
-				DC882C111926C4C3004C3166 /* YapRowidSet.h */,
-				DC882C121926C4C3004C3166 /* YapRowidSet.mm */,
-				DC882C131926C4C3004C3166 /* YapTouch.h */,
-				DC882C141926C4C3004C3166 /* YapTouch.m */,
+				D80C9C361AB208FB00AF7F29 /* NSDictionary+YapDatabase.h */,
+				D80C9C371AB208FB00AF7F29 /* NSDictionary+YapDatabase.m */,
+				D80C9C381AB208FB00AF7F29 /* YapDatabaseConnectionDefaults.h */,
+				D80C9C391AB208FB00AF7F29 /* YapDatabaseConnectionDefaults.m */,
+				D80C9C3A1AB208FB00AF7F29 /* YapDatabaseConnectionState.h */,
+				D80C9C3B1AB208FB00AF7F29 /* YapDatabaseConnectionState.m */,
+				D80C9C3C1AB208FB00AF7F29 /* YapDatabaseLogging.h */,
+				D80C9C3D1AB208FB00AF7F29 /* YapDatabaseLogging.m */,
+				D80C9C3E1AB208FB00AF7F29 /* YapDatabaseManager.h */,
+				D80C9C3F1AB208FB00AF7F29 /* YapDatabaseManager.m */,
+				D80C9C401AB208FB00AF7F29 /* YapDatabasePrivate.h */,
+				D80C9C411AB208FB00AF7F29 /* YapDatabaseStatement.h */,
+				D80C9C421AB208FB00AF7F29 /* YapDatabaseStatement.m */,
+				D80C9C431AB208FB00AF7F29 /* YapDatabaseString.h */,
+				D80C9C441AB208FB00AF7F29 /* YapMemoryTable.h */,
+				D80C9C451AB208FB00AF7F29 /* YapMemoryTable.m */,
+				D80C9C461AB208FB00AF7F29 /* YapNull.h */,
+				D80C9C471AB208FB00AF7F29 /* YapNull.m */,
+				D80C9C481AB208FB00AF7F29 /* YapRowidSet.h */,
+				D80C9C491AB208FB00AF7F29 /* YapRowidSet.mm */,
+				D80C9C4A1AB208FB00AF7F29 /* YapTouch.h */,
+				D80C9C4B1AB208FB00AF7F29 /* YapTouch.m */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -618,12 +633,16 @@
 		DC882C161926C4C3004C3166 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				DC882C171926C4C3004C3166 /* YapCollectionKey.h */,
-				DC882C181926C4C3004C3166 /* YapCollectionKey.m */,
-				DC882C191926C4C3004C3166 /* YapDatabaseQuery.h */,
-				DC882C1A1926C4C3004C3166 /* YapDatabaseQuery.m */,
-				DC882C1B1926C4C3004C3166 /* YapSet.h */,
-				DC882C1C1926C4C3004C3166 /* YapSet.m */,
+				D80C9C561AB2090A00AF7F29 /* YapCache.h */,
+				D80C9C571AB2090A00AF7F29 /* YapCache.m */,
+				D80C9C581AB2090A00AF7F29 /* YapCollectionKey.h */,
+				D80C9C591AB2090A00AF7F29 /* YapCollectionKey.m */,
+				D80C9C5A1AB2090A00AF7F29 /* YapDatabaseQuery.h */,
+				D80C9C5B1AB2090A00AF7F29 /* YapDatabaseQuery.m */,
+				D80C9C5C1AB2090A00AF7F29 /* YapSet.h */,
+				D80C9C5D1AB2090A00AF7F29 /* YapSet.m */,
+				D80C9C5E1AB2090A00AF7F29 /* YapWhitelistBlacklist.h */,
+				D80C9C5F1AB2090A00AF7F29 /* YapWhitelistBlacklist.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -705,71 +724,76 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DC882C4F1926C4C3004C3166 /* YapRowidSet.mm in Sources */,
+				D80C9CC31AB209D000AF7F29 /* YapDatabaseViewTypes.m in Sources */,
+				D80C9C6D1AB2091A00AF7F29 /* YapDatabase.m in Sources */,
+				D80C9C6E1AB2091A00AF7F29 /* YapDatabaseConnection.m in Sources */,
 				DC882C351926C4C3004C3166 /* YapDatabaseSearchResultsView.m in Sources */,
-				DC882C4E1926C4C3004C3166 /* YapNull.m in Sources */,
-				DC882C2A1926C4C3004C3166 /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */,
-				DC882C491926C4C3004C3166 /* YapDatabaseConnectionState.m in Sources */,
+				D80C9CAB1AB209B000AF7F29 /* YapDatabaseViewState.m in Sources */,
+				D80C9C881AB2094F00AF7F29 /* YapDatabaseFullTextSearch.m in Sources */,
+				D80C9C621AB2090A00AF7F29 /* YapDatabaseQuery.m in Sources */,
 				DCA2AE221962124800B5E7CA /* DDDispatchQueueLogFormatter.m in Sources */,
+				D80C9C9D1AB2099700AF7F29 /* YapDatabaseSecondaryIndexSetup.m in Sources */,
+				D80C9CA91AB209B000AF7F29 /* YapDatabaseViewPage.mm in Sources */,
 				DC882B931926C469004C3166 /* DDLog.m in Sources */,
 				DC882C331926C4C3004C3166 /* YapDatabaseRelationshipTransaction.m in Sources */,
-				DC882C4A1926C4C3004C3166 /* YapDatabaseLogging.m in Sources */,
-				DC882C581926C4C3004C3166 /* YapDatabaseTransaction.m in Sources */,
 				DC882B941926C469004C3166 /* DDTTYLogger.m in Sources */,
-				DC882C481926C4C3004C3166 /* YapDatabaseConnectionDefaults.m in Sources */,
-				DC882C3D1926C4C3004C3166 /* YapDatabaseViewPage.mm in Sources */,
-				DC882C421926C4C3004C3166 /* YapDatabaseView.m in Sources */,
-				DC882C501926C4C3004C3166 /* YapTouch.m in Sources */,
+				D80C9C9A1AB2099700AF7F29 /* YapDatabaseSecondaryIndexConnection.m in Sources */,
+				D80C9C9E1AB2099700AF7F29 /* YapDatabaseSecondaryIndexTransaction.m in Sources */,
+				D80C9C7B1AB2092D00AF7F29 /* YapDatabaseFilteredViewTransaction.m in Sources */,
+				D80C9C701AB2091A00AF7F29 /* YapDatabaseTransaction.m in Sources */,
+				D80C9CAA1AB209B000AF7F29 /* YapDatabaseViewPageMetadata.m in Sources */,
 				DC882C361926C4C3004C3166 /* YapDatabaseSearchResultsViewConnection.m in Sources */,
-				DC882C541926C4C3004C3166 /* YapSet.m in Sources */,
 				DC882C2D1926C4C3004C3166 /* YapDatabaseExtensionConnection.m in Sources */,
+				D80C9C641AB2090A00AF7F29 /* YapWhitelistBlacklist.m in Sources */,
+				D80C9C8C1AB2094F00AF7F29 /* YapDatabaseFullTextSearchTransaction.m in Sources */,
 				DC882B5F1926C445004C3166 /* ViewController.m in Sources */,
-				DC882C461926C4C3004C3166 /* NSDictionary+YapDatabase.m in Sources */,
+				D80C9C4F1AB208FB00AF7F29 /* YapDatabaseLogging.m in Sources */,
+				D80C9C611AB2090A00AF7F29 /* YapCollectionKey.m in Sources */,
 				DC882C301926C4C3004C3166 /* YapDatabaseRelationshipConnection.m in Sources */,
-				DC882C431926C4C3004C3166 /* YapDatabaseViewConnection.m in Sources */,
-				DC882C291926C4C3004C3166 /* YapDatabaseFullTextSearchConnection.m in Sources */,
-				DC882C551926C4C3004C3166 /* YapDatabase.m in Sources */,
+				D80C9C991AB2099700AF7F29 /* YapDatabaseSecondaryIndex.m in Sources */,
+				D80C9C501AB208FB00AF7F29 /* YapDatabaseManager.m in Sources */,
+				D80C9C551AB208FB00AF7F29 /* YapTouch.m in Sources */,
+				D80C9C891AB2094F00AF7F29 /* YapDatabaseFullTextSearchConnection.m in Sources */,
+				D80C9C8A1AB2094F00AF7F29 /* YapDatabaseFullTextSearchHandler.m in Sources */,
 				DCA2AE231962124800B5E7CA /* DDMultiFormatter.m in Sources */,
-				DC882C4D1926C4C3004C3166 /* YapMemoryTable.m in Sources */,
 				DC882B921926C469004C3166 /* DDFileLogger.m in Sources */,
+				D80C9C541AB208FB00AF7F29 /* YapRowidSet.mm in Sources */,
 				DCA2AE211962124800B5E7CA /* DDContextFilterLogFormatter.m in Sources */,
+				D80C9CC21AB209D000AF7F29 /* YapDatabaseViewTransaction.m in Sources */,
 				DC882B591926C445004C3166 /* AppDelegate.m in Sources */,
-				DC882C441926C4C3004C3166 /* YapDatabaseViewOptions.m in Sources */,
+				D80C9C601AB2090A00AF7F29 /* YapCache.m in Sources */,
 				DC882C2F1926C4C3004C3166 /* YapDatabaseRelationship.m in Sources */,
+				D80C9C7C1AB2092D00AF7F29 /* YapDatabaseFilteredViewTypes.m in Sources */,
 				DC882C371926C4C3004C3166 /* YapDatabaseSearchResultsViewOptions.m in Sources */,
-				DC882C3E1926C4C3004C3166 /* YapDatabaseViewPageMetadata.m in Sources */,
-				DC882C471926C4C3004C3166 /* YapCache.m in Sources */,
-				DC882C451926C4C3004C3166 /* YapDatabaseViewTransaction.m in Sources */,
-				DC882C3A1926C4C3004C3166 /* YapDatabaseSecondaryIndexConnection.m in Sources */,
-				DC882C3C1926C4C3004C3166 /* YapDatabaseSecondaryIndexTransaction.m in Sources */,
-				DC882C401926C4C3004C3166 /* YapDatabaseViewMappings.m in Sources */,
+				D80C9C9C1AB2099700AF7F29 /* YapDatabaseSecondaryIndexOptions.m in Sources */,
 				DC882B901926C469004C3166 /* DDAbstractDatabaseLogger.m in Sources */,
 				DC882C2E1926C4C3004C3166 /* YapDatabaseExtensionTransaction.m in Sources */,
-				DCA2AE261962127200B5E7CA /* YapDatabaseSecondaryIndexOptions.m in Sources */,
-				DC882C561926C4C3004C3166 /* YapDatabaseConnection.m in Sources */,
-				DC882C251926C4C3004C3166 /* YapDatabaseFilteredView.m in Sources */,
+				D80C9CB21AB209BD00AF7F29 /* YapDatabaseViewChange.m in Sources */,
+				D80C9C4D1AB208FB00AF7F29 /* YapDatabaseConnectionDefaults.m in Sources */,
+				D80C9CBF1AB209D000AF7F29 /* YapDatabaseView.m in Sources */,
+				D80C9C511AB208FB00AF7F29 /* YapDatabaseStatement.m in Sources */,
+				D80C9CB41AB209BD00AF7F29 /* YapDatabaseViewRangeOptions.m in Sources */,
+				D80C9C8B1AB2094F00AF7F29 /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */,
 				DC882C601926D63A004C3166 /* Person.m in Sources */,
-				DC882C3F1926C4C3004C3166 /* YapDatabaseViewChange.m in Sources */,
-				DC882C521926C4C3004C3166 /* YapCollectionKey.m in Sources */,
-				DC882C3B1926C4C3004C3166 /* YapDatabaseSecondaryIndexSetup.m in Sources */,
-				DC882C571926C4C3004C3166 /* YapDatabaseOptions.m in Sources */,
 				DC882B551926C445004C3166 /* main.m in Sources */,
+				D80C9CC01AB209D000AF7F29 /* YapDatabaseViewConnection.m in Sources */,
 				DC882B911926C469004C3166 /* DDASLLogger.m in Sources */,
+				D80C9CB31AB209BD00AF7F29 /* YapDatabaseViewMappings.m in Sources */,
+				D80C9C6F1AB2091A00AF7F29 /* YapDatabaseOptions.m in Sources */,
 				DC882C321926C4C3004C3166 /* YapDatabaseRelationshipOptions.m in Sources */,
-				DC882C531926C4C3004C3166 /* YapDatabaseQuery.m in Sources */,
-				DC882C4C1926C4C3004C3166 /* YapDatabaseStatement.m in Sources */,
+				D80C9C4E1AB208FB00AF7F29 /* YapDatabaseConnectionState.m in Sources */,
 				DC882C341926C4C3004C3166 /* YapDatabaseSearchQueue.m in Sources */,
 				DC882C311926C4C3004C3166 /* YapDatabaseRelationshipEdge.m in Sources */,
+				D80C9C521AB208FB00AF7F29 /* YapMemoryTable.m in Sources */,
 				DC882C2C1926C4C3004C3166 /* YapDatabaseExtension.m in Sources */,
-				DC882C281926C4C3004C3166 /* YapDatabaseFullTextSearch.m in Sources */,
-				DCA2AE291962129600B5E7CA /* YapDatabaseViewState.m in Sources */,
 				DC882C381926C4C3004C3166 /* YapDatabaseSearchResultsViewTransaction.m in Sources */,
-				DC882C411926C4C3004C3166 /* YapDatabaseViewRangeOptions.m in Sources */,
-				DC882C4B1926C4C3004C3166 /* YapDatabaseManager.m in Sources */,
-				DC882C261926C4C3004C3166 /* YapDatabaseFilteredViewConnection.m in Sources */,
-				DC882C391926C4C3004C3166 /* YapDatabaseSecondaryIndex.m in Sources */,
-				DC882C271926C4C3004C3166 /* YapDatabaseFilteredViewTransaction.m in Sources */,
-				DC882C2B1926C4C3004C3166 /* YapDatabaseFullTextSearchTransaction.m in Sources */,
+				D80C9C531AB208FB00AF7F29 /* YapNull.m in Sources */,
+				D80C9C631AB2090A00AF7F29 /* YapSet.m in Sources */,
+				D80C9C9B1AB2099700AF7F29 /* YapDatabaseSecondaryIndexHandler.m in Sources */,
+				D80C9C7A1AB2092D00AF7F29 /* YapDatabaseFilteredViewConnection.m in Sources */,
+				D80C9CC11AB209D000AF7F29 /* YapDatabaseViewOptions.m in Sources */,
+				D80C9C791AB2092D00AF7F29 /* YapDatabaseFilteredView.m in Sources */,
+				D80C9C4C1AB208FB00AF7F29 /* NSDictionary+YapDatabase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
It appears that several YapDB files shifted after the SearchResultsExample project was created and those changes weren't reflected in the project file which of course causes it to blow up. A framework target might not be entirely out of the question, no?