### PR TITLE
Nullability annotations

### DIFF
--- a/YapDatabase/YapDatabase.h
+++ b/YapDatabase/YapDatabase.h
@@ -5,6 +5,8 @@
 #import "YapDatabaseTransaction.h"
 #import "YapDatabaseExtension.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Welcome to YapDatabase!
  *
@@ -56,8 +58,8 @@
  * Thus to store objects in the database, the objects need only support the NSCoding protocol.
  * You may optionally use a custom serializer/deserializer for the objects and/or metadata.
 **/
-typedef NSData* (^YapDatabaseSerializer)(NSString *collection, NSString *key, id object);
-typedef id (^YapDatabaseDeserializer)(NSString *collection, NSString *key, NSData *data);
+typedef NSData * __nonnull (^YapDatabaseSerializer)(NSString *collection, NSString *key, id object);
+typedef id __nonnull (^YapDatabaseDeserializer)(NSString *collection, NSString *key, NSData *data);
 
 /**
  * The sanitizer block allows you to enforce desired behavior of the objects you put into the database.
@@ -92,7 +94,7 @@ typedef id (^YapDatabaseDeserializer)(NSString *collection, NSString *key, NSDat
  * An example of such a use for the PostSanitizer is discussed in the YapDatabaseCloudKit wiki article:
  * https://github.com/yapstudios/YapDatabase/wiki/YapDatabaseCloudKit
 **/
-typedef id (^YapDatabasePreSanitizer)(NSString *collection, NSString *key, id obj);
+typedef id __nonnull (^YapDatabasePreSanitizer)(NSString *collection, NSString *key, id obj);
 typedef void (^YapDatabasePostSanitizer)(NSString *collection, NSString *key, id obj);
 
 /**
@@ -240,15 +242,15 @@ extern NSString *const YapDatabaseAllKeysRemovedKey;
  * The given serializers and deserializers are used.
  * The given sanitizers are used.
 **/
-- (id)initWithPath:(NSString *)path objectSerializer:(YapDatabaseSerializer)objectSerializer
-                                  objectDeserializer:(YapDatabaseDeserializer)objectDeserializer
-                                  metadataSerializer:(YapDatabaseSerializer)metadataSerializer
-                                metadataDeserializer:(YapDatabaseDeserializer)metadataDeserializer
-                                  objectPreSanitizer:(YapDatabasePreSanitizer)objectPreSanitizer
-                                 objectPostSanitizer:(YapDatabasePostSanitizer)objectPostSanitizer
-                                metadataPreSanitizer:(YapDatabasePreSanitizer)metadataPreSanitizer
-                               metadataPostSanitizer:(YapDatabasePostSanitizer)metadataPostSanitizer
-                                             options:(YapDatabaseOptions *)options;
+- (id)initWithPath:(NSString *)path objectSerializer:(nullable YapDatabaseSerializer)objectSerializer
+                                  objectDeserializer:(nullable YapDatabaseDeserializer)objectDeserializer
+                                  metadataSerializer:(nullable YapDatabaseSerializer)metadataSerializer
+                                metadataDeserializer:(nullable YapDatabaseDeserializer)metadataDeserializer
+                                  objectPreSanitizer:(nullable YapDatabasePreSanitizer)objectPreSanitizer
+                                 objectPostSanitizer:(nullable YapDatabasePostSanitizer)objectPostSanitizer
+                                metadataPreSanitizer:(nullable YapDatabasePreSanitizer)metadataPreSanitizer
+                               metadataPostSanitizer:(nullable YapDatabasePostSanitizer)metadataPostSanitizer
+                                             options:(nullable YapDatabaseOptions *)options;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Properties
@@ -262,11 +264,11 @@ extern NSString *const YapDatabaseAllKeysRemovedKey;
 @property (nonatomic, strong, readonly) YapDatabaseSerializer metadataSerializer;
 @property (nonatomic, strong, readonly) YapDatabaseDeserializer metadataDeserializer;
 
-@property (nonatomic, strong, readonly) YapDatabasePreSanitizer objectPreSanitizer;
-@property (nonatomic, strong, readonly) YapDatabasePostSanitizer objectPostSanitizer;
+@property (nullable, nonatomic, strong, readonly) YapDatabasePreSanitizer objectPreSanitizer;
+@property (nullable, nonatomic, strong, readonly) YapDatabasePostSanitizer objectPostSanitizer;
 
-@property (nonatomic, strong, readonly) YapDatabasePreSanitizer metadataPreSanitizer;
-@property (nonatomic, strong, readonly) YapDatabasePostSanitizer metadataPostSanitizer;
+@property (nullable, nonatomic, strong, readonly) YapDatabasePreSanitizer metadataPreSanitizer;
+@property (nullable, nonatomic, strong, readonly) YapDatabasePostSanitizer metadataPostSanitizer;
 
 @property (nonatomic, copy, readonly) YapDatabaseOptions *options;
 
@@ -504,7 +506,7 @@ extern NSString *const YapDatabaseAllKeysRemovedKey;
 **/
 - (BOOL)registerExtension:(YapDatabaseExtension *)extension
                  withName:(NSString *)extensionName
-               connection:(YapDatabaseConnection *)connection;
+               connection:(nullable YapDatabaseConnection *)connection;
 
 /**
  * Asynchronoulsy starts the extension registration process.
@@ -530,7 +532,7 @@ extern NSString *const YapDatabaseAllKeysRemovedKey;
 **/
 - (void)asyncRegisterExtension:(YapDatabaseExtension *)extension
 					  withName:(NSString *)extensionName
-			   completionBlock:(void(^)(BOOL ready))completionBlock;
+			   completionBlock:(nullable void(^)(BOOL ready))completionBlock;
 
 /**
  * Asynchronoulsy starts the extension registration process.
@@ -559,8 +561,8 @@ extern NSString *const YapDatabaseAllKeysRemovedKey;
 **/
 - (void)asyncRegisterExtension:(YapDatabaseExtension *)extension
                       withName:(NSString *)extensionName
-               completionQueue:(dispatch_queue_t)completionQueue
-               completionBlock:(void(^)(BOOL ready))completionBlock;
+               completionQueue:(nullable dispatch_queue_t)completionQueue
+               completionBlock:(nullable void(^)(BOOL ready))completionBlock;
 
 /**
  * Asynchronoulsy starts the extension registration process.
@@ -595,9 +597,9 @@ extern NSString *const YapDatabaseAllKeysRemovedKey;
 **/
 - (void)asyncRegisterExtension:(YapDatabaseExtension *)extension
                       withName:(NSString *)extensionName
-                    connection:(YapDatabaseConnection *)connection
-               completionQueue:(dispatch_queue_t)completionQueue
-               completionBlock:(void(^)(BOOL ready))completionBlock;
+                    connection:(nullable YapDatabaseConnection *)connection
+               completionQueue:(nullable dispatch_queue_t)completionQueue
+               completionBlock:(nullable void(^)(BOOL ready))completionBlock;
 
 /**
  * DEPRECATED in v2.5
@@ -680,7 +682,7 @@ __attribute((deprecated("Use method asyncRegisterExtension:withName:completionQu
  *     You may optionally pass your own databaseConnection for this method to use.
  *     If you pass nil, an internal databaseConnection will automatically be used.
 **/
-- (void)unregisterExtensionWithName:(NSString *)extensionName connection:(YapDatabaseConnection *)connection;
+- (void)unregisterExtensionWithName:(NSString *)extensionName connection:(nullable YapDatabaseConnection *)connection;
 
 /**
  * Asynchronoulsy starts the extension unregistration process.
@@ -697,7 +699,7 @@ __attribute((deprecated("Use method asyncRegisterExtension:withName:completionQu
  *     The completionBlock will be invoked on the main thread (dispatch_get_main_queue()).
 **/
 - (void)asyncUnregisterExtensionWithName:(NSString *)extensionName
-                         completionBlock:(dispatch_block_t)completionBlock;
+                         completionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * Asynchronoulsy starts the extension unregistration process.
@@ -718,8 +720,8 @@ __attribute((deprecated("Use method asyncRegisterExtension:withName:completionQu
  *     If the extension registration was successful then the ready parameter will be YES.
 **/
 - (void)asyncUnregisterExtensionWithName:(NSString *)extensionName
-                         completionQueue:(dispatch_queue_t)completionQueue
-                         completionBlock:(dispatch_block_t)completionBlock;
+                         completionQueue:(nullable dispatch_queue_t)completionQueue
+                         completionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * Asynchronoulsy starts the extension unregistration process.
@@ -744,9 +746,9 @@ __attribute((deprecated("Use method asyncRegisterExtension:withName:completionQu
  *     If the extension registration was successful then the ready parameter will be YES.
 **/
 - (void)asyncUnregisterExtensionWithName:(NSString *)extensionName
-                              connection:(YapDatabaseConnection *)connection
-                         completionQueue:(dispatch_queue_t)completionQueue
-                         completionBlock:(dispatch_block_t)completionBlock;
+                              connection:(nullable YapDatabaseConnection *)connection
+                         completionQueue:(nullable dispatch_queue_t)completionQueue
+                         completionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * DEPRECATED in v2.5
@@ -797,13 +799,13 @@ __attribute((deprecated("Use method asyncUnregisterExtensionWithName:completionQ
  * Returns the registered extension with the given name.
  * The returned object will be a subclass of YapDatabaseExtension.
 **/
-- (id)registeredExtension:(NSString *)extensionName;
+- (nullable id)registeredExtension:(NSString *)extensionName;
 
 /**
  * Returns all currently registered extensions as a dictionary.
  * The key is the registed name (NSString), and the value is the extension (YapDatabaseExtension subclass).
 **/
-- (NSDictionary *)registeredExtensions;
+- (nullable NSDictionary *)registeredExtensions;
 
 /**
  * Allows you to fetch the registered extension names from the last time the database was run.
@@ -819,7 +821,7 @@ __attribute((deprecated("Use method asyncUnregisterExtensionWithName:completionQ
  * but which are no longer registered. YapDatabase will automatically cleanup these orphaned extensions,
  * and also clear the previouslyRegisteredExtensionNames information at this point.
 **/
-- (NSArray *)previouslyRegisteredExtensionNames;
+- (nullable NSArray *)previouslyRegisteredExtensionNames;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Connection Pooling
@@ -872,3 +874,5 @@ __attribute((deprecated("Use method asyncUnregisterExtensionWithName:completionQ
 @property (atomic, assign, readwrite) NSTimeInterval connectionPoolLifetime;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/YapDatabase/YapDatabaseConnection.h
+++ b/YapDatabase/YapDatabaseConnection.h
@@ -75,6 +75,7 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
 
 
 @interface YapDatabaseConnection : NSObject
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A database connection maintains a strong reference to its parent.
@@ -325,7 +326,7 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
  * The completionBlock will be invoked on the main thread (dispatch_get_main_queue()).
 **/
 - (void)asyncReadWithBlock:(void (^)(YapDatabaseReadTransaction *transaction))block
-           completionBlock:(dispatch_block_t)completionBlock;
+           completionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * Read-only access to the database.
@@ -340,8 +341,8 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
  * If NULL, dispatch_get_main_queue() is automatically used.
 **/
 - (void)asyncReadWithBlock:(void (^)(YapDatabaseReadTransaction *transaction))block
-           completionQueue:(dispatch_queue_t)completionQueue
-           completionBlock:(dispatch_block_t)completionBlock;
+           completionQueue:(nullable dispatch_queue_t)completionQueue
+           completionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * DEPRECATED in v2.5
@@ -396,7 +397,7 @@ __attribute((deprecated("Use method asyncReadWithBlock:completionQueue:completio
  * The completionBlock will be invoked on the main thread (dispatch_get_main_queue()).
 **/
 - (void)asyncReadWriteWithBlock:(void (^)(YapDatabaseReadWriteTransaction *transaction))block
-                completionBlock:(dispatch_block_t)completionBlock;
+                completionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * Read-write access to the database.
@@ -412,8 +413,8 @@ __attribute((deprecated("Use method asyncReadWithBlock:completionQueue:completio
  * If NULL, dispatch_get_main_queue() is automatically used.
 **/
 - (void)asyncReadWriteWithBlock:(void (^)(YapDatabaseReadWriteTransaction *transaction))block
-                completionQueue:(dispatch_queue_t)completionQueue
-                completionBlock:(dispatch_block_t)completionBlock;
+                completionQueue:(nullable dispatch_queue_t)completionQueue
+                completionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * DEPRECATED in v2.5
@@ -712,7 +713,7 @@ __attribute((deprecated("Use method asyncReadWriteWithBlock:completionQueue:comp
  * 
  * @see pragmaAutoVacuum
 **/
-- (void)asyncVacuumWithCompletionBlock:(dispatch_block_t)completionBlock;
+- (void)asyncVacuumWithCompletionBlock:(nullable dispatch_block_t)completionBlock;
 
 /**
  * Performs a VACUUM on the sqlite database.
@@ -731,7 +732,8 @@ __attribute((deprecated("Use method asyncReadWriteWithBlock:completionQueue:comp
  * 
  * @see pragmaAutoVacuum
 **/
-- (void)asyncVacuumWithCompletionQueue:(dispatch_queue_t)completionQueue
-                       completionBlock:(dispatch_block_t)completionBlock;
+- (void)asyncVacuumWithCompletionQueue:(nullable dispatch_queue_t)completionQueue
+                       completionBlock:(nullable dispatch_block_t)completionBlock;
 
+NS_ASSUME_NONNULL_END
 @end

--- a/YapDatabase/YapDatabaseTransaction.h
+++ b/YapDatabase/YapDatabaseTransaction.h
@@ -49,6 +49,7 @@
  * A transaction allows you to safely access the database as needed in a thread-safe and optimized manner.
 **/
 @interface YapDatabaseReadTransaction : NSObject
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Transactions are light-weight objects created by connections.
@@ -69,7 +70,7 @@
  * Keep in mind that transactions are short lived objects.
  * Each transaction is a new/different transaction object.
 **/
-@property (nonatomic, strong, readwrite) id userInfo;
+@property (nullable, nonatomic, strong, readwrite) id userInfo;
 
 #pragma mark Count
 
@@ -83,7 +84,7 @@
  * Returns the total number of keys in the given collection.
  * Returns zero if the collection doesn't exist (or all key/object pairs from the collection have been removed).
 **/
-- (NSUInteger)numberOfKeysInCollection:(NSString *)collection;
+- (NSUInteger)numberOfKeysInCollection:(nullable NSString *)collection;
 
 /**
  * Returns the total number of key/object pairs in the entire database (including all collections).
@@ -100,7 +101,7 @@
 /**
  * Returns a list of all keys in the given collection.
 **/
-- (NSArray *)allKeysInCollection:(NSString *)collection;
+- (NSArray *)allKeysInCollection:(nullable NSString *)collection;
 
 #pragma mark Object & Metadata
 
@@ -108,25 +109,25 @@
  * Object access.
  * Objects are automatically deserialized using database's configured deserializer.
 **/
-- (id)objectForKey:(NSString *)key inCollection:(NSString *)collection;
+- (nullable id)objectForKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * Returns whether or not the given key/collection exists in the database.
 **/
-- (BOOL)hasObjectForKey:(NSString *)key inCollection:(NSString *)collection;
+- (BOOL)hasObjectForKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * Provides access to both object and metadata in a single call.
  *
  * @return YES if the key exists in the database. NO otherwise, in which case both object and metadata will be nil.
 **/
-- (BOOL)getObject:(id *)objectPtr metadata:(id *)metadataPtr forKey:(NSString *)key inCollection:(NSString *)collection;
+- (BOOL)getObject:(__nullable id * __nullable)objectPtr metadata:(__nullable id * __nullable)metadataPtr forKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * Provides access to the metadata.
  * This fetches directly from the metadata dictionary stored in memory, and thus never hits the disk.
 **/
-- (id)metadataForKey:(NSString *)key inCollection:(NSString *)collection;
+- (id)metadataForKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 #pragma mark Primitive
 
@@ -139,7 +140,7 @@
  * 
  * @see objectForKey:inCollection:
 **/
-- (NSData *)serializedObjectForKey:(NSString *)key inCollection:(NSString *)collection;
+- (NSData *)serializedObjectForKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * Primitive access.
@@ -150,7 +151,7 @@
  *
  * @see metadataForKey:inCollection:
 **/
-- (NSData *)serializedMetadataForKey:(NSString *)key inCollection:(NSString *)collection;
+- (NSData *)serializedMetadataForKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * Primitive access.
@@ -161,10 +162,10 @@
  *
  * @see getObject:metadata:forKey:inCollection:
 **/
-- (BOOL)getSerializedObject:(NSData **)serializedObjectPtr
-         serializedMetadata:(NSData **)serializedMetadataPtr
+- (BOOL)getSerializedObject:(NSData * __nullable * __nullable)serializedObjectPtr
+         serializedMetadata:(NSData * __nullable * __nullable)serializedMetadataPtr
                      forKey:(NSString *)key
-               inCollection:(NSString *)collection;
+               inCollection:(nullable NSString *)collection;
 
 #pragma mark Enumerate
 
@@ -192,7 +193,7 @@
  * This uses a "SELECT key FROM database WHERE collection = ?" operation,
  * and then steps over the results invoking the given block handler.
 **/
-- (void)enumerateKeysInCollection:(NSString *)collection
+- (void)enumerateKeysInCollection:(nullable NSString *)collection
                        usingBlock:(void (^)(NSString *key, BOOL *stop))block;
 
 /**
@@ -214,7 +215,7 @@
  * 
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
-- (void)enumerateKeysAndMetadataInCollection:(NSString *)collection
+- (void)enumerateKeysAndMetadataInCollection:(nullable NSString *)collection
                                   usingBlock:(void (^)(NSString *key, id metadata, BOOL *stop))block;
 
 /**
@@ -226,9 +227,9 @@
  * 
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
-- (void)enumerateKeysAndMetadataInCollection:(NSString *)collection
+- (void)enumerateKeysAndMetadataInCollection:(nullable NSString *)collection
                                   usingBlock:(void (^)(NSString *key, id metadata, BOOL *stop))block
-                                  withFilter:(BOOL (^)(NSString *key))filter;
+                                  withFilter:(nullable BOOL (^)(NSString *key))filter;
 
 
 
@@ -259,7 +260,7 @@
  **/
 - (void)enumerateKeysAndMetadataInAllCollectionsUsingBlock:
                                         (void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
-                             withFilter:(BOOL (^)(NSString *collection, NSString *key))filter;
+                             withFilter:(nullable BOOL (^)(NSString *collection, NSString *key))filter;
 
 /**
  * Fast enumeration over all objects in the database.
@@ -271,7 +272,7 @@
  * consider using the alternative version below which provides a filter,
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
-- (void)enumerateKeysAndObjectsInCollection:(NSString *)collection
+- (void)enumerateKeysAndObjectsInCollection:(nullable NSString *)collection
                                  usingBlock:(void (^)(NSString *key, id object, BOOL *stop))block;
 
 /**
@@ -282,9 +283,9 @@
  * If the filter block returns NO, then the block handler is skipped for the given key,
  * which avoids the cost associated with deserializing the object.
 **/
-- (void)enumerateKeysAndObjectsInCollection:(NSString *)collection
+- (void)enumerateKeysAndObjectsInCollection:(nullable NSString *)collection
                                  usingBlock:(void (^)(NSString *key, id object, BOOL *stop))block
-                                 withFilter:(BOOL (^)(NSString *key))filter;
+                                 withFilter:(nullable BOOL (^)(NSString *key))filter;
 
 /**
  * Enumerates all key/object pairs in all collections.
@@ -312,7 +313,7 @@
 **/
 - (void)enumerateKeysAndObjectsInAllCollectionsUsingBlock:
                                             (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block
-                                 withFilter:(BOOL (^)(NSString *collection, NSString *key))filter;
+                                 withFilter:(nullable BOOL (^)(NSString *collection, NSString *key))filter;
 
 /**
  * Fast enumeration over all rows in the database.
@@ -324,7 +325,7 @@
  * consider using the alternative version below which provides a filter,
  * allowing you to skip the serialization step for those rows you're not interested in.
 **/
-- (void)enumerateRowsInCollection:(NSString *)collection
+- (void)enumerateRowsInCollection:(nullable NSString *)collection
                        usingBlock:(void (^)(NSString *key, id object, id metadata, BOOL *stop))block;
 
 /**
@@ -335,9 +336,9 @@
  * If the filter block returns NO, then the block handler is skipped for the given key,
  * which avoids the cost associated with deserializing the object & metadata.
 **/
-- (void)enumerateRowsInCollection:(NSString *)collection
+- (void)enumerateRowsInCollection:(nullable NSString *)collection
                        usingBlock:(void (^)(NSString *key, id object, id metadata, BOOL *stop))block
-                       withFilter:(BOOL (^)(NSString *key))filter;
+                       withFilter:(nullable BOOL (^)(NSString *key))filter;
 
 /**
  * Enumerates all rows in all collections.
@@ -365,7 +366,7 @@
 **/
 - (void)enumerateRowsInAllCollectionsUsingBlock:
                             (void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
-                 withFilter:(BOOL (^)(NSString *collection, NSString *key))filter;
+                 withFilter:(nullable BOOL (^)(NSString *collection, NSString *key))filter;
 
 /**
  * Enumerates over the given list of keys (unordered).
@@ -380,7 +381,7 @@
  * Due to cache optimizations, the items may not be enumerated in the same order as the 'keys' parameter.
 **/
 - (void)enumerateMetadataForKeys:(NSArray *)keys
-                    inCollection:(NSString *)collection
+                    inCollection:(nullable NSString *)collection
              unorderedUsingBlock:(void (^)(NSUInteger keyIndex, id metadata, BOOL *stop))block;
 
 /**
@@ -396,7 +397,7 @@
  * Due to cache optimizations, the items may not be enumerated in the same order as the 'keys' parameter.
 **/
 - (void)enumerateObjectsForKeys:(NSArray *)keys
-                   inCollection:(NSString *)collection
+                   inCollection:(nullable NSString *)collection
             unorderedUsingBlock:(void (^)(NSUInteger keyIndex, id object, BOOL *stop))block;
 
 /**
@@ -412,7 +413,7 @@
  * Due to cache optimizations, the items may not be enumerated in the same order as the 'keys' parameter.
 **/
 - (void)enumerateRowsForKeys:(NSArray *)keys
-                inCollection:(NSString *)collection
+                inCollection:(nullable NSString *)collection
          unorderedUsingBlock:(void (^)(NSUInteger keyIndex, id object, id metadata, BOOL *stop))block;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -435,6 +436,7 @@
 - (id)extension:(NSString *)extensionName;
 - (id)ext:(NSString *)extensionName; // <-- Shorthand (same as extension: method)
 
+NS_ASSUME_NONNULL_END
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -442,6 +444,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @interface YapDatabaseReadWriteTransaction : YapDatabaseReadTransaction
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Under normal circumstances, when a read-write transaction block completes,
@@ -494,7 +497,7 @@
  *   The <collection, key> tuple is used to uniquely identify the row in the database.
  *   If a nil collection is passed, then the collection is implicitly the empty string (@"").
 **/
-- (void)setObject:(id)object forKey:(NSString *)key inCollection:(NSString *)collection;
+- (void)setObject:(nullable id)object forKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * Sets the object & metadata for the given key/collection.
@@ -521,7 +524,7 @@
  *   The metadata is optional. You can pass nil for the metadata is unneeded.
  *   If non-nil then the metadata is also written to the database (metadata is also persistent).
 **/
-- (void)setObject:(id)object forKey:(NSString *)key inCollection:(NSString *)collection withMetadata:(id)metadata;
+- (void)setObject:(nullable id)object forKey:(NSString *)key inCollection:(nullable NSString *)collection withMetadata:(id)metadata;
 
 /**
  * Sets the object & metadata for the given key/collection.
@@ -568,10 +571,10 @@
  * The preSerializedObject is only used if object is non-nil.
  * The preSerializedMetadata is only used if metadata is non-nil.
 **/
-- (void)setObject:(id)object forKey:(NSString *)key inCollection:(NSString *)collection
+- (void)setObject:(nullable id)object forKey:(NSString *)key inCollection:(nullable NSString *)collection
                                                     withMetadata:(id)metadata
-                                                serializedObject:(NSData *)preSerializedObject
-                                              serializedMetadata:(NSData *)preSerializedMetadata;
+                                                serializedObject:(nullable NSData *)preSerializedObject
+                                              serializedMetadata:(nullable NSData *)preSerializedMetadata;
 
 /**
  * If a row with the given key/collection exists, then replaces the object for that row with the new value.
@@ -595,7 +598,7 @@
  *   The <collection, key> tuple is used to uniquely identify the row in the database.
  *   If a nil collection is passed, then the collection is implicitly the empty string (@"").
 **/
-- (void)replaceObject:(id)object forKey:(NSString *)key inCollection:(NSString *)collection;
+- (void)replaceObject:(nullable id)object forKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * If a row with the given key/collection exists, then replaces the object for that row with the new value.
@@ -630,8 +633,8 @@
  *   It is assumed that preSerializedObject is equal to what we would get if we ran the object through
  *   the database's configured objectSerializer.
 **/
-- (void)replaceObject:(id)object forKey:(NSString *)key inCollection:(NSString *)collection
-                                                withSerializedObject:(NSData *)preSerializedObject;
+- (void)replaceObject:(nullable id)object forKey:(NSString *)key inCollection:(nullable NSString *)collection
+                                                withSerializedObject:(nullable NSData *)preSerializedObject;
 
 /**
  * If a row with the given key/collection exists, then replaces the metadata for that row with the new value.
@@ -655,7 +658,7 @@
  *   The <collection, key> tuple is used to uniquely identify the row in the database.
  *   If a nil collection is passed, then the collection is implicitly the empty string (@"").
 **/
-- (void)replaceMetadata:(id)metadata forKey:(NSString *)key inCollection:(NSString *)collection;
+- (void)replaceMetadata:(nullable id)metadata forKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * If a row with the given key/collection exists, then replaces the metadata for that row with the new value.
@@ -690,8 +693,8 @@
  *   It is assumed that preSerializedMetadata is equal to what we would get if we ran the metadata through
  *   the database's configured metadataSerializer.
 **/
-- (void)replaceMetadata:(id)metadata forKey:(NSString *)key inCollection:(NSString *)collection
-                                                  withSerializedMetadata:(NSData *)preSerializedMetadata;
+- (void)replaceMetadata:(nullable id)metadata forKey:(NSString *)key inCollection:(nullable NSString *)collection
+                                                  withSerializedMetadata:(nullable NSData *)preSerializedMetadata;
 
 #pragma mark Touch
 
@@ -727,8 +730,8 @@
  * Normally, altering the database while enumerating it will result in an exception (just like altering an array
  * while enumerating it). However, it's safe to touch objects during enumeration.
 **/
-- (void)touchObjectForKey:(NSString *)key inCollection:(NSString *)collection;
-- (void)touchMetadataForKey:(NSString *)key inCollection:(NSString *)collection;
+- (void)touchObjectForKey:(NSString *)key inCollection:(nullable NSString *)collection;
+- (void)touchMetadataForKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 #pragma mark Remove
 
@@ -738,22 +741,23 @@
  * This method is automatically called if you invoke
  * setObject:forKey:collection: and pass a nil object.
 **/
-- (void)removeObjectForKey:(NSString *)key inCollection:(NSString *)collection;
+- (void)removeObjectForKey:(NSString *)key inCollection:(nullable NSString *)collection;
 
 /**
  * Deletes the database rows with the given keys in the given collection.
 **/
-- (void)removeObjectsForKeys:(NSArray *)keys inCollection:(NSString *)collection;
+- (void)removeObjectsForKeys:(NSArray *)keys inCollection:(nullable NSString *)collection;
 
 /**
  * Deletes every key/object pair from the given collection.
  * No trace of the collection will remain afterwards.
 **/
-- (void)removeAllObjectsInCollection:(NSString *)collection;
+- (void)removeAllObjectsInCollection:(nullable NSString *)collection;
 
 /**
  * Removes every key/object pair in the entire database (from all collections).
 **/
 - (void)removeAllObjectsInAllCollections;
 
+NS_ASSUME_NONNULL_END
 @end


### PR DESCRIPTION
Have annotated the following:

- [x] YapDatabase
- [x] YapDatabaseConnection
- [x] YapDatabaseReadTransaction
- [x] YapDatabaseReadWriteTransaction

These generate better Swift interfaces with correct support for Optionals.

![creating read transaction](https://cloud.githubusercontent.com/assets/309420/7158075/e798011a-e36d-11e4-982b-85d920a85bd8.png)

Note that on the current `master`, the signature of this block is `(YapDatabaseReadTransaction!) -> Void`

![read transaction](https://cloud.githubusercontent.com/assets/309420/7158077/ec486308-e36d-11e4-893e-6eed090cb58e.png)

Note that on the current `master`, the collection parameter is required (it defaults to `@""` so is actually optional), and most importantly, the return type is not marked as an optional. 

Note also, that this should be a version bump, as current existing Swift codebases may fail to compile without changes.


