### PR TITLE
Aggregate function parameter ignored

### DIFF
--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -155,7 +155,7 @@
 {
 	if (queryString == nil) return nil;
 	
-	return [self queryWithAggregateFunction:nil
+	return [self queryWithAggregateFunction:aggregateFunction
 	                            queryString:queryString
 	                             parameters:queryParameters
 	                         paramLocations:nil];


### PR DESCRIPTION
The `aggregateFunction` parameter in `YapDatabaseQuery`'s `+queryWithAggregateFunction:string:parameters:` is currently ignored.  This PR fixes the issue.