### PR TITLE
Changed YDB_NodeDeleteRules to use NS_OPTIONS

### DIFF
--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipEdge.h
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipEdge.h
@@ -16,21 +16,19 @@
  * https://github.com/yapstudios/YapDatabase/wiki/Relationships
 **/
 
-enum {
-	// notify only
-	YDB_NotifyIfSourceDeleted      = 1 << 0,
-	YDB_NotifyIfDestinationDeleted = 1 << 1,
-	
-	// one-to-one
-	YDB_DeleteSourceIfDestinationDeleted = 1 << 2,
-	YDB_DeleteDestinationIfSourceDeleted = 1 << 3,
-	
-	// one-to-many & many-to-many
-	YDB_DeleteSourceIfAllDestinationsDeleted = 1 << 4,
-	YDB_DeleteDestinationIfAllSourcesDeleted = 1 << 5,
+typedef NS_OPTIONS(uint16_t, YDB_NodeDeleteRules) {
+    // notify only
+    YDB_NotifyIfSourceDeleted      = 1 << 0,
+    YDB_NotifyIfDestinationDeleted = 1 << 1,
+    
+    // one-to-one
+    YDB_DeleteSourceIfDestinationDeleted = 1 << 2,
+    YDB_DeleteDestinationIfSourceDeleted = 1 << 3,
+    
+    // one-to-many & many-to-many
+    YDB_DeleteSourceIfAllDestinationsDeleted = 1 << 4,
+    YDB_DeleteDestinationIfAllSourcesDeleted = 1 << 5,
 };
-typedef uint16_t YDB_NodeDeleteRules;
-
 
 @interface YapDatabaseRelationshipEdge : NSObject <NSCoding, NSCopying>
 


### PR DESCRIPTION
Using NS_OPTIONS is better than using a C-style enum because NS_OPTIONS (and NS_ENUM) are fully compatible with Swift, whereas a C-style enum is more difficult to access in Swift.