### PR TITLE
[YAP-244]: Adds nullable attribute to properties consistently.

### DIFF
--- a/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitOptions.h
+++ b/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitOptions.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * The default value is nil.
 **/
-@property (nonatomic, strong, readwrite) YapWhitelistBlacklist *allowedCollections;
+@property (nonatomic, strong, readwrite, nullable) YapWhitelistBlacklist *allowedCollections;
 
 
 // Todo: Need ability to set default options for CKModifyRecordsOperation

--- a/YapDatabase/Extensions/RTreeIndex/YapDatabaseRTreeIndexOptions.h
+++ b/YapDatabase/Extensions/RTreeIndex/YapDatabaseRTreeIndexOptions.h
@@ -36,6 +36,6 @@
  *
  * The default value is nil.
 **/
-@property (nonatomic, strong, readwrite) YapWhitelistBlacklist *allowedCollections;
+@property (nonatomic, strong, readwrite, nullable) YapWhitelistBlacklist *allowedCollections;
 
 @end

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipOptions.h
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipOptions.h
@@ -59,7 +59,7 @@ typedef _Nonnull id (^YapDatabaseRelationshipFilePathDecryptor)(NSData *data);
  *
  * The default value is nil.
 **/
-@property (nonatomic, strong, readwrite) YapWhitelistBlacklist *allowedCollections;
+@property (nonatomic, strong, readwrite, nullable) YapWhitelistBlacklist *allowedCollections;
 
 /**
  * The relationship extension allows you to create relationships between objects in the database & files on disk.

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexOptions.h
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexOptions.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * The default value is nil.
 **/
-@property (nonatomic, strong, readwrite) YapWhitelistBlacklist *allowedCollections;
+@property (nonatomic, strong, readwrite, nullable) YapWhitelistBlacklist *allowedCollections;
 
 @end
 

--- a/YapDatabase/Extensions/Views/YapDatabaseViewOptions.h
+++ b/YapDatabase/Extensions/Views/YapDatabaseViewOptions.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * The default value is nil.
 **/
-@property (nullable, nonatomic, strong, readwrite) YapWhitelistBlacklist *allowedCollections;
+@property (nonatomic, strong, readwrite, nullable) YapWhitelistBlacklist *allowedCollections;
 
 /**
  * You can configure the view to skip the initial view population.

--- a/YapDatabase/YapDatabase.h
+++ b/YapDatabase/YapDatabase.h
@@ -312,11 +312,11 @@ extern NSString *const YapDatabaseAllKeysRemovedKey;
 @property (nonatomic, strong, readonly) YapDatabaseSerializer metadataSerializer;
 @property (nonatomic, strong, readonly) YapDatabaseDeserializer metadataDeserializer;
 
-@property (nullable, nonatomic, strong, readonly) YapDatabasePreSanitizer objectPreSanitizer;
-@property (nullable, nonatomic, strong, readonly) YapDatabasePostSanitizer objectPostSanitizer;
+@property (nonatomic, strong, readonly, nullable) YapDatabasePreSanitizer objectPreSanitizer;
+@property (nonatomic, strong, readonly, nullable) YapDatabasePostSanitizer objectPostSanitizer;
 
-@property (nullable, nonatomic, strong, readonly) YapDatabasePreSanitizer metadataPreSanitizer;
-@property (nullable, nonatomic, strong, readonly) YapDatabasePostSanitizer metadataPostSanitizer;
+@property (nonatomic, strong, readonly, nullable) YapDatabasePreSanitizer metadataPreSanitizer;
+@property (nonatomic, strong, readonly, nullable) YapDatabasePostSanitizer metadataPostSanitizer;
 
 @property (nonatomic, copy, readonly) YapDatabaseOptions *options;
 

--- a/YapDatabase/YapDatabaseTransaction.h
+++ b/YapDatabase/YapDatabaseTransaction.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Keep in mind that transactions are short lived objects.
  * Each transaction is a new/different transaction object.
 **/
-@property (nullable, nonatomic, strong, readwrite) id userInfo;
+@property (nonatomic, strong, readwrite, nullable) id userInfo;
 
 #pragma mark Count
 


### PR DESCRIPTION
There were more `nullable` attributes missing from properties which should be optionals. Also, I've edited existing `nullable` attributes so that they're added to the list of property attributes so that nullable is added consistently at the end.