### PR TITLE
Clear out the WAL when the database is configured on startup.

### DIFF
--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "YapDatabase"
-  s.version      = "2.5.2"
+  s.version      = "2.5.3"
   s.summary      = "A key/value store built atop sqlite for iOS & Mac."
   s.homepage     = "https://github.com/yaptv/YapDatabase"
   s.license      = 'MIT'

--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "YapDatabase"
-  s.version      = "2.5.3"
+  s.version      = "2.5.2"
   s.summary      = "A key/value store built atop sqlite for iOS & Mac."
   s.homepage     = "https://github.com/yaptv/YapDatabase"
   s.license      = 'MIT'

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -586,6 +586,17 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 		YDBLogError(@"Error setting PRAGMA journal_size_limit: %d %s", status, sqlite3_errmsg(db));
 		// This isn't critical, so we can continue.
 	}
+
+    // Clear out the WAL on startup
+    //
+    // This should be handled by manual checkpointing but better to be safe than sorry.
+    // WALs that grow across app launches have been found in the field.
+    status = sqlite3_wal_checkpoint_v2(db, "main", SQLITE_CHECKPOINT_FULL, NULL, NULL);
+    if (status != SQLITE_OK)
+    {
+        YDBLogError(@"Error running full checkpoint: %d %s", status, sqlite3_errmsg(db));
+        // This isn't critical, so we can continue.
+    }
 	
 	// Disable autocheckpointing.
 	//


### PR DESCRIPTION
This handles the mysterious case of a WAL that grows across app launches.