### PR TITLE
[YAP-241]: Adds nullable attribute to a property which defaults to nil

### DIFF
--- a/YapDatabase/Extensions/Views/YapDatabaseViewOptions.h
+++ b/YapDatabase/Extensions/Views/YapDatabaseViewOptions.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * The default value is nil.
 **/
-@property (nonatomic, strong, readwrite) YapWhitelistBlacklist *allowedCollections;
+@property (nullable, nonatomic, strong, readwrite) YapWhitelistBlacklist *allowedCollections;
 
 /**
  * You can configure the view to skip the initial view population.


### PR DESCRIPTION
In `YapDatabaseViewOptions` which is bracketed by `NS_ASSUME_NONNULL_BEGIN/END` clauses, there is a property which defaults to nil, and should therefore be an optional, however, it is not marked as nullable.