### PR TITLE
Added more options to using YapDatabase with SQLCipher

### DIFF
--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -763,6 +763,39 @@ NSString *const YapDatabaseNotificationKey           = @"notification";
 			return NO;
 		}
 		
+        //Setting the PBKDF2 default iteration number (this will have effect next time database is opened)
+        if (options.cipherDefaultkdfIterNumber > 0) {
+            char *errorMsg;
+            NSString *pragmaCommand = [NSString stringWithFormat:@"PRAGMA cipher_default_kdf_iter = %lu", (unsigned long)options.cipherDefaultkdfIterNumber];
+            if (sqlite3_exec(sqlite, [pragmaCommand UTF8String], NULL, NULL, &errorMsg) != SQLITE_OK)
+            {
+                YDBLogError(@"failed to set database cipher_default_kdf_iter: %s", errorMsg);
+                return NO;
+            }
+        }
+        
+        //Setting the PBKDF2 iteration number
+        if (options.kdfIterNumber > 0) {
+            char *errorMsg;
+            NSString *pragmaCommand = [NSString stringWithFormat:@"PRAGMA kdf_iter = %lu", (unsigned long)options.kdfIterNumber];
+            if (sqlite3_exec(sqlite, [pragmaCommand UTF8String], NULL, NULL, &errorMsg) != SQLITE_OK)
+            {
+                YDBLogError(@"failed to set database kdf_iter: %s", errorMsg);
+                return NO;
+            }
+        }
+        
+        //Setting the encrypted database page size
+        if (options.cipherPageSize > 0) {
+            char *errorMsg;
+            NSString *pragmaCommand = [NSString stringWithFormat:@"PRAGMA cipher_page_size = %lu", (unsigned long)options.cipherPageSize];
+            if (sqlite3_exec(sqlite, [pragmaCommand UTF8String], NULL, NULL, &errorMsg) != SQLITE_OK)
+            {
+                YDBLogError(@"failed to set database cipher_page_size: %s", errorMsg);
+                return NO;
+            }
+        }
+        
 		int status = sqlite3_key(sqlite, [keyData bytes], (int)[keyData length]);
 		if (status != SQLITE_OK)
 		{

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -168,6 +168,59 @@ typedef NSData* (^YapDatabaseCipherKeyBlock)(void);
  * Important: If you do not set a cipherKeyBlock the database will NOT be configured with encryption.
 **/
 @property (nonatomic, copy, readwrite) YapDatabaseCipherKeyBlock cipherKeyBlock;
+
+/**
+ * Set the PBKDF2 iteration number for deriving the key to the SQLCipher database.
+ *
+ * This is the PBKDF2 iteration number that will be passed to SQLCipher via the 'kdf_iter' pragma.
+ * This parameter will be used everytime the database is openened and you must not change it,
+ * otherwise SQLCipher will not be able to decrypt it.
+ * https://www.zetetic.net/sqlcipher/sqlcipher-api/#kdf_iter
+ *
+ * You must use the 'YapDatabase/SQLCipher' subspec
+ * in your Podfile for this option to take effect.
+ *
+ * This parameter isn't compulsory to a SQLCipher database but it is useful if you want
+ * to customize the iteration count (for performance reasons) of PBKDF.
+ * Default is 64,000 PBKDF2 iterations (effectively 256,000 SHA1 operations)
+ **/
+@property (nonatomic, assign, readwrite) NSUInteger kdfIterNumber;
+
+/**
+ * Set the PBKDF2 iteration number for the SQLCipher database.
+ *
+ * In some very specific cases, it is not possible to call 'kdf_iter' (@see kdfIterNumber)
+ * as one of the first operations on a database. In these cases cipherDefaultkdfIterNumber
+ * can be used to globally alter the default number of PBKDF2 iterations used when opening a database.
+ *
+ * This is the PBKDF2 iteration number that will be passed to SQLCipher via the 'cipher_default_kdf_iter' pragma.
+ * This parameter will be used everytime the database is openened and you must not change it,
+ * otherwise SQLCipher will not be able to decrypt it.
+ * https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_default_kdf_iter
+ *
+ * You must use the 'YapDatabase/SQLCipher' subspec
+ * in your Podfile for this option to take effect.
+ *
+ * This parameter isn't compulsory to a SQLCipher database but it is useful if you want
+ * to customize the iteration count (for performance reasons) of PBKDF.
+ **/
+@property (nonatomic, assign, readwrite) NSUInteger cipherDefaultkdfIterNumber;
+
+/**
+ * Set the page size for the encrypted database. The default page size is 1024 bytes.
+ *
+ * This is the adjusted page size that will be passed to SQLCipher via the 'cipher_page_size' pragma.
+ * This parameter will be used everytime the database is openened and you must not change it,
+ * otherwise SQLCipher will not be able to decrypt it.
+ * https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_page_size
+ *
+ * You must use the 'YapDatabase/SQLCipher' subspec
+ * in your Podfile for this option to take effect.
+ *
+ * This parameter isn't compulsory to a SQLCipher database but it is useful if you want
+ * to customize the page size of your encrypted database.
+ **/
+@property (nonatomic, assign, readwrite) NSUInteger cipherPageSize;
 #endif
 
 /**

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -21,6 +21,9 @@
 @synthesize pragmaMMapSize = pragmaMMapSize;
 #ifdef SQLITE_HAS_CODEC
 @synthesize cipherKeyBlock = cipherKeyBlock;
+@synthesize kdfIterNumber = kdfIterNumber;
+@synthesize cipherDefaultkdfIterNumber = cipherDefaultkdfIterNumber;
+@synthesize cipherPageSize = cipherPageSize;
 #endif
 @synthesize aggressiveWALTruncationSize = aggressiveWALTruncationSize;
 
@@ -48,6 +51,9 @@
 	copy->pragmaMMapSize = pragmaMMapSize;
 #ifdef SQLITE_HAS_CODEC
     copy->cipherKeyBlock = cipherKeyBlock;
+    copy->kdfIterNumber = kdfIterNumber;
+    copy->cipherDefaultkdfIterNumber = cipherDefaultkdfIterNumber;
+    copy->cipherPageSize = cipherPageSize;
 #endif
 	copy->aggressiveWALTruncationSize = aggressiveWALTruncationSize;
 	


### PR DESCRIPTION
- Added cipherPageSize property to YapDatabaseOptions allowing to customise the encrypted database page size
- Added kdfIterNumber and cipherDefaultkdfIterNumber allowing to customise the PBKDF2 iteration number for database key derivation.

These options allow one to customise more deeply YapDatabase usage with SQLCipher.