### PR TITLE
fixes EXC_BAD_INSTRUCTION crash when syncing for the first time

### DIFF
--- a/Examples/CloudKitTodo/CloudKitTodo/CloudKitManager.m
+++ b/Examples/CloudKitTodo/CloudKitTodo/CloudKitManager.m
@@ -647,7 +647,7 @@ static NSString *const Key_ServerChangeToken   = @"serverChangeToken";
 			} completionBlock:^{
 				
 				if (moreComing) {
-					[self _fetchRecordChangesWithCompletionHandler:completionHandler];
+					[self fetchRecordChangesWithCompletionHandler:completionHandler];
 				}
 				
 				if (completionHandler)


### PR DESCRIPTION
…and there is a lot of data.

The dispatch_resume in line 660 crashed since the second time round, the fetchQueue was never suspended
(which is done in the fetchRecordChangesWithCompetionHandler: method).