### PR TITLE
Issue 226 made extension and ext methods return types nullable 

### DIFF
--- a/YapDatabase/YapDatabaseTransaction.h
+++ b/YapDatabase/YapDatabaseTransaction.h
@@ -442,8 +442,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @see [YapDatabase registerExtension:withName:]
 **/
-- (id)extension:(NSString *)extensionName;
-- (id)ext:(NSString *)extensionName; // <-- Shorthand (same as extension: method)
+- (nullable id)extension:(NSString *)extensionName;
+- (nullable id)ext:(NSString *)extensionName; // <-- Shorthand (same as extension: method)
 
 NS_ASSUME_NONNULL_END
 @end

--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -3826,7 +3826,7 @@
  *
  * @see [YapDatabase registerExtension:withName:]
 **/
-- (id)extension:(NSString *)extensionName
+- (nullable id)extension:(NSString *)extensionName
 {
 	// This method is PUBLIC
 	
@@ -3861,7 +3861,7 @@
 	return extTransaction;
 }
 
-- (id)ext:(NSString *)extensionName
+- (nullable id)ext:(NSString *)extensionName
 {
 	// This method is PUBLIC
 	


### PR DESCRIPTION
Making these two nullable allows you to check if an extension is setup or not in Swift. This is needed if you register your view extensions asynchronously and need to check if your extension exists before updating your mappings. With these made nullable you can now do this in Swift:

```if (transaction.ext(Ext_View_SomeView) != nil) { ... }```

I ran the tests in the project successfully and also used this change in my own app that uses YapDatabase and have had no issues so far.