### PR TITLE
Fix XCode Warnings

### DIFF
--- a/Testing/Benchmarking/BenchmarkYapDatabase.m
+++ b/Testing/Benchmarking/BenchmarkYapDatabase.m
@@ -81,7 +81,7 @@ static NSMutableArray *keys;
 	
 	[connection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
 		
-		[transaction enumerateKeysInAllCollectionsUsingBlock:^(NSString *collection, NSString *key, BOOL *stop) {
+		[transaction enumerateKeysInAllCollectionsUsingBlock:^(NSString __unused *collection, NSString __unused *key, BOOL __unused *stop) {
 			
 			// Nothing to do, just testing overhead
 		}];
@@ -95,7 +95,7 @@ static NSMutableArray *keys;
 	[connection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
 		
 		[transaction enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-		    ^(NSString *collection, NSString *key, id object, BOOL *stop) {
+		    ^(NSString __unused *collection, NSString __unused *key, id __unused object, BOOL __unused *stop) {
 			
 			// Nothing to do, just testing overhead
 		}];
@@ -185,7 +185,7 @@ static NSMutableArray *keys;
 	
 	for (NSUInteger i = 0; i < loopCount; i++)
 	{
-		[connection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+		[connection readWithBlock:^(YapDatabaseReadTransaction __unused *transaction) {
 			
 			// Nothing to do, just testing overhead
 		}];
@@ -208,7 +208,7 @@ static NSMutableArray *keys;
 	
 	for (NSUInteger i = 0; i < loopCount; i++)
 	{
-		[connection readWriteWithBlock:^(YapDatabaseReadTransaction *transaction) {
+		[connection readWriteWithBlock:^(YapDatabaseReadTransaction __unused *transaction) {
 			
 			// Nothing to do, just testing overhead
 		}];
@@ -280,11 +280,11 @@ static NSMutableArray *keys;
 		
 		NSLog(@"FETCH DATABASE");
 		
-		[self fetchValuesInLoop:500 withCacheHitPercentage:0.05];
-		[self fetchValuesInLoop:500 withCacheHitPercentage:0.25];
-		[self fetchValuesInLoop:500 withCacheHitPercentage:0.50];
-		[self fetchValuesInLoop:500 withCacheHitPercentage:0.75];
-		[self fetchValuesInLoop:500 withCacheHitPercentage:0.95];
+		[self fetchValuesInLoop:500 withCacheHitPercentage:0.05f];
+		[self fetchValuesInLoop:500 withCacheHitPercentage:0.25f];
+		[self fetchValuesInLoop:500 withCacheHitPercentage:0.50f];
+		[self fetchValuesInLoop:500 withCacheHitPercentage:0.75f];
+		[self fetchValuesInLoop:500 withCacheHitPercentage:0.95f];
 		
 		NSLog(@"====================================================");
 	});

--- a/Testing/Xcode-mobile/YapDatabase/AppDelegate.m
+++ b/Testing/Xcode-mobile/YapDatabase/AppDelegate.m
@@ -102,7 +102,7 @@ static const NSUInteger STR_LENGTH = 2000;
 	
 		[connection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
 			
-			for (int i = 0; i < COUNT; i++)
+			for (unsigned int i = 0; i < COUNT; i++)
 			{
 				NSString *key = [NSString stringWithFormat:@"%d", i];
 				
@@ -119,7 +119,7 @@ static const NSUInteger STR_LENGTH = 2000;
 		
 		[connection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
 			
-			for (int i = 1; i < COUNT; i += 2)
+			for (unsigned int i = 1; i < COUNT; i += 2)
 			{
 				NSString *key = [NSString stringWithFormat:@"%d", i];
 				
@@ -136,7 +136,7 @@ static const NSUInteger STR_LENGTH = 2000;
 		
 		[connection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
 			
-			for (int i = 0; i < COUNT; i += 2)
+			for (unsigned int i = 0; i < COUNT; i += 2)
 			{
 				NSString *key = [NSString stringWithFormat:@"%d", i];
 				
@@ -153,7 +153,7 @@ static const NSUInteger STR_LENGTH = 2000;
 		
 		[connection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
 			
-			for (int i = 1; i < COUNT; i+=2)
+			for (unsigned int i = 1; i < COUNT; i+=2)
 			{
 				NSString *key = [NSString stringWithFormat:@"%d", i];
 				
@@ -170,7 +170,7 @@ static const NSUInteger STR_LENGTH = 2000;
 		
 		[connection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
 			
-			for (int i = 0; i < COUNT; i+=2)
+			for (unsigned int i = 0; i < COUNT; i+=2)
 			{
 				NSString *key = [NSString stringWithFormat:@"%d", i];
 				
@@ -237,7 +237,7 @@ static const NSUInteger STR_LENGTH = 2000;
 			
 			NSLog(@"Fetching items...");
 			
-			for (int i = 0; i < COUNT; i++)
+			for (unsigned int i = 0; i < COUNT; i++)
 			{
 				NSString *key = [NSString stringWithFormat:@"%d", i];
 				
@@ -249,7 +249,7 @@ static const NSUInteger STR_LENGTH = 2000;
 			
 			NSLog(@"Fetching more items...");
 			
-			for (int i = 0; i < COUNT; i++)
+			for (unsigned int i = 0; i < COUNT; i++)
 			{
 				NSString *key = [NSString stringWithFormat:@"%d", i];
 				

--- a/Testing/Xcode-mobile/YapDatabase/AppDelegate.m
+++ b/Testing/Xcode-mobile/YapDatabase/AppDelegate.m
@@ -15,7 +15,7 @@
 	YapDatabaseConnection *databaseConnection;
 }
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+- (BOOL)application:(UIApplication __unused *)application didFinishLaunchingWithOptions:(NSDictionary __unused *)launchOptions
 {
 	[DDLog addLogger:[DDTTYLogger sharedInstance]];
 	
@@ -319,14 +319,14 @@ static const NSUInteger STR_LENGTH = 2000;
 	NSLog(@"Registering mainView....");
 
 	YapDatabaseViewGrouping *grouping = [YapDatabaseViewGrouping withObjectBlock:
-	    ^NSString *(NSString *collection, NSString *key, id object){
+	    ^NSString *(NSString __unused *collection, NSString __unused *key, id __unused object){
 		
 		return @"";
 	}];
 	
 	YapDatabaseViewSorting *sorting = [YapDatabaseViewSorting withObjectBlock:
-	    ^(NSString *group, NSString *collection1, NSString *key1, id obj1,
-	                       NSString *collection2, NSString *key2, id obj2){
+	    ^(NSString __unused *group, NSString __unused *collection1, NSString __unused *key1, id obj1,
+	                       NSString __unused *collection2, NSString __unused *key2, id obj2){
 		
 		return [obj1 compare:obj2];
 	}];
@@ -346,14 +346,14 @@ static const NSUInteger STR_LENGTH = 2000;
 	NSLog(@"Registering onTheFlyView....");
 
 	YapDatabaseViewGrouping *grouping = [YapDatabaseViewGrouping withObjectBlock:
-	    ^NSString *(NSString *collection, NSString *key, id object){
+	    ^NSString *(NSString __unused *collection, NSString __unused *key, id __unused object){
 		
 		return @"";
 	}];
 
 	YapDatabaseViewSorting *sorting = [YapDatabaseViewSorting withObjectBlock:
-	    ^(NSString *group, NSString *collection, NSString *key1, id obj1,
-	                       NSString *collection2, NSString *key2, id obj2){
+	    ^(NSString __unused *group, NSString __unused *collection, NSString __unused *key1, id obj1,
+	                       NSString __unused *collection2, NSString __unused *key2, id obj2){
 		
 		return [obj1 compare:obj2];
 	}];

--- a/Vendor/CocoaLumberjack/DDASLLogCapture.m
+++ b/Vendor/CocoaLumberjack/DDASLLogCapture.m
@@ -136,7 +136,7 @@ static int _captureLogLevel = LOG_LEVEL_VERBOSE;
          for the messages.
          */
         int notifyToken = 0;  // Can be used to unregister with notify_cancel().
-        notify_register_dispatch(kNotifyASLDBUpdate, &notifyToken, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(int token)
+        notify_register_dispatch(kNotifyASLDBUpdate, &notifyToken, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(int __unused token)
                                  {
                                      // At least one message has been posted; build a search query.
                                      @autoreleasepool

--- a/Vendor/CocoaLumberjack/DDAbstractDatabaseLogger.m
+++ b/Vendor/CocoaLumberjack/DDAbstractDatabaseLogger.m
@@ -47,7 +47,7 @@
 #pragma mark Override Me
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (BOOL)db_log:(DDLogMessage *)logMessage
+- (BOOL)db_log:(DDLogMessage __unused *)logMessage
 {
     // Override me and add your implementation.
     // 

--- a/Vendor/CocoaLumberjack/DDFileLogger.m
+++ b/Vendor/CocoaLumberjack/DDFileLogger.m
@@ -117,9 +117,9 @@ BOOL doesAppRunInBackground(void);
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
+                      ofObject:(id __unused)object
                         change:(NSDictionary *)change
-                       context:(void *)context
+                       context:(void __unused *)context
 {
     NSNumber *old = [change objectForKey:NSKeyValueChangeOldKey];
     NSNumber *new = [change objectForKey:NSKeyValueChangeNewKey];

--- a/Vendor/CocoaLumberjack/DDLog.m
+++ b/Vendor/CocoaLumberjack/DDLog.m
@@ -193,7 +193,7 @@ static unsigned int numProcessors;
 #pragma mark Notifications
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-+ (void)applicationWillTerminate:(NSNotification *)notification
++ (void)applicationWillTerminate:(NSNotification __unused *)notification
 {
     [self flushLog];
 }
@@ -1071,7 +1071,7 @@ static char *dd_str_copy(const char *str)
 }
 
 
-- (id)copyWithZone:(NSZone *)zone {
+- (id)copyWithZone:(NSZone __unused *)zone {
     DDLogMessage *newMessage = [[DDLogMessage alloc] init];
     
     newMessage->logLevel = self->logLevel;
@@ -1148,7 +1148,7 @@ static char *dd_str_copy(const char *str)
     #endif
 }
 
-- (void)logMessage:(DDLogMessage *)logMessage
+- (void)logMessage:(DDLogMessage __unused *)logMessage
 {
     // Override me
 }

--- a/Vendor/CocoaLumberjack/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Vendor/CocoaLumberjack/Extensions/DDDispatchQueueLogFormatter.m
@@ -240,12 +240,12 @@
     return [NSString stringWithFormat:@"%@ [%@] %@", timestamp, queueThreadLabel, logMessage->logMsg];
 }
 
-- (void)didAddToLogger:(id <DDLogger>)logger
+- (void)didAddToLogger:(id <DDLogger> __unused)logger
 {
     OSAtomicIncrement32(&atomicLoggerCount);
 }
 
-- (void)willRemoveFromLogger:(id <DDLogger>)logger
+- (void)willRemoveFromLogger:(id <DDLogger> __unused)logger
 {
     OSAtomicDecrement32(&atomicLoggerCount);
 }

--- a/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredView.m
+++ b/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredView.m
@@ -28,10 +28,10 @@
 
 #pragma mark Invalid
 
-- (instancetype)initWithGrouping:(YapDatabaseViewGrouping *)grouping
-                         sorting:(YapDatabaseViewSorting *)sorting
-                      versionTag:(NSString *)inVersionTag
-                         options:(YapDatabaseViewOptions *)inOptions
+- (instancetype)initWithGrouping:(YapDatabaseViewGrouping __unused *)grouping
+                         sorting:(YapDatabaseViewSorting __unused *)sorting
+                      versionTag:(NSString __unused *)inVersionTag
+                         options:(YapDatabaseViewOptions __unused *)inOptions
 {
 	NSString *reason = @"You must use the init method(s) specific to YapDatabaseFilteredView.";
 	

--- a/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredView.m
+++ b/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredView.m
@@ -26,6 +26,8 @@
 @synthesize filteringBlock = filteringBlock;
 @synthesize filteringBlockType = filteringBlockType;
 
+@dynamic options;
+
 #pragma mark Invalid
 
 - (instancetype)initWithGrouping:(YapDatabaseViewGrouping __unused *)grouping

--- a/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredViewTransaction.m
+++ b/YapDatabase/Extensions/FilteredViews/YapDatabaseFilteredViewTransaction.m
@@ -231,7 +231,7 @@
 		__unsafe_unretained YapDatabaseViewFilteringWithKeyBlock filterBlock =
 		  (YapDatabaseViewFilteringWithKeyBlock)filteringBlock_generic;
 		
-		InvokeFilterBlock = ^(NSString *group, int64_t rowid, YapCollectionKey *ck){
+		InvokeFilterBlock = ^(NSString *group, int64_t __unused rowid, YapCollectionKey *ck){
 			
 			return filterBlock(group, ck.collection, ck.key);
 		};
@@ -282,7 +282,7 @@
 		__block NSUInteger filteredIndex = 0;
 		
 		[parentViewTransaction enumerateRowidsInGroup:group
-		                                   usingBlock:^(int64_t rowid, NSUInteger parentIndex, BOOL *stop)
+		                                   usingBlock:^(int64_t rowid, NSUInteger __unused parentIndex, BOOL __unused *stop)
 		{
 			YapCollectionKey *ck = [databaseTransaction collectionKeyForRowid:rowid];
 			
@@ -366,7 +366,7 @@
 	//
 	// The changeset mechanism will automatically consolidate all changes to the minimum.
 	
-	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL *outerStop) {
+	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL __unused *outerStop) {
 		
 		// We must add the changes in reverse order.
 		// Either that, or the change index of each item would have to be zero,
@@ -374,7 +374,7 @@
 		
 		[self enumerateRowidsInGroup:group
 		                 withOptions:NSEnumerationReverse
-		                  usingBlock:^(int64_t rowid, NSUInteger index, BOOL *innerStop)
+		                  usingBlock:^(int64_t rowid, NSUInteger index, BOOL __unused *innerStop)
 		{
 			YapCollectionKey *collectionKey = [databaseTransaction collectionKeyForRowid:rowid];
 			 
@@ -433,7 +433,7 @@
 		__unsafe_unretained YapDatabaseViewFilteringWithKeyBlock filterBlock =
 		  (YapDatabaseViewFilteringWithKeyBlock)filteringBlock_generic;
 		
-		InvokeFilterBlock = ^(NSString *group, int64_t rowid, YapCollectionKey *ck){
+		InvokeFilterBlock = ^(NSString *group, int64_t __unused rowid, YapCollectionKey *ck){
 			
 			return filterBlock(group, ck.collection, ck.key);
 		};
@@ -493,7 +493,7 @@
 		__block NSUInteger index = 0;
 		
 		[parentViewTransaction enumerateRowidsInGroup:group
-		                                   usingBlock:^(int64_t rowid, NSUInteger parentIndex, BOOL *stop)
+		                                   usingBlock:^(int64_t rowid, NSUInteger __unused parentIndex, BOOL __unused *stop)
 		{
 			if (existing && ((existingRowid == rowid)))
 			{
@@ -642,7 +642,7 @@
 		__unsafe_unretained YapDatabaseViewFilteringWithKeyBlock filterBlock =
 		  (YapDatabaseViewFilteringWithKeyBlock)filteringBlock_generic;
 		
-		InvokeFilterBlock = ^(NSString *group, int64_t rowid, YapCollectionKey *ck){
+		InvokeFilterBlock = ^(NSString *group, int64_t __unused rowid, YapCollectionKey *ck){
 			
 			return filterBlock(group, ck.collection, ck.key);
 		};
@@ -698,7 +698,7 @@
 		__block NSUInteger index = 0;
 		
 		[parentViewTransaction enumerateRowidsInGroup:group
-		                                   usingBlock:^(int64_t rowid, NSUInteger parentIndex, BOOL *stop)
+		                                   usingBlock:^(int64_t rowid, NSUInteger __unused parentIndex, BOOL __unused *stop)
 		{
 			YapCollectionKey *ck = [databaseTransaction collectionKeyForRowid:rowid];
 			
@@ -1337,7 +1337,7 @@
 	__unsafe_unretained NSString *registeredName = [self registeredName];
 	__unsafe_unretained NSDictionary *extensionDependencies = databaseTransaction->connection->extensionDependencies;
 	
-	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop){
 		
 		__unsafe_unretained NSString *extName = (NSString *)key;
 		__unsafe_unretained NSSet *extDependencies = (NSSet *)obj;
@@ -1362,9 +1362,9 @@
 
 @implementation YapDatabaseFilteredViewTransaction (ReadWrite)
 
-- (void)setGrouping:(YapDatabaseViewGrouping *)grouping
-            sorting:(YapDatabaseViewSorting *)sorting
-         versionTag:(NSString *)versionTag
+- (void)setGrouping:(YapDatabaseViewGrouping __unused *)grouping
+            sorting:(YapDatabaseViewSorting __unused *)sorting
+         versionTag:(NSString __unused *)versionTag
 {
 	NSString *reason = @"This method is not available for YapDatabaseFilteredView.";
 	
@@ -1415,7 +1415,7 @@
 	NSString *registeredName = [self registeredName];
 	NSDictionary *extensionDependencies = databaseTransaction->connection->extensionDependencies;
 	
-	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop){
 		
 		__unsafe_unretained NSString *extName = (NSString *)key;
 		__unsafe_unretained NSSet *extDependencies = (NSSet *)obj;

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.m
@@ -24,7 +24,7 @@ static const int ydbLogLevel = YDB_LOG_LEVEL_WARN;
 
 + (void)dropTablesForRegisteredName:(NSString *)registeredName
                     withTransaction:(YapDatabaseReadWriteTransaction *)transaction
-                      wasPersistent:(BOOL)wasPersistent
+                      wasPersistent:(BOOL __unused)wasPersistent
 {
 	sqlite3 *db = transaction->connection->db;
 	

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchConnection.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchConnection.m
@@ -126,9 +126,9 @@
 /**
  * Required override method from YapDatabaseExtensionConnection
 **/
-- (void)getInternalChangeset:(NSMutableDictionary **)internalChangesetPtr
-           externalChangeset:(NSMutableDictionary **)externalChangesetPtr
-              hasDiskChanges:(BOOL *)hasDiskChangesPtr
+- (void)getInternalChangeset:(NSMutableDictionary __unused **)internalChangesetPtr
+           externalChangeset:(NSMutableDictionary __unused **)externalChangesetPtr
+              hasDiskChanges:(BOOL __unused *)hasDiskChangesPtr
 {
 	// Nothing to do for this particular extension.
 	//
@@ -139,7 +139,7 @@
 /**
  * Required override method from YapDatabaseExtensionConnection
 **/
-- (void)processChangeset:(NSDictionary *)changeset
+- (void)processChangeset:(NSDictionary __unused *)changeset
 {
 	// Nothing to do for this particular extension.
 	//

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchSnippetOptions.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchSnippetOptions.m
@@ -47,7 +47,7 @@
 	return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseFullTextSearchSnippetOptions *copy = [[YapDatabaseFullTextSearchSnippetOptions alloc] initForCopy];
 	

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
@@ -184,7 +184,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 	}
 	
 	NSDictionary *options = ftsConnection->fts->options;
-	[options enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+	[options enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 		
 		NSString *option = (NSString *)key;
 		NSString *value = (NSString *)obj;
@@ -238,7 +238,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		    (YapDatabaseFullTextSearchWithRowBlock)fts->block;
 		
 		[databaseTransaction _enumerateRowsInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop) {
+		    ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL __unused *stop) {
 			
 			block(ftsConnection->blockDict, collection, key, object, metadata);
 			
@@ -255,7 +255,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		    (YapDatabaseFullTextSearchWithObjectBlock)fts->block;
 		
 		[databaseTransaction _enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop) {
+		    ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL __unused *stop) {
 			
 			block(ftsConnection->blockDict, collection, key, object);
 			
@@ -272,7 +272,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		    (YapDatabaseFullTextSearchWithMetadataBlock)fts->block;
 		
 		[databaseTransaction _enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop) {
+		    ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL __unused *stop) {
 			
 			block(ftsConnection->blockDict, collection, key, metadata);
 			
@@ -289,7 +289,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		    (YapDatabaseFullTextSearchWithKeyBlock)fts->block;
 		
 		[databaseTransaction _enumerateKeysInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, BOOL *stop) {
+		    ^(int64_t rowid, NSString *collection, NSString *key, BOOL __unused *stop) {
 			
 			block(ftsConnection->blockDict, collection, key);
 			
@@ -793,7 +793,7 @@ static NSString *const ext_key__version_deprecated = @"version";
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleTouchObjectForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchObjectForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	// Nothing to do for this extension
 }
@@ -802,7 +802,7 @@ static NSString *const ext_key__version_deprecated = @"version";
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	// Nothing to do for this extension
 }
@@ -811,7 +811,7 @@ static NSString *const ext_key__version_deprecated = @"version";
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleRemoveObjectForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleRemoveObjectForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t)rowid
 {
 	YDBLogAutoTrace();
 	
@@ -822,7 +822,7 @@ static NSString *const ext_key__version_deprecated = @"version";
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleRemoveObjectsForKeys:(NSArray *)keys inCollection:(NSString *)collection withRowids:(NSArray *)rowids
+- (void)handleRemoveObjectsForKeys:(NSArray __unused *)keys inCollection:(NSString __unused *)collection withRowids:(NSArray *)rowids
 {
 	YDBLogAutoTrace();
 	

--- a/YapDatabase/Extensions/Protocol/YapDatabaseExtension.m
+++ b/YapDatabase/Extensions/Protocol/YapDatabaseExtension.m
@@ -20,9 +20,9 @@
  *   If YES, then the extension should drop tables from sqlite.
  *   If NO, then the extension should unregister the proper YapMemoryTable(s).
 **/
-+ (void)dropTablesForRegisteredName:(NSString *)registeredName
-                    withTransaction:(YapDatabaseReadWriteTransaction *)transaction
-                      wasPersistent:(BOOL)wasPersistent
++ (void)dropTablesForRegisteredName:(NSString __unused *)registeredName
+                    withTransaction:(YapDatabaseReadWriteTransaction __unused *)transaction
+                      wasPersistent:(BOOL __unused)wasPersistent
 {
 	NSAssert(NO, @"Missing required method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -74,7 +74,7 @@
  * 
  * Return YES if the class/instance supports the database configuration.
 **/
-- (BOOL)supportsDatabase:(YapDatabase *)database withRegisteredExtensions:(NSDictionary *)registeredExtensions
+- (BOOL)supportsDatabase:(YapDatabase __unused *)database withRegisteredExtensions:(NSDictionary __unused *)registeredExtensions
 {
 	return YES;
 }
@@ -108,7 +108,7 @@
  * Subclasses MUST implement this method.
  * Returns a proper instance of the YapDatabaseExtensionConnection subclass.
 **/
-- (YapDatabaseExtensionConnection *)newConnection:(YapDatabaseConnection *)databaseConnection
+- (YapDatabaseExtensionConnection *)newConnection:(YapDatabaseConnection __unused *)databaseConnection
 {
 	NSAssert(NO, @"Missing required method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 	return nil;
@@ -125,7 +125,7 @@
  * This allows new view connections to be able to (sometimes) fetch the view state from their extension,
  * rather than read it from the database and piece it together manually.
 **/
-- (void)processChangeset:(NSDictionary *)changeset
+- (void)processChangeset:(NSDictionary __unused *)changeset
 {
 	// Override me if needed (for optimizations)
 }

--- a/YapDatabase/Extensions/Protocol/YapDatabaseExtensionConnection.m
+++ b/YapDatabase/Extensions/Protocol/YapDatabaseExtensionConnection.m
@@ -30,7 +30,7 @@
  * You may optionally use different subclasses for read-only vs read-write transactions.
  * Alternatively you can just store an ivar to determine the type of the transaction in order to protect as needed.
 **/
-- (id)newReadTransaction:(YapDatabaseReadTransaction *)databaseTransaction
+- (id)newReadTransaction:(YapDatabaseReadTransaction __unused *)databaseTransaction
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 	return nil;
@@ -43,7 +43,7 @@
  * You may optionally use different subclasses for read-only vs read-write transactions.
  * Alternatively you can just store an ivar to determine the type of the transaction in order to protect as needed.
 **/
-- (id)newReadWriteTransaction:(YapDatabaseReadWriteTransaction *)databaseTransaction
+- (id)newReadWriteTransaction:(YapDatabaseReadWriteTransaction __unused *)databaseTransaction
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 	return nil;
@@ -67,7 +67,7 @@
  *     sqlite_finalize_null(&myStatement);
  * }
 **/
-- (void)_flushMemoryWithFlags:(YapDatabaseConnectionFlushMemoryFlags)flags
+- (void)_flushMemoryWithFlags:(YapDatabaseConnectionFlushMemoryFlags __unused)flags
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -129,7 +129,7 @@
  * as they move from one snapshot to the next. It is the responsibility of this method to process
  * the changeset to ensure the connection's state is properly updated.
 **/
-- (void)processChangeset:(NSDictionary *)changeset
+- (void)processChangeset:(NSDictionary __unused *)changeset
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }

--- a/YapDatabase/Extensions/Protocol/YapDatabaseExtensionTransaction.m
+++ b/YapDatabase/Extensions/Protocol/YapDatabaseExtensionTransaction.m
@@ -232,10 +232,10 @@
  *
  * The row is being inserted, meaning there is not currently an entry for the collection/key tuple.
 **/
-- (void)handleInsertObject:(id)object
-          forCollectionKey:(YapCollectionKey *)collectionKey
-              withMetadata:(id)metadata
-                     rowid:(int64_t)rowid
+- (void)handleInsertObject:(id __unused)object
+          forCollectionKey:(YapCollectionKey __unused *)collectionKey
+              withMetadata:(id __unused)metadata
+                     rowid:(int64_t __unused)rowid
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -251,10 +251,10 @@
  *
  * The row is being modified, meaning there is already an entry for the collection/key tuple which is being modified.
 **/
-- (void)handleUpdateObject:(id)object
-          forCollectionKey:(YapCollectionKey *)collectionKey
-              withMetadata:(id)metadata
-                     rowid:(int64_t)rowid
+- (void)handleUpdateObject:(id __unused)object
+          forCollectionKey:(YapCollectionKey __unused *)collectionKey
+              withMetadata:(id __unused)metadata
+                     rowid:(int64_t __unused)rowid
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -269,9 +269,9 @@
  * 
  * There is already a row for the collection/key tuple, and only the object is being modified (metadata untouched).
 **/
-- (void)handleReplaceObject:(id)object
-           forCollectionKey:(YapCollectionKey *)collectionKey
-                  withRowid:(int64_t)rowid
+- (void)handleReplaceObject:(id __unused)object
+           forCollectionKey:(YapCollectionKey __unused *)collectionKey
+                  withRowid:(int64_t __unused)rowid
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -286,9 +286,9 @@
  * 
  * There is already a row for the collection/key tuple, and only the metadata is being modified (object untouched).
 **/
-- (void)handleReplaceMetadata:(id)metadata
-             forCollectionKey:(YapCollectionKey *)collectionKey
-                    withRowid:(int64_t)rowid
+- (void)handleReplaceMetadata:(id __unused)metadata
+             forCollectionKey:(YapCollectionKey __unused *)collectionKey
+                    withRowid:(int64_t __unused)rowid
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -300,7 +300,7 @@
  * Corresponds to the following method(s) in YapDatabaseReadWriteTransaction:
  * - touchObjectForKey:inCollection:collection:
 **/
-- (void)handleTouchObjectForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchObjectForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -312,7 +312,7 @@
  * Corresponds to the following method(s) in YapDatabaseReadWriteTransaction:
  * - touchMetadataForKey:inCollection:
 **/
-- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -324,7 +324,7 @@
  * Corresponds to the following method(s) in YapDatabaseReadWriteTransaction
  * - removeObjectForKey:inCollection:
 **/
-- (void)handleRemoveObjectForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleRemoveObjectForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }
@@ -344,7 +344,7 @@
  * The YapDatabaseReadWriteTransaction will inspect the list of keys that are to be removed,
  * and then loop over them in "chunks" which are readily processable for extensions.
 **/
-- (void)handleRemoveObjectsForKeys:(NSArray *)keys inCollection:(NSString *)collection withRowids:(NSArray *)rowids
+- (void)handleRemoveObjectsForKeys:(NSArray __unused *)keys inCollection:(NSString __unused *)collection withRowids:(NSArray __unused *)rowids
 {
 	NSAssert(NO, @"Missing required override method(%@) in class(%@)", NSStringFromSelector(_cmd), [self class]);
 }

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationship.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationship.m
@@ -33,7 +33,7 @@
 **/
 + (void)dropTablesForRegisteredName:(NSString *)registeredName
                     withTransaction:(YapDatabaseReadWriteTransaction *)transaction
-                      wasPersistent:(BOOL)wasPersistent
+                      wasPersistent:(BOOL __unused)wasPersistent
 {
 	sqlite3 *db = transaction->connection->db;
 	
@@ -90,13 +90,13 @@
  * This method is called during the view registration process to enusre the extension supports
  * the database configuration.
 **/
-- (BOOL)supportsDatabase:(YapDatabase *)database withRegisteredExtensions:(NSDictionary *)registeredExtensions
+- (BOOL)supportsDatabase:(YapDatabase __unused *)database withRegisteredExtensions:(NSDictionary *)registeredExtensions
 {
 	// Only 1 relationship extension is supported at a time.
 	
 	__block BOOL supported = YES;
 	
-	[registeredExtensions enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+	[registeredExtensions enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL *stop) {
 		
 		if ([obj isKindOfClass:[YapDatabaseRelationship class]])
 		{

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipConnection.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipConnection.m
@@ -220,7 +220,7 @@
 	*hasDiskChangesPtr = hasDiskChanges;
 }
 
-- (void)processChangeset:(NSDictionary *)changeset
+- (void)processChangeset:(NSDictionary __unused *)changeset
 {
 	// Nothing to do here.
 	// This method is required to be overriden by YapDatabaseExtensionConnection.

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipEdge.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipEdge.m
@@ -191,7 +191,7 @@
 	{
 		name = [inName copy];
 		destinationFilePath = [dstFilePath copy];
-		nodeDeleteRules = rules;
+		nodeDeleteRules = (unsigned short)rules;
 		isManualEdge = manual;
 		
 		edgeRowid = rowid;
@@ -219,7 +219,7 @@
 		
 		destinationFilePath = [decoder decodeObjectForKey:@"destinationFilePath"];
 		
-		nodeDeleteRules = [decoder decodeIntForKey:@"nodeDeleteRules"];
+		nodeDeleteRules = (unsigned short)[decoder decodeIntForKey:@"nodeDeleteRules"];
 		isManualEdge = [decoder decodeBoolForKey:@"isManualEdge"];
 		
 		if (destinationFilePath)

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipEdge.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipEdge.m
@@ -248,7 +248,7 @@
 
 #pragma mark NSCopying
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseRelationshipEdge *copy = [[YapDatabaseRelationshipEdge alloc] init];
 	

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipOptions.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipOptions.m
@@ -19,7 +19,7 @@
 	return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseRelationshipOptions *copy = [[YapDatabaseRelationshipOptions alloc] init];
 	copy->disableYapDatabaseRelationshipNodeProtocol = disableYapDatabaseRelationshipNodeProtocol;

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -317,12 +317,12 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	
 	if (allowedCollections)
 	{
-		[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *outerStop) {
+		[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *outerStop) {
 			
 			if ([allowedCollections isAllowed:collection])
 			{
 				[databaseTransaction _enumerateKeysAndObjectsInCollection:collection usingBlock:
-				    ^(int64_t rowid, NSString *key, id object, BOOL *innerStop)
+				    ^(int64_t rowid, NSString *key, id object, BOOL __unused *innerStop)
 				{
 					ProcessRow(rowid, collection, key, object);
 				}];
@@ -332,7 +332,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	else
 	{
 		[databaseTransaction _enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-		   	^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop)
+		   	^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL __unused *stop)
 		{
 			ProcessRow(rowid, collection, key, object);
 		}];
@@ -392,7 +392,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	
 	// Find matching protocol edges
 	
-	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id dictKey, id dictObj, BOOL *stop){
+	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id __unused dictKey, id dictObj, BOOL __unused *stop){
 		
 	//	__unsafe_unretained NSString *srcRowidNumber = (NSNumber *)dictKey;
 		__unsafe_unretained NSArray *changedEdgesForSrc = (NSArray *)dictObj;
@@ -534,7 +534,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	}
 	else
 	{
-		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop) {
 			
 		//	__unsafe_unretained NSString *edgeName = (NSString *)key;
 			__unsafe_unretained NSArray *manualChangesMatchingName = (NSArray *)obj;
@@ -600,7 +600,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	
 	// Find matching protocol edges
 	
-	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id dictKey, id dictObj, BOOL *stop){
+	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id __unused dictKey, id dictObj, BOOL __unused *stop){
 		
 	//	__unsafe_unretained NSString *srcRowidNumber = (NSNumber *)dictKey;
 		__unsafe_unretained NSArray *changedEdgesForSrc = (NSArray *)dictObj;
@@ -679,7 +679,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	}
 	else
 	{
-		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop){
 			
 		//	__unsafe_unretained NSString *edgeName = (NSString *)key;
 			__unsafe_unretained NSArray *manualChangesMatchingName = (NSArray *)obj;
@@ -740,7 +740,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	
 	// Find matching protocol edges
 	
-	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id dictKey, id dictObj, BOOL *stop){
+	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id __unused dictKey, id dictObj, BOOL __unused *stop){
 		
 	//	__unsafe_unretained NSString *srcRowidNumber = (NSNumber *)dictKey;
 		__unsafe_unretained NSArray *changedEdgesForSrc = (NSArray *)dictObj;
@@ -789,7 +789,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	}
 	else
 	{
-		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop){
 			
 		//	__unsafe_unretained NSString *edgeName = (NSString *)key;
 			__unsafe_unretained NSArray *manualChangesMatchingName = (NSArray *)obj;
@@ -953,7 +953,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	}
 	else
 	{
-		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop) {
 			
 		//	__unsafe_unretained NSString *edgeName = (NSString *)key;
 			__unsafe_unretained NSArray *manualChangesMatchingName = (NSArray *)obj;
@@ -1084,7 +1084,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	}
 	else
 	{
-		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop) {
 			
 		//	__unsafe_unretained NSString *edgeName = (NSString *)key;
 			__unsafe_unretained NSArray *manualChangesMatchingName = (NSArray *)obj;
@@ -2526,7 +2526,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	// - writing modified edges to the database (changed nodeDeleteRules)
 	// - deleting edges that were manually removed from the list
 	
-	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+	[relationshipConnection->protocolChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop){
 		
 		__unsafe_unretained NSNumber *srcRowidNumber = (NSNumber *)key;
 		__unsafe_unretained NSMutableArray *protocolEdges = (NSMutableArray *)obj;
@@ -2564,7 +2564,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	//
 	// Process all manual edges that have been set during the transaction.
 	
-	[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+	[relationshipConnection->manualChanges enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop) {
 		
 	//	__unsafe_unretained NSString *edgeName = (NSString *)key;
 		__unsafe_unretained NSMutableArray *manualEdges = (NSMutableArray *)obj;
@@ -2691,7 +2691,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		
 		// Enumerate all edges where source node is this deleted node.
 		[self enumerateExistingEdgesWithSource:rowid usingBlock:
-		^(int64_t edgeRowid, NSString *name, int64_t dstRowid, NSString *dstFilePath, int nodeDeleteRules, BOOL manual)
+		^(int64_t __unused edgeRowid, NSString *name, int64_t dstRowid, NSString *dstFilePath, int nodeDeleteRules, BOOL __unused manual)
 		{
 			if (dstFilePath)
 			{
@@ -2804,7 +2804,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		
 		// Enumerate all edges where destination node is this deleted node.
 		[self enumerateExistingEdgesWithDestination:rowid usingBlock:
-		    ^(int64_t edgeRowid, NSString *name, int64_t srcRowid, int nodeDeleteRules, BOOL manual)
+		    ^(int64_t __unused edgeRowid, NSString *name, int64_t srcRowid, int nodeDeleteRules, BOOL __unused manual)
 		{
 			if ([relationshipConnection->deletedInfo ydb_containsKey:@(srcRowid)])
 			{
@@ -3013,7 +3013,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 **/
 - (void)handleInsertObject:(id)object
           forCollectionKey:(YapCollectionKey *)collectionKey
-              withMetadata:(id)metadata
+              withMetadata:(id __unused)metadata
                      rowid:(int64_t)rowid
 {
 	YDBLogAutoTrace();
@@ -3116,7 +3116,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 **/
 - (void)handleUpdateObject:(id)object
           forCollectionKey:(YapCollectionKey *)collectionKey
-              withMetadata:(id)metadata
+              withMetadata:(id __unused)metadata
                      rowid:(int64_t)rowid
 {
 	YDBLogAutoTrace();
@@ -3230,7 +3230,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleReplaceMetadata:(id)metadata forCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleReplaceMetadata:(id __unused)metadata forCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	YDBLogAutoTrace();
 	
@@ -3241,7 +3241,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleTouchObjectForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchObjectForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	YDBLogAutoTrace();
 	
@@ -3252,7 +3252,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	YDBLogAutoTrace();
 	
@@ -4929,7 +4929,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 	if (databaseTransaction->isReadWriteTransaction)
 	{
 		__block NSUInteger count = 0;
-		[self enumerateEdgesWithName:name usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
+		[self enumerateEdgesWithName:name usingBlock:^(YapDatabaseRelationshipEdge __unused *edge, BOOL __unused *stop) {
 			
 			count++;
 		}];
@@ -5002,7 +5002,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		[self enumerateEdgesWithName:name
 		                   sourceKey:srcKey
 		                  collection:srcCollection
-		                  usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
+		                  usingBlock:^(YapDatabaseRelationshipEdge __unused *edge, BOOL __unused *stop) {
 			
 			count++;
 		}];
@@ -5108,7 +5108,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		[self enumerateEdgesWithName:name
 		              destinationKey:dstKey
 		                  collection:dstCollection
-		                  usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
+		                  usingBlock:^(YapDatabaseRelationshipEdge __unused *edge, BOOL __unused *stop) {
 			
 			count++;
 		}];
@@ -5205,7 +5205,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		__block NSUInteger count = 0;
 		[self enumerateEdgesWithName:name
 		         destinationFilePath:dstFilePath
-		                  usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
+		                  usingBlock:^(YapDatabaseRelationshipEdge __unused *edge, BOOL __unused *stop) {
 			
 			count++;
 		}];
@@ -5355,7 +5355,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		                  collection:srcCollection
 		              destinationKey:dstKey
 		                  collection:dstCollection
-		                  usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
+		                  usingBlock:^(YapDatabaseRelationshipEdge __unused *edge, BOOL __unused *stop) {
 			
 			count++;
 		}];
@@ -5494,7 +5494,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		                   sourceKey:srcKey
 		                  collection:srcCollection
 		         destinationFilePath:dstFilePath
-		                  usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
+		                  usingBlock:^(YapDatabaseRelationshipEdge __unused *edge, BOOL __unused *stop) {
 			
 			count++;
 		}];

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -1546,7 +1546,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 		
 		matchingEdge = [edge copy];
 		matchingEdge->edgeRowid = edgeRowid;
-		matchingEdge->nodeDeleteRules = rules;
+		matchingEdge->nodeDeleteRules = (unsigned short)rules;
 		
 		matchingEdge->flags |= YDB_FlagsHasEdgeRowid;
 	}
@@ -2779,7 +2779,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 							edge->destinationKey = dst.key;
 							edge->destinationCollection = dst.collection;
 							edge->destinationRowid = dstRowid;
-							edge->nodeDeleteRules = nodeDeleteRules;
+							edge->nodeDeleteRules = (unsigned short)nodeDeleteRules;
 							
 							id updatedDstNode =
 							  [dstNode yapDatabaseRelationshipEdgeDeleted:edge withReason:YDB_SourceNodeDeleted];
@@ -2866,7 +2866,7 @@ NS_INLINE BOOL EdgeMatchesDestination(YapDatabaseRelationshipEdge *edge, int64_t
 						edge->destinationKey = collectionKey.key;
 						edge->destinationCollection = collectionKey.collection;
 						edge->destinationRowid = rowid;
-						edge->nodeDeleteRules = nodeDeleteRules;
+						edge->nodeDeleteRules = (unsigned short)nodeDeleteRules;
 						
 						id updatedSrcNode =
 						  [srcNode yapDatabaseRelationshipEdgeDeleted:edge withReason:YDB_DestinationNodeDeleted];

--- a/YapDatabase/Extensions/SearchResults/YapDatabaseSearchResultsView.m
+++ b/YapDatabase/Extensions/SearchResults/YapDatabaseSearchResultsView.m
@@ -61,10 +61,10 @@
 #pragma mark Invalid
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (instancetype)initWithGrouping:(YapDatabaseViewGrouping *)grouping
-                         sorting:(YapDatabaseViewSorting *)sorting
-                      versionTag:(NSString *)inVersionTag
-                         options:(YapDatabaseViewOptions *)inOptions
+- (instancetype)initWithGrouping:(YapDatabaseViewGrouping __unused *)grouping
+                         sorting:(YapDatabaseViewSorting __unused *)sorting
+                      versionTag:(NSString __unused *)inVersionTag
+                         options:(YapDatabaseViewOptions __unused *)inOptions
 {
 	NSString *reason = @"You must use the init method(s) specific to YapDatabaseSearchResults.";
 	

--- a/YapDatabase/Extensions/SearchResults/YapDatabaseSearchResultsViewTransaction.m
+++ b/YapDatabase/Extensions/SearchResults/YapDatabaseSearchResultsViewTransaction.m
@@ -227,7 +227,7 @@ static NSString *const ext_key_query             = @"query";
 /**
  * Standard upgrade hook
 **/
-- (void)dropTablesForOldSubclassVersion:(int)oldSubclassVersion
+- (void)dropTablesForOldSubclassVersion:(int __unused)oldSubclassVersion
 {
 	// Placeholder method.
 	// To be used if we have a major upgrade to this class.
@@ -477,7 +477,7 @@ static NSString *const ext_key_query             = @"query";
 	//
 	// The changeset mechanism will automatically consolidate all changes to the minimum.
 	
-	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL *outerStop) {
+	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL __unused *outerStop) {
 		
 		// We must add the changes in reverse order.
 		// Either that, or the change index of each item would have to be zero,
@@ -485,7 +485,7 @@ static NSString *const ext_key_query             = @"query";
 		
 		[self enumerateRowidsInGroup:group
 		                 withOptions:NSEnumerationReverse // <- required
-		                  usingBlock:^(int64_t rowid, NSUInteger index, BOOL *innerStop)
+		                  usingBlock:^(int64_t rowid, NSUInteger index, BOOL __unused *innerStop)
 		{
 			YapCollectionKey *collectionKey = [databaseTransaction collectionKeyForRowid:rowid];
 			 
@@ -590,7 +590,7 @@ static NSString *const ext_key_query             = @"query";
 		__block NSUInteger index = 0;
 		
 		[parentViewTransaction enumerateRowidsInGroup:group
-		                                   usingBlock:^(int64_t rowid, NSUInteger parentIndex, BOOL *stop)
+		                                   usingBlock:^(int64_t rowid, NSUInteger __unused parentIndex, BOOL __unused *stop)
 		{
 			if (existing && ((existingRowid == rowid)))
 			{
@@ -893,7 +893,7 @@ static NSString *const ext_key_query             = @"query";
 /**
  * This method is invoked whenever a batch of items are removed from our view.
 **/
-- (void)didRemoveRowids:(NSArray *)rowids collectionKeys:(NSArray *)collectionKeys
+- (void)didRemoveRowids:(NSArray *)rowids collectionKeys:(NSArray __unused *)collectionKeys
 {
 	__unsafe_unretained YapDatabaseSearchResultsViewOptions *searchResultsOptions =
 	  (YapDatabaseSearchResultsViewOptions *)viewConnection->view->options;
@@ -2011,7 +2011,7 @@ static NSString *const ext_key_query             = @"query";
 	__unsafe_unretained NSString *registeredName = [self registeredName];
 	__unsafe_unretained NSDictionary *extensionDependencies = databaseTransaction->connection->extensionDependencies;
 	
-	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop){
 		
 		__unsafe_unretained NSString *extName = (NSString *)key;
 		__unsafe_unretained NSSet *extDependencies = (NSSet *)obj;

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndex.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndex.m
@@ -25,7 +25,7 @@
 
 + (void)dropTablesForRegisteredName:(NSString *)registeredName
                     withTransaction:(YapDatabaseReadWriteTransaction *)transaction
-                      wasPersistent:(BOOL)wasPersistent
+                      wasPersistent:(BOOL __unused)wasPersistent
 {
 	sqlite3 *db = transaction->connection->db;
 	NSString *tableName = [self tableNameForRegisteredName:registeredName];

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexConnection.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexConnection.m
@@ -207,9 +207,9 @@ static const int ydbLogLevel = YDB_LOG_LEVEL_WARN;
 /**
  * Required override method from YapDatabaseExtension
 **/
-- (void)getInternalChangeset:(NSMutableDictionary **)internalChangesetPtr
-           externalChangeset:(NSMutableDictionary **)externalChangesetPtr
-              hasDiskChanges:(BOOL *)hasDiskChangesPtr
+- (void)getInternalChangeset:(NSMutableDictionary __unused **)internalChangesetPtr
+           externalChangeset:(NSMutableDictionary __unused **)externalChangesetPtr
+              hasDiskChanges:(BOOL __unused *)hasDiskChangesPtr
 {
 	// Nothing to do for this particular extension.
 	//
@@ -220,7 +220,7 @@ static const int ydbLogLevel = YDB_LOG_LEVEL_WARN;
 /**
  * Required override method from YapDatabaseExtension
 **/
-- (void)processChangeset:(NSDictionary *)changeset
+- (void)processChangeset:(NSDictionary __unused *)changeset
 {
 	// Nothing to do for this particular extension.
 	//

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexOptions.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexOptions.m
@@ -16,7 +16,7 @@
 
 @synthesize allowedCollections = allowedCollections;
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseSecondaryIndexOptions *copy = [[YapDatabaseSecondaryIndexOptions alloc] init];
 	copy->allowedCollections = allowedCollections;

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexSetup.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexSetup.m
@@ -148,7 +148,7 @@
 	return [columnNames copy];
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseSecondaryIndexSetup *copy = [[YapDatabaseSecondaryIndexSetup alloc] initForCopy];
 	copy->setup = [setup mutableCopy];

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
@@ -286,7 +286,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		    (YapDatabaseSecondaryIndexWithKeyBlock)secondaryIndex->block;
 		
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop);
-		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, BOOL *stop) {
+		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, BOOL __unused *stop) {
 			
 			secondaryIndexBlock(secondaryIndexConnection->blockDict, collection, key);
 			
@@ -299,7 +299,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		
 		if (allowedCollections)
 		{
-			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 				
 				if ([allowedCollections isAllowed:collection])
 				{
@@ -318,7 +318,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		    (YapDatabaseSecondaryIndexWithObjectBlock)secondaryIndex->block;
 		
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop);
-		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop) {
+		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL __unused *stop) {
 			
 			secondaryIndexBlock(secondaryIndexConnection->blockDict, collection, key, object);
 			
@@ -331,7 +331,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		
 		if (allowedCollections)
 		{
-			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 				
 				if ([allowedCollections isAllowed:collection])
 				{
@@ -351,7 +351,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		    (YapDatabaseSecondaryIndexWithMetadataBlock)secondaryIndex->block;
 		
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop);
-		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop) {
+		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL __unused *stop) {
 			
 			secondaryIndexBlock(secondaryIndexConnection->blockDict, collection, key, metadata);
 			
@@ -364,7 +364,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		
 		if (allowedCollections)
 		{
-			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 				
 				if ([allowedCollections isAllowed:collection])
 				{
@@ -384,7 +384,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		    (YapDatabaseSecondaryIndexWithRowBlock)secondaryIndex->block;
 		
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop);
-		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop) {
+		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL __unused *stop) {
 			
 			secondaryIndexBlock(secondaryIndexConnection->blockDict, collection, key, object, metadata);
 			
@@ -397,7 +397,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		
 		if (allowedCollections)
 		{
-			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 				
 				if ([allowedCollections isAllowed:collection])
 				{
@@ -985,7 +985,7 @@ static NSString *const ext_key_version_deprecated = @"version";
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleTouchObjectForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchObjectForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	// Nothing to do for this extension
 }
@@ -994,7 +994,7 @@ static NSString *const ext_key_version_deprecated = @"version";
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
+- (void)handleTouchMetadataForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
 	// Nothing to do for this extension
 }
@@ -1022,7 +1022,7 @@ static NSString *const ext_key_version_deprecated = @"version";
  * YapDatabase extension hook.
  * This method is invoked by a YapDatabaseReadWriteTransaction as a post-operation-hook.
 **/
-- (void)handleRemoveObjectsForKeys:(NSArray *)keys inCollection:(NSString *)collection withRowids:(NSArray *)rowids
+- (void)handleRemoveObjectsForKeys:(NSArray __unused *)keys inCollection:(NSString *)collection withRowids:(NSArray *)rowids
 {
 	YDBLogAutoTrace();
 	

--- a/YapDatabase/Extensions/Views/Internal/YapDatabaseViewPage.mm
+++ b/YapDatabase/Extensions/Views/Internal/YapDatabaseViewPage.mm
@@ -24,7 +24,7 @@
 	return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewPage *copy = [[YapDatabaseViewPage alloc] initWithCapacity:[self count]];
 	

--- a/YapDatabase/Extensions/Views/Internal/YapDatabaseViewPageMetadata.m
+++ b/YapDatabase/Extensions/Views/Internal/YapDatabaseViewPageMetadata.m
@@ -3,7 +3,7 @@
 
 @implementation YapDatabaseViewPageMetadata
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewPageMetadata *copy = [[YapDatabaseViewPageMetadata alloc] init];
 	

--- a/YapDatabase/Extensions/Views/Internal/YapDatabaseViewState.m
+++ b/YapDatabase/Extensions/Views/Internal/YapDatabaseViewState.m
@@ -36,7 +36,7 @@
 {
 	NSMutableDictionary *deepCopy = [NSMutableDictionary dictionaryWithCapacity:[group_pagesMetadata_dict count]];
 	
-	[group_pagesMetadata_dict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+	[group_pagesMetadata_dict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 		
 		__unsafe_unretained NSString *group = (NSString *)key;
 		__unsafe_unretained NSMutableArray *pagesMetadata = (NSMutableArray *)obj;
@@ -52,7 +52,7 @@
 	return deepCopy;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	if (isImmutable)
 	{
@@ -69,7 +69,7 @@
 	}
 }
 
-- (id)mutableCopyWithZone:(NSZone *)zone
+- (id)mutableCopyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewState *copy = [[YapDatabaseViewState alloc] initForCopy];
 	copy->isImmutable = NO;

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
@@ -75,7 +75,7 @@
 	return op;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewSectionChange *op = [[YapDatabaseViewSectionChange alloc] init];
 	op->type = type;
@@ -207,7 +207,7 @@
 	return collectionKey;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewRowChange *op = [[YapDatabaseViewRowChange alloc] init];
 	op->collectionKey = collectionKey;

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
@@ -551,7 +551,7 @@
 					if (wasDelete)
 						dependencyIndex--;
 				}
-				else if ((offset < 0) && (-1*offset <= groupIndex))
+				else if ((offset < 0) && (-1*offset <= (NSInteger)groupIndex))
 				{
 					dependencyIndex = groupIndex + offset;
 				}

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.m
@@ -113,7 +113,7 @@
 	snapshotOfLastUpdate = UINT64_MAX;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewMappings *copy = [[YapDatabaseViewMappings alloc] init];
 	copy->allGroups = allGroups;

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewRangeOptions.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewRangeOptions.m
@@ -88,7 +88,7 @@
 
 #pragma mark Copy
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewRangeOptions *copy = [[YapDatabaseViewRangeOptions alloc] init];
 	copy->length = length;

--- a/YapDatabase/Extensions/Views/YapDatabaseViewConnection.m
+++ b/YapDatabase/Extensions/Views/YapDatabaseViewConnection.m
@@ -418,7 +418,7 @@
 		NSMutableArray *keysToRemove = changeset_reset ? [NSMutableArray arrayWithCapacity:removeCapacity] : nil;
 		NSMutableArray *keysToUpdate = [NSMutableArray arrayWithCapacity:updateCapacity];
 		
-		[mapCache enumerateKeysWithBlock:^(id key, BOOL *stop) {
+		[mapCache enumerateKeysWithBlock:^(id key, BOOL __unused *stop) {
 			
 			// Order matters.
 			// Consider the following database change:
@@ -461,7 +461,7 @@
 		NSMutableArray *keysToRemove = changeset_reset ? [NSMutableArray arrayWithCapacity:removeCapacity] : nil;
 		NSMutableArray *keysToUpdate = [NSMutableArray arrayWithCapacity:updateCapacity];
 		
-		[pageCache enumerateKeysWithBlock:^(id key, BOOL *stop) {
+		[pageCache enumerateKeysWithBlock:^(id key, BOOL __unused *stop) {
 			
 			// Order matters.
 			// Consider the following database change:

--- a/YapDatabase/Extensions/Views/YapDatabaseViewOptions.m
+++ b/YapDatabase/Extensions/Views/YapDatabaseViewOptions.m
@@ -16,7 +16,7 @@
 	return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseViewOptions *copy = [[[self class] alloc] init]; // [self class] required to support subclassing
 	copy->isPersistent = isPersistent;

--- a/YapDatabase/Extensions/Views/YapDatabaseViewTransaction.m
+++ b/YapDatabase/Extensions/Views/YapDatabaseViewTransaction.m
@@ -369,7 +369,7 @@
 	}
 	else // if (isNonPersistentView)
 	{
-		[pageMetadataTableTransaction enumerateKeysAndObjectsWithBlock:^(id key, id obj, BOOL *stop) {
+		[pageMetadataTableTransaction enumerateKeysAndObjectsWithBlock:^(id __unused key, id obj, BOOL __unused *stop) {
 			
 			YapDatabaseViewPageMetadata *pageMetadata = [(YapDatabaseViewPageMetadata *)obj copy];
 			
@@ -408,7 +408,7 @@
 		
 		// Enumerate over each group
 		
-		[groupOrderDict enumerateKeysAndObjectsUsingBlock:^(id _group, id _orderDict, BOOL *stop) {
+		[groupOrderDict enumerateKeysAndObjectsUsingBlock:^(id _group, id _orderDict, BOOL __unused *stop) {
 			
 			__unsafe_unretained NSString *group = (NSString *)_group;
 			__unsafe_unretained NSMutableDictionary *orderDict = (NSMutableDictionary *)_orderDict;
@@ -665,7 +665,7 @@
 	
 	if (groupingBlockType == YapDatabaseViewBlockTypeWithKey)
 	{
-		getGroup = ^(NSString *collection, NSString *key, id object, id metadata){
+		getGroup = ^(NSString *collection, NSString *key, id __unused object, id __unused metadata){
 			
 			__unsafe_unretained YapDatabaseViewGroupingWithKeyBlock groupingBlock =
 		        (YapDatabaseViewGroupingWithKeyBlock)groupingBlock_generic;
@@ -675,7 +675,7 @@
 	}
 	else if (groupingBlockType == YapDatabaseViewBlockTypeWithObject)
 	{
-		getGroup = ^(NSString *collection, NSString *key, id object, id metadata){
+		getGroup = ^(NSString *collection, NSString *key, id object, id __unused metadata){
 			
 			__unsafe_unretained YapDatabaseViewGroupingWithObjectBlock groupingBlock =
 		        (YapDatabaseViewGroupingWithObjectBlock)groupingBlock_generic;
@@ -685,7 +685,7 @@
 	}
 	else if (groupingBlockType == YapDatabaseViewBlockTypeWithMetadata)
 	{
-		getGroup = ^(NSString *collection, NSString *key, id object, id metadata){
+		getGroup = ^(NSString *collection, NSString *key, id __unused object, id metadata){
 			
 			__unsafe_unretained YapDatabaseViewGroupingWithMetadataBlock groupingBlock =
 		        (YapDatabaseViewGroupingWithMetadataBlock)groupingBlock_generic;
@@ -711,7 +711,7 @@
 		if (groupingNeedsObject || groupingNeedsMetadata)
 		{
 			void (^block)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop);
-			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop){
+			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL __unused *stop){
 				
 				NSString *group = getGroup(collection, key, object, metadata);
 				if (group)
@@ -729,7 +729,7 @@
 			YapWhitelistBlacklist *allowedCollections = viewConnection->view->options.allowedCollections;
 			if (allowedCollections)
 			{
-				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *outerStop) {
+				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *__unused outerStop) {
 					
 					if ([allowedCollections isAllowed:collection]) {
 						[databaseTransaction _enumerateRowsInCollections:@[ collection ] usingBlock:block];
@@ -749,14 +749,14 @@
 			__block NSString *group = nil;
 			
 			BOOL (^filter)(int64_t rowid, NSString *collection, NSString *key);
-			filter = ^BOOL(int64_t rowid, NSString *collection, NSString *key) {
+			filter = ^BOOL(int64_t __unused rowid, NSString *collection, NSString *key) {
 				
 				group = getGroup(collection, key, nil, nil);
 				return (group != nil);
 			};
 			
 			void (^block)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop);
-			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop){
+			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL __unused *stop){
 				
 				YapCollectionKey *collectionKey = [[YapCollectionKey alloc] initWithCollection:collection key:key];
 					
@@ -770,7 +770,7 @@
 			YapWhitelistBlacklist *allowedCollections = viewConnection->view->options.allowedCollections;
 			if (allowedCollections)
 			{
-				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 					
 					if ([allowedCollections isAllowed:collection])
 					{
@@ -791,7 +791,7 @@
 		if (groupingNeedsObject)
 		{
 			void (^block)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop);
-			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop){
+			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL __unused *stop){
 				
 				NSString *group = getGroup(collection, key, object, nil);
 				if (group)
@@ -809,7 +809,7 @@
 			YapWhitelistBlacklist *allowedCollections = viewConnection->view->options.allowedCollections;
 			if (allowedCollections)
 			{
-				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 					
 					if ([allowedCollections isAllowed:collection])
 					{
@@ -831,14 +831,14 @@
 			__block NSString *group = nil;
 			
 			BOOL (^filter)(int64_t rowid, NSString *collection, NSString *key);
-			filter = ^BOOL(int64_t rowid, NSString *collection, NSString *key) {
+			filter = ^BOOL(int64_t __unused rowid, NSString *collection, NSString *key) {
 				
 				group = getGroup(collection, key, nil, nil);
 				return (group != nil);
 			};
 			
 			void (^block)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop);
-			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop){
+			block = ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL __unused *stop){
 				
 				YapCollectionKey *collectionKey = [[YapCollectionKey alloc] initWithCollection:collection key:key];
 				
@@ -852,7 +852,7 @@
 			YapWhitelistBlacklist *allowedCollections = viewConnection->view->options.allowedCollections;
 			if (allowedCollections)
 			{
-				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 					
 					if ([allowedCollections isAllowed:collection])
 					{
@@ -873,7 +873,7 @@
 		if (groupingNeedsMetadata)
 		{
 			void (^block)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop);
-			block = ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop){
+			block = ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL __unused *stop){
 				
 				NSString *group = getGroup(collection, key, nil, metadata);
 				if (group)
@@ -892,7 +892,7 @@
 			YapWhitelistBlacklist *allowedCollections = viewConnection->view->options.allowedCollections;
 			if (allowedCollections)
 			{
-				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 					
 					if ([allowedCollections isAllowed:collection])
 					{
@@ -914,14 +914,14 @@
 			__block NSString *group = nil;
 			
 			BOOL (^filter)(int64_t rowid, NSString *collection, NSString *key);
-			filter = ^BOOL(int64_t rowid, NSString *collection, NSString *key){
+			filter = ^BOOL(int64_t __unused rowid, NSString *collection, NSString *key){
 				
 				group = getGroup(collection, key, nil, nil);
 				return (group != nil);
 			};
 			
 			void (^block)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop);
-			block = ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop){
+			block = ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL __unused *stop){
 				
 				YapCollectionKey *collectionKey = [[YapCollectionKey alloc] initWithCollection:collection key:key];
 				
@@ -935,7 +935,7 @@
 			YapWhitelistBlacklist *allowedCollections = viewConnection->view->options.allowedCollections;
 			if (allowedCollections)
 			{
-				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+				[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 					
 					if ([allowedCollections isAllowed:collection])
 					{
@@ -954,7 +954,7 @@
 	else // if (!needsObject && !needsMetadata)
 	{
 		void (^block)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop);
-		block = ^(int64_t rowid, NSString *collection, NSString *key, BOOL *stop){
+		block = ^(int64_t rowid, NSString *collection, NSString *key, BOOL __unused *stop){
 			
 			NSString *group = getGroup(collection, key, nil, nil);
 			if (group)
@@ -972,7 +972,7 @@
 		YapWhitelistBlacklist *allowedCollections = viewConnection->view->options.allowedCollections;
 		if (allowedCollections)
 		{
-			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL *stop) {
+			[databaseTransaction enumerateCollectionsUsingBlock:^(NSString *collection, BOOL __unused *stop) {
 				
 				if ([allowedCollections isAllowed:collection])
 				{
@@ -1014,7 +1014,7 @@
 	//
 	// The changeset mechanism will automatically consolidate all changes to the minimum.
 	
-	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL *outerStop) {
+	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL __unused *outerStop) {
 		
 		// We must add the changes in reverse order.
 		// Either that, or the change index of each item would have to be zero,
@@ -1022,7 +1022,7 @@
 		
 		[self enumerateRowidsInGroup:group
 		                 withOptions:NSEnumerationReverse
-		                  usingBlock:^(int64_t rowid, NSUInteger index, BOOL *innerStop)
+		                  usingBlock:^(int64_t rowid, NSUInteger index, BOOL __unused *innerStop)
 		{
 			YapCollectionKey *collectionKey = [databaseTransaction collectionKeyForRowid:rowid];
 			
@@ -1556,7 +1556,7 @@
 	__block BOOL found = NO;
 	
 	[pagesMetadataForGroup enumerateObjectsWithOptions:NSEnumerationReverse
-	                                        usingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+	                                        usingBlock:^(id obj, NSUInteger __unused idx, BOOL *stop) {
 												
 		__unsafe_unretained YapDatabaseViewPageMetadata *pageMetadata = (YapDatabaseViewPageMetadata *)obj;
 		
@@ -2400,7 +2400,7 @@
 		
 		// Mark all rowids for deletion
 		
-		[page enumerateRowidsUsingBlock:^(int64_t rowid, NSUInteger idx, BOOL *stop) {
+		[page enumerateRowidsUsingBlock:^(int64_t rowid, NSUInteger __unused idx, BOOL __unused *stop) {
 			
 			[removedRowids addObject:@(rowid)];
 			
@@ -2480,7 +2480,7 @@
 		[pageMetadataTableTransaction removeAllObjects];
 	}
 	
-	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL *stop) {
+	[viewConnection->state enumerateGroupsWithBlock:^(NSString *group, BOOL __unused *stop) {
 		
 		if (!isRepopulate) {
 			[viewConnection->changes addObject:[YapDatabaseViewSectionChange resetGroup:group]];
@@ -2574,7 +2574,7 @@
 				
 				[prevPage enumerateRowidsWithOptions:0
 				                               range:prevPageRange
-				                          usingBlock:^(int64_t rowid, NSUInteger index, BOOL *stop) {
+				                          usingBlock:^(int64_t rowid, NSUInteger __unused index, BOOL __unused *stop) {
 					
 					NSNumber *number = @(rowid);
 					
@@ -2624,7 +2624,7 @@
 				
 				[nextPage enumerateRowidsWithOptions:0
 				                               range:nextPageRange
-				                          usingBlock:^(int64_t rowid, NSUInteger index, BOOL *stop) {
+				                          usingBlock:^(int64_t rowid, NSUInteger __unused index, BOOL __unused *stop) {
 					
 					NSNumber *number = @(rowid);
 					
@@ -2689,7 +2689,7 @@
 		
 		// Mark rowid mappings as dirty
 		
-		[newPage enumerateRowidsUsingBlock:^(int64_t rowid, NSUInteger idx, BOOL *stop) {
+		[newPage enumerateRowidsUsingBlock:^(int64_t rowid, NSUInteger __unused idx, BOOL __unused *stop) {
 			
 			NSNumber *number = @(rowid);
 			
@@ -2700,7 +2700,7 @@
 	} // end while (pageMetadata->count > maxPageSize)
 }
 
-- (void)dropEmptyPage:(YapDatabaseViewPage *)page withPageKey:(NSString *)pageKey
+- (void)dropEmptyPage:(YapDatabaseViewPage __unused *)page withPageKey:(NSString *)pageKey
 {
 	YDBLogAutoTrace();
 	
@@ -2846,7 +2846,7 @@
 		//
 		// Write dirty pages to table (along with associated dirty metadata)
 	
-		[viewConnection->dirtyPages enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[viewConnection->dirtyPages enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 			
 			__unsafe_unretained NSString *pageKey = (NSString *)key;
 			__unsafe_unretained YapDatabaseViewPage *page = (YapDatabaseViewPage *)obj;
@@ -3205,7 +3205,7 @@
 		{
 			[pageTableTransaction modifyWithBlock:^{ @autoreleasepool {
 				
-				[viewConnection->dirtyPages enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+				[viewConnection->dirtyPages enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 					
 					__unsafe_unretained NSString *pageKey = (NSString *)key;
 					__unsafe_unretained YapDatabaseViewPage *page = (YapDatabaseViewPage *)obj;
@@ -3230,7 +3230,7 @@
 		{
 			[pageMetadataTableTransaction modifyWithBlock:^{ @autoreleasepool {
 				
-				[viewConnection->dirtyPages enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+				[viewConnection->dirtyPages enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 					
 					__unsafe_unretained NSString *pageKey = (NSString *)key;
 					__unsafe_unretained YapDatabaseViewPage *page = (YapDatabaseViewPage *)obj;
@@ -3269,7 +3269,7 @@
 					}
 				}];
 				
-				[viewConnection->dirtyLinks enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+				[viewConnection->dirtyLinks enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 					
 					__unsafe_unretained NSString *pageKey = (NSString *)key;
 					__unsafe_unretained YapDatabaseViewPageMetadata *pageMetadata = (YapDatabaseViewPageMetadata *)obj;
@@ -3295,7 +3295,7 @@
 		{
 			[mapTableTransaction modifyWithBlock:^{ @autoreleasepool {
 				
-				[viewConnection->dirtyMaps enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+				[viewConnection->dirtyMaps enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 					
 					__unsafe_unretained NSNumber *rowidNumber = (NSNumber *)key;
 					__unsafe_unretained NSString *pageKey = (NSString *)obj;
@@ -3955,7 +3955,7 @@
 	// output.key = pageKey
 	// output.value = NSDictionary with keyMappings for page
 	
-	[output enumerateKeysAndObjectsUsingBlock:^(id pageKeyObj, id dictObj, BOOL *stop) {
+	[output enumerateKeysAndObjectsUsingBlock:^(id pageKeyObj, id dictObj, BOOL __unused *stop) {
 		
 		__unsafe_unretained NSString *pageKey = (NSString *)pageKeyObj;
 		__unsafe_unretained NSDictionary *keyMappingsForPage = (NSDictionary *)dictObj;
@@ -3999,7 +3999,7 @@
 	
 	__block NSUInteger count = 0;
 	
-	[viewConnection->state enumerateWithBlock:^(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop) {
+	[viewConnection->state enumerateWithBlock:^(NSString __unused *group, NSArray *pagesMetadataForGroup, BOOL __unused *stop) {
 		
 		for (YapDatabaseViewPageMetadata *pageMetadata in pagesMetadataForGroup)
 		{
@@ -4021,7 +4021,7 @@
 	
 	NSMutableArray *allGroups = [NSMutableArray arrayWithCapacity:[viewConnection->state numberOfGroups]];
 	
-	[viewConnection->state enumerateWithBlock:^(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop) {
+	[viewConnection->state enumerateWithBlock:^(NSString *group, NSArray *pagesMetadataForGroup, BOOL __unused *stop) {
 		
 		for (YapDatabaseViewPageMetadata *pageMetadata in pagesMetadataForGroup)
 		{
@@ -4077,7 +4077,7 @@
 {
 	__block NSUInteger count = 0;
 	
-	[viewConnection->state enumerateWithBlock:^(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop) {
+	[viewConnection->state enumerateWithBlock:^(NSString __unused *group, NSArray *pagesMetadataForGroup, BOOL __unused *stop) {
 		
 		for (YapDatabaseViewPageMetadata *pageMetadata in pagesMetadataForGroup)
 		{
@@ -4114,7 +4114,7 @@
 {
 	__block BOOL result = YES;
 	
-	[viewConnection->state enumerateWithBlock:^(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop) {
+	[viewConnection->state enumerateWithBlock:^(NSString __unused *group, NSArray *pagesMetadataForGroup, BOOL *stop) {
 		
 		for (YapDatabaseViewPageMetadata *pageMetadata in pagesMetadataForGroup)
 		{
@@ -4622,14 +4622,14 @@
 	NSArray *pagesMetadataForGroup = [viewConnection->state pagesMetadataForGroup:group];
 	
 	[pagesMetadataForGroup enumerateObjectsWithOptions:options
-	                                        usingBlock:^(id pageMetadataObj, NSUInteger outerIdx, BOOL *outerStop)
+	                                        usingBlock:^(id pageMetadataObj, NSUInteger __unused outerIdx, BOOL *outerStop)
 	{
 		__unsafe_unretained YapDatabaseViewPageMetadata *pageMetadata =
 		    (YapDatabaseViewPageMetadata *)pageMetadataObj;
 		
 		YapDatabaseViewPage *page = [self pageForPageKey:pageMetadata->pageKey];
 		
-		[page enumerateRowidsWithOptions:options usingBlock:^(int64_t rowid, NSUInteger innerIdx, BOOL *innerStop) {
+		[page enumerateRowidsWithOptions:options usingBlock:^(int64_t rowid, NSUInteger __unused innerIdx, BOOL *innerStop) {
 			
 			block(rowid, index, &stop);
 			
@@ -4719,7 +4719,7 @@
 		__block BOOL startedRange = NO;
 		
 		[pagesMetadataForGroup enumerateObjectsWithOptions:options
-		                                        usingBlock:^(id pageMetadataObj, NSUInteger pageIndex, BOOL *outerStop)
+		                                        usingBlock:^(id pageMetadataObj, NSUInteger __unused pageIndex, BOOL *outerStop)
 		{
 			__unsafe_unretained YapDatabaseViewPageMetadata *pageMetadata =
 			    (YapDatabaseViewPageMetadata *)pageMetadataObj;
@@ -4795,7 +4795,7 @@
 /**
  * Invoked when an item is added to the view.
 **/
-- (void)didInsertRowid:(int64_t)rowid collectionKey:(YapCollectionKey *)collectionKey
+- (void)didInsertRowid:(int64_t __unused)rowid collectionKey:(YapCollectionKey __unused *)collectionKey
 {
 	// Subclasses may override me.
 	// Default implementation does nothing.
@@ -4808,7 +4808,7 @@
  * That is, when an individual item is removed from the view as a single operation.
  * For larger (non-single) remove operations, the other hook methods are used.
 **/
-- (void)didRemoveRowid:(int64_t)rowid collectionKey:(YapCollectionKey *)collectionKey
+- (void)didRemoveRowid:(int64_t __unused)rowid collectionKey:(YapCollectionKey __unused *)collectionKey
 {
 	// Subclasses may override me.
 	// Default implementation does nothing.
@@ -4829,7 +4829,7 @@
  *   But that is ** NOT ** the case here.
  *   So you'll be required to check for this, and split your queries accordingly.
 **/
-- (void)didRemoveRowids:(NSArray *)rowids collectionKeys:(NSArray *)collectionKeys
+- (void)didRemoveRowids:(NSArray __unused *)rowids collectionKeys:(NSArray __unused *)collectionKeys
 {
 	// Subclasses may override me.
 	// Default implementation does nothing.
@@ -5068,7 +5068,7 @@
 	NSString *registeredName = [self registeredName];
 	NSDictionary *extensionDependencies = databaseTransaction->connection->extensionDependencies;
 	
-	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
+	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop){
 		
 		__unsafe_unretained NSString *extName = (NSString *)key;
 		__unsafe_unretained NSSet *extDependencies = (NSSet *)obj;

--- a/YapDatabase/Internal/YapDatabaseConnectionDefaults.m
+++ b/YapDatabase/Internal/YapDatabaseConnectionDefaults.m
@@ -39,7 +39,7 @@ static NSUInteger const DEFAULT_METADATA_CACHE_LIMIT = 500;
 	return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseConnectionDefaults *copy = [[[self class] alloc] init];
 	

--- a/YapDatabase/Internal/YapDatabaseConnectionState.m
+++ b/YapDatabase/Internal/YapDatabaseConnectionState.m
@@ -24,7 +24,7 @@
 #endif
 }
 
-- (void)prepareWriteLock;
+- (void)prepareWriteLock
 {
 	if (writeSemaphore == NULL) {
 		writeSemaphore = dispatch_semaphore_create(0);

--- a/YapDatabase/Internal/YapMemoryTable.m
+++ b/YapDatabase/Internal/YapMemoryTable.m
@@ -148,7 +148,7 @@
 				__unsafe_unretained YapMemoryTableValue *prvValue = nil;
 				__unsafe_unretained YapMemoryTableValue *value = [dict objectForKey:key];
 				
-				while (value && value->snapshot >= minSnapshot)
+				while (value && value->snapshot >= (uint64_t)minSnapshot)
 				{
 					if (hasObject == NO)
 						hasObject = (value->object != nil);
@@ -217,7 +217,7 @@
 		{
 			__unsafe_unretained YapMemoryTableValue *value = [dict objectForKey:key];
 			
-			if (value && value->snapshot == snapshot)
+			if (value && value->snapshot == (uint64_t)snapshot)
 			{
 				if (value->olderValue == nil)
 				{

--- a/YapDatabase/Internal/YapMemoryTable.m
+++ b/YapDatabase/Internal/YapMemoryTable.m
@@ -280,7 +280,7 @@
 {
 	dispatch_block_t block = ^{ @autoreleasepool {
 		
-		[table->dict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[table->dict enumerateKeysAndObjectsUsingBlock:^(id key, id __unused obj, BOOL *stop) {
 			
 			__unsafe_unretained YapMemoryTableValue *value = [table->dict objectForKey:key];
 			while (value)
@@ -311,7 +311,7 @@
 {
 	dispatch_block_t block = ^{ @autoreleasepool {
 		
-		[table->dict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[table->dict enumerateKeysAndObjectsUsingBlock:^(id key, id __unused obj, BOOL *stop) {
 			
 			__unsafe_unretained YapMemoryTableValue *value = [table->dict objectForKey:key];
 			while (value)

--- a/YapDatabase/Utilities/YapCache.m
+++ b/YapDatabase/Utilities/YapCache.m
@@ -124,7 +124,7 @@
 		countLimit = newCountLimit;
 		
 		if (countLimit != 0) {
-			while (CFDictionaryGetCount(cfdict) > countLimit)
+			while (CFDictionaryGetCount(cfdict) > (CFIndex)countLimit)
 			{
 				leastRecentCacheItem->prev->next = nil;
 				
@@ -278,7 +278,7 @@
 		
 		// Evict leastRecentCacheItem if needed
 		
-		if ((countLimit != 0) && (CFDictionaryGetCount(cfdict) > countLimit))
+		if ((countLimit != 0) && (CFDictionaryGetCount(cfdict) > (CFIndex)countLimit))
 		{
 			YDBLogVerbose(@"key(%@), out(%@)", key, leastRecentCacheItem->key);
 			

--- a/YapDatabase/Utilities/YapCollectionKey.m
+++ b/YapDatabase/Utilities/YapCollectionKey.m
@@ -59,7 +59,7 @@ YapCollectionKey* YapCollectionKeyCreate(NSString *collection, NSString *key)
 	[coder encodeObject:key        forKey:@"key"];
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	return self; // Immutable
 }

--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -124,7 +124,7 @@
 			{
 				NSInteger elementCount = [paramIndexToElementCountMap[index] intValue];
 				NSMutableArray *unpackedParams = [NSMutableArray array];
-				for (NSUInteger i = 0; i < elementCount; i++)
+				for (NSInteger i = 0; i < elementCount; i++)
 				{
 					[unpackedParams addObject:@"?"];
 				}

--- a/YapDatabase/Utilities/YapSet.m
+++ b/YapDatabase/Utilities/YapSet.m
@@ -62,7 +62,7 @@
 	else
 	{
 		if (block == NULL) return;
-		[dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id __unused obj, BOOL *stop) {
 			
 			block(key, stop);
 		}];

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -99,7 +99,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 **/
 + (YapDatabaseSerializer)defaultSerializer
 {
-	return ^ NSData* (NSString *collection, NSString *key, id object){
+	return ^ NSData* (NSString __unused *collection, NSString __unused *key, id object){
 		return [NSKeyedArchiver archivedDataWithRootObject:object];
 	};
 }
@@ -110,7 +110,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 **/
 + (YapDatabaseDeserializer)defaultDeserializer
 {
-	return ^ id (NSString *collection, NSString *key, NSData *data){
+	return ^ id (NSString __unused *collection, NSString __unused *key, NSData *data){
 		return [NSKeyedUnarchiver unarchiveObjectWithData:data];
 	};
 }
@@ -124,7 +124,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 **/
 + (YapDatabaseSerializer)propertyListSerializer
 {
-	return ^ NSData* (NSString *collection, NSString *key, id object){
+	return ^ NSData* (NSString __unused *collection, NSString __unused *key, id object){
 		return [NSPropertyListSerialization dataWithPropertyList:object
 		                                                  format:NSPropertyListBinaryFormat_v1_0
 		                                                 options:NSPropertyListImmutable
@@ -141,7 +141,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 **/
 + (YapDatabaseDeserializer)propertyListDeserializer
 {
-	return ^ id (NSString *collection, NSString *key, NSData *data){
+	return ^ id (NSString __unused *collection, NSString __unused *key, NSData *data){
 		return [NSPropertyListSerialization propertyListWithData:data options:0 format:NULL error:NULL];
 	};
 }
@@ -152,7 +152,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 **/
 + (YapDatabaseSerializer)timestampSerializer
 {
-	return ^ NSData* (NSString *collection, NSString *key, id object) {
+	return ^ NSData* (NSString __unused *collection, NSString __unused *key, id object) {
 		
 		if ([object isKindOfClass:[NSDate class]])
 		{
@@ -173,7 +173,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 **/
 + (YapDatabaseDeserializer)timestampDeserializer
 {
-	return ^ id (NSString *collection, NSString *key, NSData *data) {
+	return ^ id (NSString __unused *collection, NSString __unused *key, NSData *data) {
 		
 		if ([data length] == sizeof(NSTimeInterval))
 		{
@@ -2372,7 +2372,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 	NSDate *date = [connectionPoolDates objectAtIndex:0];
 	NSTimeInterval interval = [date timeIntervalSinceNow] + connectionPoolLifetime;
 	
-	dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (interval * NSEC_PER_SEC));
+	dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(interval * NSEC_PER_SEC));
 	dispatch_source_set_timer(connectionPoolTimer, tt, DISPATCH_TIME_FOREVER, 0);
 	
 	if (isNewTimer) {
@@ -2491,7 +2491,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
  *
  * - snapshot : NSNumber with the changeset's snapshot
 **/
-- (void)notePendingChanges:(NSDictionary *)pendingChangeset fromConnection:(YapDatabaseConnection *)sender
+- (void)notePendingChanges:(NSDictionary *)pendingChangeset fromConnection:(YapDatabaseConnection __unused *)sender
 {
 	NSAssert(dispatch_get_specific(IsOnSnapshotQueueKey), @"Must go through snapshotQueue for atomic access.");
 	NSAssert([pendingChangeset objectForKey:YapDatabaseSnapshotKey], @"Missing required change key: snapshot");
@@ -2576,7 +2576,7 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 	NSDictionary *changeset_extensions = [changeset objectForKey:YapDatabaseExtensionsKey];
 	if (changeset_extensions)
 	{
-		[registeredExtensions enumerateKeysAndObjectsUsingBlock:^(id extName, id extObj, BOOL *stop) {
+		[registeredExtensions enumerateKeysAndObjectsUsingBlock:^(id extName, id extObj, BOOL __unused *stop) {
 			
 			NSDictionary *changeset_extensions_extName = [changeset_extensions objectForKey:extName];
 			if (changeset_extensions_extName)

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -426,7 +426,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		[self _flushStatements];
 	}
 	
-	[extensions enumerateKeysAndObjectsUsingBlock:^(id extNameObj, id extConnectionObj, BOOL *stop) {
+	[extensions enumerateKeysAndObjectsUsingBlock:^(id __unused extNameObj, id extConnectionObj, BOOL __unused *stop) {
 		
 		[(YapDatabaseExtensionConnection *)extConnectionObj _flushMemoryWithFlags:flags];
 	}];
@@ -464,7 +464,7 @@ NS_INLINE BOOL YDBIsMainThread()
 }
 
 #if TARGET_OS_IPHONE
-- (void)didReceiveMemoryWarning:(NSNotification *)notification
+- (void)didReceiveMemoryWarning:(NSNotification __unused *)notification
 {
 	[self flushMemoryWithFlags:[self autoFlushMemoryFlags]];
 }
@@ -2053,7 +2053,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		
 		[database asyncCheckpoint:minSnapshot];
 		
-		[registeredMemoryTables enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[registeredMemoryTables enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop) {
 			
 			[(YapMemoryTable *)obj asyncCheckpoint:minSnapshot];
 		}];
@@ -2472,7 +2472,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		{
 			[database asyncCheckpoint:snapshot];
 			
-			[registeredMemoryTables enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+			[registeredMemoryTables enumerateKeysAndObjectsUsingBlock:^(id __unused key, id obj, BOOL __unused *stop) {
 				
 				[(YapMemoryTable *)obj asyncCheckpoint:snapshot];
 			}];
@@ -3014,7 +3014,7 @@ NS_INLINE BOOL YDBIsMainThread()
 	__block NSMutableDictionary *internalChangeset_extensions = nil;
 	__block NSMutableDictionary *externalChangeset_extensions = nil;
 	
-	[extensions enumerateKeysAndObjectsUsingBlock:^(id extName, id extConnectionObj, BOOL *stop) {
+	[extensions enumerateKeysAndObjectsUsingBlock:^(id extName, id extConnectionObj, BOOL __unused *stop) {
 		
 		__unsafe_unretained YapDatabaseExtensionConnection *extConnection = extConnectionObj;
 		
@@ -3199,7 +3199,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		// Use existing extensions (extensions ivar, not [self extensions]).
 		// There's no need to create any new extConnections at this point.
 		
-		[extensions enumerateKeysAndObjectsUsingBlock:^(id extName, id extConnectionObj, BOOL *stop) {
+		[extensions enumerateKeysAndObjectsUsingBlock:^(id extName, id extConnectionObj, BOOL __unused *stop) {
 			
 			__unsafe_unretained YapDatabaseExtensionConnection *extConnection = extConnectionObj;
 			
@@ -3240,7 +3240,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		if (hasRemovedCollections)
 		{
 			__block NSMutableArray *toRemove = nil;
-			[keyCache enumerateKeysAndObjectsWithBlock:^(id key, id obj, BOOL *stop) {
+			[keyCache enumerateKeysAndObjectsWithBlock:^(id key, id obj, BOOL __unused *stop) {
 				
 				__unsafe_unretained NSNumber *rowidNumber = (NSNumber *)key;
 				__unsafe_unretained YapCollectionKey *collectionKey = (YapCollectionKey *)obj;
@@ -3259,7 +3259,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		
 		if (changeset_removedRowids)
 		{
-			[changeset_removedRowids enumerateObjectsUsingBlock:^(id obj, BOOL *stop) {
+			[changeset_removedRowids enumerateObjectsUsingBlock:^(id obj, BOOL __unused *stop) {
 				
 				[keyCache removeObjectForKey:obj];
 			}];
@@ -3285,7 +3285,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		BOOL isPolicyContainment = (objectPolicy == YapDatabasePolicyContainment);
 		BOOL isPolicyShare       = (objectPolicy == YapDatabasePolicyShare);
 		
-		[changeset_objectChanges enumerateKeysAndObjectsUsingBlock:^(id key, id newObject, BOOL *stop) {
+		[changeset_objectChanges enumerateKeysAndObjectsUsingBlock:^(id key, id newObject, BOOL __unused *stop) {
 			
 			__unsafe_unretained YapCollectionKey *cacheKey = (YapCollectionKey *)key;
 			
@@ -3322,7 +3322,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		NSMutableArray *keysToUpdate = [NSMutableArray arrayWithCapacity:updateCapacity];
 		NSMutableArray *keysToRemove = [NSMutableArray arrayWithCapacity:removeCapacity];
 		
-		[objectCache enumerateKeysWithBlock:^(id key, BOOL *stop) {
+		[objectCache enumerateKeysWithBlock:^(id key, BOOL __unused *stop) {
 			
 			// Order matters.
 			// Consider the following database change:
@@ -3397,7 +3397,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		BOOL isPolicyContainment = (metadataPolicy == YapDatabasePolicyContainment);
 		BOOL isPolicyShare       = (metadataPolicy == YapDatabasePolicyShare);
 		
-		[changeset_metadataChanges enumerateKeysAndObjectsUsingBlock:^(id key, id newMetadata, BOOL *stop) {
+		[changeset_metadataChanges enumerateKeysAndObjectsUsingBlock:^(id key, id newMetadata, BOOL __unused *stop) {
 			
 			__unsafe_unretained YapCollectionKey *cacheKey = (YapCollectionKey *)key;
 			
@@ -3434,7 +3434,7 @@ NS_INLINE BOOL YDBIsMainThread()
 		NSMutableArray *keysToUpdate = [NSMutableArray arrayWithCapacity:updateCapacity];
 		NSMutableArray *keysToRemove = [NSMutableArray arrayWithCapacity:removeCapacity];
 		
-		[metadataCache enumerateKeysWithBlock:^(id key, BOOL *stop) {
+		[metadataCache enumerateKeysWithBlock:^(id key, BOOL __unused *stop) {
 			
 			// Order matters.
 			// Consider the following database change:
@@ -4115,7 +4115,7 @@ NS_INLINE BOOL YDBIsMainThread()
 	
 	if (!extensionsReady)
 	{
-		[registeredExtensions enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		[registeredExtensions enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 			
 			__unsafe_unretained NSString *extName = key;
 			__unsafe_unretained YapDatabaseExtension *ext = obj;
@@ -4313,7 +4313,7 @@ NS_INLINE BOOL YDBIsMainThread()
 			// remove rows in yap memory table (where collectionKey.collection == extensionName)
 			NSMutableArray *keysToRemove = [NSMutableArray array];
 			
-			[memoryTableTransaction enumerateKeysWithBlock:^(id key, BOOL *stop) {
+			[memoryTableTransaction enumerateKeysWithBlock:^(id key, BOOL __unused *stop) {
 				
 				__unsafe_unretained YapCollectionKey *ck = (YapCollectionKey *)key;
 				if ([ck.collection isEqualToString:extensionName])

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -32,7 +32,7 @@
 	return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone __unused *)zone
 {
 	YapDatabaseOptions *copy = [[[self class] alloc] init];
 	copy->corruptAction = corruptAction;

--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -94,7 +94,7 @@
 		restart = NO;
 		prevExtModifiesMainDatabaseTable = NO;
 		
-		[extensions enumerateKeysAndObjectsUsingBlock:^(id extNameObj, id extTransactionObj, BOOL *stop) {
+		[extensions enumerateKeysAndObjectsUsingBlock:^(id __unused extNameObj, id extTransactionObj, BOOL *stop) {
 			
 			BOOL extModifiesMainDatabaseTable =
 			  [(YapDatabaseExtensionTransaction *)extTransactionObj flushPendingChangesToMainDatabaseTable];
@@ -127,7 +127,7 @@
 	// Allow extensions to flush changes to their own tables,
 	// and perform any needed "cleanup" code needed before the changeset is requested.
 	
-	[extensions enumerateKeysAndObjectsUsingBlock:^(id extNameObj, id extTransactionObj, BOOL *stop) {
+	[extensions enumerateKeysAndObjectsUsingBlock:^(id __unused extNameObj, id extTransactionObj, BOOL __unused *stop) {
 		
 		[(YapDatabaseExtensionTransaction *)extTransactionObj flushPendingChangesToExtensionTables];
 	}];
@@ -153,7 +153,7 @@
 	
 	if (isReadWriteTransaction)
 	{
-		[extensions enumerateKeysAndObjectsUsingBlock:^(id extNameObj, id extTransactionObj, BOOL *stop) {
+		[extensions enumerateKeysAndObjectsUsingBlock:^(id __unused extNameObj, id extTransactionObj, BOOL __unused *stop) {
 			
 			[(YapDatabaseExtensionTransaction *)extTransactionObj didCommitTransaction];
 		}];
@@ -176,7 +176,7 @@
 		sqlite3_reset(statement);
 	}
 	
-	[extensions enumerateKeysAndObjectsUsingBlock:^(id extNameObj, id extTransactionObj, BOOL *stop) {
+	[extensions enumerateKeysAndObjectsUsingBlock:^(id __unused extNameObj, id extTransactionObj, BOOL __unused *stop) {
 		
 		[(YapDatabaseExtensionTransaction *)extTransactionObj didRollbackTransaction];
 	}];
@@ -323,7 +323,7 @@
 	NSUInteger count = [self numberOfKeysInCollection:collection];
 	NSMutableArray *result = [NSMutableArray arrayWithCapacity:count];
 	
-	[self _enumerateKeysInCollection:collection usingBlock:^(int64_t rowid, NSString *key, BOOL *stop) {
+	[self _enumerateKeysInCollection:collection usingBlock:^(int64_t __unused rowid, NSString *key, BOOL __unused *stop) {
 		
 		[result addObject:key];
 	}];
@@ -1347,7 +1347,7 @@
 {
 	if (block == NULL) return;
 	
-	[self _enumerateKeysInCollection:collection usingBlock:^(int64_t rowid, NSString *key, BOOL *stop) {
+	[self _enumerateKeysInCollection:collection usingBlock:^(int64_t __unused rowid, NSString *key, BOOL *stop) {
 		
 		block(key, stop);
 	}];
@@ -1363,7 +1363,7 @@
 {
 	if (block == NULL) return;
 	
-	[self _enumerateKeysInAllCollectionsUsingBlock:^(int64_t rowid, NSString *collection, NSString *key, BOOL *stop) {
+	[self _enumerateKeysInAllCollectionsUsingBlock:^(int64_t __unused rowid, NSString *collection, NSString *key, BOOL *stop) {
 		
 		block(collection, key, stop);
 	}];
@@ -1404,11 +1404,11 @@
 	if (filter)
 	{
 		[self _enumerateKeysAndMetadataInCollection:collection
-		                                 usingBlock:^(int64_t rowid, NSString *key, id metadata, BOOL *stop) {
+		                                 usingBlock:^(int64_t __unused rowid, NSString *key, id metadata, BOOL *stop) {
 		
 			block(key, metadata, stop);
 			
-		} withFilter:^BOOL(int64_t rowid, NSString *key) {
+		} withFilter:^BOOL(int64_t __unused rowid, NSString *key) {
 			
 			return filter(key);
 		}];
@@ -1416,7 +1416,7 @@
 	else
 	{
 		[self _enumerateKeysAndMetadataInCollection:collection
-		                                 usingBlock:^(int64_t rowid, NSString *key, id metadata, BOOL *stop) {
+		                                 usingBlock:^(int64_t __unused rowid, NSString *key, id metadata, BOOL *stop) {
 		
 			block(key, metadata, stop);
 			
@@ -1461,11 +1461,11 @@
 	if (filter)
 	{
 		[self _enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop) {
+		    ^(int64_t __unused rowid, NSString *collection, NSString *key, id metadata, BOOL *stop) {
 			
 			block(collection, key, metadata, stop);
 			
-		} withFilter:^BOOL(int64_t rowid, NSString *collection, NSString *key) {
+		} withFilter:^BOOL(int64_t __unused rowid, NSString *collection, NSString *key) {
 			
 			return filter(collection, key);
 		}];
@@ -1473,7 +1473,7 @@
 	else
 	{
 		[self _enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop) {
+		    ^(int64_t __unused rowid, NSString *collection, NSString *key, id metadata, BOOL *stop) {
 			
 			block(collection, key, metadata, stop);
 			
@@ -1514,11 +1514,11 @@
 	if (filter)
 	{
 		[self _enumerateKeysAndObjectsInCollection:collection
-		                                usingBlock:^(int64_t rowid, NSString *key, id object, BOOL *stop) {
+		                                usingBlock:^(int64_t __unused rowid, NSString *key, id object, BOOL *stop) {
 			
 			block(key, object, stop);
 			
-		} withFilter:^BOOL(int64_t rowid, NSString *key) {
+		} withFilter:^BOOL(int64_t __unused rowid, NSString *key) {
 			
 			return filter(key);
 		}];
@@ -1526,7 +1526,7 @@
 	else
 	{
 		[self _enumerateKeysAndObjectsInCollection:collection
-		                                usingBlock:^(int64_t rowid, NSString *key, id object, BOOL *stop) {
+		                                usingBlock:^(int64_t __unused rowid, NSString *key, id object, BOOL *stop) {
 			
 			block(key, object, stop);
 			
@@ -1570,11 +1570,11 @@
 	if (filter)
 	{
 		[self _enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop) {
+		    ^(int64_t __unused rowid, NSString *collection, NSString *key, id object, BOOL *stop) {
 			
 			block(collection, key, object, stop);
 			
-		} withFilter:^BOOL(int64_t rowid, NSString *collection, NSString *key) {
+		} withFilter:^BOOL(int64_t __unused rowid, NSString *collection, NSString *key) {
 			
 			return filter(collection, key);
 		}];
@@ -1582,7 +1582,7 @@
 	else
 	{
 		[self _enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop) {
+		    ^(int64_t __unused rowid, NSString *collection, NSString *key, id object, BOOL *stop) {
 			
 			block(collection, key, object, stop);
 			
@@ -1623,11 +1623,11 @@
 	if (filter)
 	{
 		[self _enumerateRowsInCollection:collection
-		                      usingBlock:^(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop) {
+		                      usingBlock:^(int64_t __unused rowid, NSString *key, id object, id metadata, BOOL *stop) {
 			
 			block(key, object, metadata, stop);
 			
-		} withFilter:^BOOL(int64_t rowid, NSString *key) {
+		} withFilter:^BOOL(int64_t __unused rowid, NSString *key) {
 			
 			return filter(key);
 		}];
@@ -1635,7 +1635,7 @@
 	else
 	{
 		[self _enumerateRowsInCollection:collection
-		                      usingBlock:^(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop) {
+		                      usingBlock:^(int64_t __unused rowid, NSString *key, id object, id metadata, BOOL *stop) {
 			
 			block(key, object, metadata, stop);
 			
@@ -1679,11 +1679,11 @@
 	if (filter)
 	{
 		[self _enumerateRowsInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop) {
+		    ^(int64_t __unused rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop) {
 			
 			block(collection, key, object, metadata, stop);
 			
-		} withFilter:^BOOL(int64_t rowid, NSString *collection, NSString *key) {
+		} withFilter:^BOOL(int64_t __unused rowid, NSString *collection, NSString *key) {
 			
 			return filter(collection, key);
 		}];
@@ -1691,7 +1691,7 @@
 	else
 	{
 		[self _enumerateRowsInAllCollectionsUsingBlock:
-		    ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop) {
+		    ^(int64_t __unused rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop) {
 			
 			block(collection, key, object, metadata, stop);
 			
@@ -3879,7 +3879,7 @@
 	
 	NSDictionary *extConnections = [connection extensions];
 	
-	[extConnections enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+	[extConnections enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop) {
 		
 		__unsafe_unretained NSString *extName = key;
 		__unsafe_unretained YapDatabaseExtensionConnection *extConnection = obj;
@@ -5296,7 +5296,7 @@
 	
 	{ // keyCache
 		
-		[connection->keyCache enumerateKeysAndObjectsWithBlock:^(id key, id obj, BOOL *stop) {
+		[connection->keyCache enumerateKeysAndObjectsWithBlock:^(id key, id obj, BOOL __unused *stop) {
 			
 			__unsafe_unretained NSNumber *rowidNumber = (NSNumber *)key;
 			__unsafe_unretained YapCollectionKey *collectionKey = (YapCollectionKey *)obj;
@@ -5312,7 +5312,7 @@
 	
 	{ // objectCache
 		
-		[connection->objectCache enumerateKeysWithBlock:^(id key, BOOL *stop) {
+		[connection->objectCache enumerateKeysWithBlock:^(id key, BOOL __unused *stop) {
 			
 			__unsafe_unretained YapCollectionKey *cacheKey = (YapCollectionKey *)key;
 			if ([cacheKey.collection isEqualToString:collection])
@@ -5342,7 +5342,7 @@
 	
 	{ // metadataCache
 		
-		[connection->metadataCache enumerateKeysWithBlock:^(id key, BOOL *stop) {
+		[connection->metadataCache enumerateKeysWithBlock:^(id key, BOOL __unused *stop) {
 			
 			__unsafe_unretained YapCollectionKey *cacheKey = (YapCollectionKey *)key;
 			if ([cacheKey.collection isEqualToString:collection])

--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -1029,7 +1029,7 @@
  *
  * @see objectForKey:inCollection:
 **/
-- (NSData *)serializedObjectForKey:(NSString *)key inCollection:(NSString *)collection;
+- (NSData *)serializedObjectForKey:(NSString *)key inCollection:(NSString *)collection
 {
 	if (key == nil) return nil;
 	if (collection == nil) collection = @"";
@@ -2609,7 +2609,7 @@
 **/
 - (void)_enumerateKeysAndMetadataInCollection:(NSString *)collection
                                    usingBlock:(void (^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
-                                   withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter;
+                                   withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter
 {
 	if (block == NULL) return;
 	if (collection == nil) collection = @"";


### PR DESCRIPTION
Fixes XCode warnings generated for:
1) Unused parameters.
2) Type mismatches.
3) Misplaced semicolons in method implementations.
4) Redeclaration of superclass properties (warnings introduced in XCode 6.3).