### PR TITLE
Add support for running tests on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: objective-c
+
+script:
+  - xctool -project ./Testing/Xcode-desktop/YapDatabase.xcodeproj -scheme YapDatabase -sdk macosx -arch x86_64 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: beta-xcode6.3
 
 script:
   - xctool -project ./Testing/Xcode-desktop/YapDatabase.xcodeproj -scheme YapDatabase -sdk macosx -arch x86_64 test

--- a/Testing/Xcode-desktop/YapDatabase.xcodeproj/xcshareddata/xcschemes/YapDatabase.xcscheme
+++ b/Testing/Xcode-desktop/YapDatabase.xcodeproj/xcshareddata/xcschemes/YapDatabase.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC84FF8A175130D2003BFBB2"
+               BuildableName = "YapDatabase.app"
+               BlueprintName = "YapDatabase"
+               ReferencedContainer = "container:YapDatabase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC84FFAA175130D3003BFBB2"
+               BuildableName = "YapDatabaseTests.xctest"
+               BlueprintName = "YapDatabaseTests"
+               ReferencedContainer = "container:YapDatabase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC84FFAA175130D3003BFBB2"
+               BuildableName = "YapDatabaseTests.xctest"
+               BlueprintName = "YapDatabaseTests"
+               ReferencedContainer = "container:YapDatabase.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC84FF8A175130D2003BFBB2"
+            BuildableName = "YapDatabase.app"
+            BlueprintName = "YapDatabase"
+            ReferencedContainer = "container:YapDatabase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC84FF8A175130D2003BFBB2"
+            BuildableName = "YapDatabase.app"
+            BlueprintName = "YapDatabase"
+            ReferencedContainer = "container:YapDatabase.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC84FF8A175130D2003BFBB2"
+            BuildableName = "YapDatabase.app"
+            BlueprintName = "YapDatabase"
+            ReferencedContainer = "container:YapDatabase.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Builds and runs the existing test suite for the OS X target. For the time being we have to use a beta image on Travis because of the nullability annotations introduced in Xcode 6.3: http://blog.travis-ci.com/2015-05-26-xcode-63-beta-general-availability/

@robbiehanson Once merged you just need to go to https://travis-ci.org/profile and turn on Travis for yapstudios/YapDatabase.

Cheers!
