### PR TITLE
Remove redundant options property declaration

### DIFF
--- a/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredView.h
+++ b/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredView.h
@@ -73,9 +73,4 @@ __attribute((deprecated("Use method initWithParentViewName:filtering:versionTag:
 @property (nonatomic, strong, readonly) YapDatabaseViewFilteringBlock filteringBlock;
 @property (nonatomic, assign, readonly) YapDatabaseViewBlockType filteringBlockType;
 
-/**
- * The options allow you to specify things like creating an IN-MEMORY-ONLY VIEW (non persistent).
-**/
-@property (nonatomic, copy, readonly) YapDatabaseViewOptions *options;
-
 @end


### PR DESCRIPTION
The superclass declares the `options` property [YapDatabaseView.h#L137](https://github.com/yapstudios/YapDatabase/blob/master/YapDatabase/Extensions/Views/YapDatabaseView.h#L137):
```objective-c
/**
 * The options allow you to specify things like creating an in-memory-only view (non persistent).
**/
@property (nonatomic, copy, readonly) YapDatabaseViewOptions *options;
```

as does the subclass [YapDatabaseFilteredView.h#L79](https://github.com/yapstudios/YapDatabase/blob/master/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredView.h#L79):
```objective-c
/**
 * The options allow you to specify things like creating an IN-MEMORY-ONLY VIEW (non persistent).
**/
@property (nonatomic, copy, readonly) YapDatabaseViewOptions *options;
```