### PR TITLE
Fix compilation error in SearchResultsExample

### DIFF
--- a/Examples/SearchResultsExample/Podfile.lock
+++ b/Examples/SearchResultsExample/Podfile.lock
@@ -7,9 +7,9 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - YapDatabase (2.7.3):
-    - YapDatabase/standard (= 2.7.3)
-  - YapDatabase/standard (2.7.3):
+  - YapDatabase (2.7.7):
+    - YapDatabase/standard (= 2.7.7)
+  - YapDatabase/standard (2.7.7):
     - CocoaLumberjack (~> 2)
 
 DEPENDENCIES:
@@ -17,10 +17,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   YapDatabase:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  YapDatabase: 6d6a30e97face6c3158830823c27614afe83e1e0
+  YapDatabase: a7a1ae3e0f89c319e3b22615c2351987fbbdbded
 
 COCOAPODS: 0.39.0

--- a/Examples/SearchResultsExample/Pods/Headers/Private/YapDatabase/yap_vfs_shim.h
+++ b/Examples/SearchResultsExample/Pods/Headers/Private/YapDatabase/yap_vfs_shim.h
@@ -1,0 +1,1 @@
+../../../../../../YapDatabase/Internal/yap_vfs_shim.h

--- a/Examples/SearchResultsExample/Pods/Local Podspecs/YapDatabase.podspec.json
+++ b/Examples/SearchResultsExample/Pods/Local Podspecs/YapDatabase.podspec.json
@@ -1,21 +1,22 @@
 {
   "name": "YapDatabase",
-  "version": "2.7.3",
+  "version": "2.7.7",
   "summary": "A key/value store built atop sqlite for iOS & Mac.",
   "homepage": "https://github.com/yapstudios/YapDatabase",
   "license": "MIT",
-  "platforms": {
-    "ios": "6.0",
-    "osx": "10.8"
-  },
   "authors": {
     "Robbie Hanson": "robbiehanson@deusty.com"
   },
   "source": {
     "git": "https://github.com/yapstudios/YapDatabase.git",
-    "tag": "2.7.3"
+    "tag": "2.7.7"
   },
-  "module_map": "module.modulemap",
+  "platforms": {
+    "osx": "10.8",
+    "ios": "6.0",
+    "tvos": "9.0"
+  },
+  "module_map": "Framework/module.modulemap",
   "libraries": "c++",
   "default_subspecs": "standard",
   "subspecs": [
@@ -27,7 +28,7 @@
           "~> 2"
         ]
       },
-      "source_files": "YapDatabase/**/*.{h,m,mm}",
+      "source_files": "YapDatabase/**/*.{h,m,mm,c}",
       "private_header_files": "YapDatabase/**/Internal/*.h",
       "requires_arc": true
     },
@@ -41,11 +42,11 @@
           "~> 2"
         ]
       },
-      "source_files": "YapDatabase/**/*.{h,m,mm}",
-      "private_header_files": "YapDatabase/**/Internal/*.h",
       "xcconfig": {
         "OTHER_CFLAGS": "$(inherited) -DSQLITE_HAS_CODEC"
       },
+      "source_files": "YapDatabase/**/*.{h,m,mm,c}",
+      "private_header_files": "YapDatabase/**/Internal/*.h",
       "requires_arc": true
     }
   ]

--- a/Examples/SearchResultsExample/Pods/Manifest.lock
+++ b/Examples/SearchResultsExample/Pods/Manifest.lock
@@ -7,9 +7,9 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - YapDatabase (2.7.3):
-    - YapDatabase/standard (= 2.7.3)
-  - YapDatabase/standard (2.7.3):
+  - YapDatabase (2.7.7):
+    - YapDatabase/standard (= 2.7.7)
+  - YapDatabase/standard (2.7.7):
     - CocoaLumberjack (~> 2)
 
 DEPENDENCIES:
@@ -17,10 +17,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   YapDatabase:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  YapDatabase: 6d6a30e97face6c3158830823c27614afe83e1e0
+  YapDatabase: a7a1ae3e0f89c319e3b22615c2351987fbbdbded
 
 COCOAPODS: 0.39.0

--- a/Examples/SearchResultsExample/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/SearchResultsExample/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,223 +7,225 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		04CCD002FBFEEF1B1D12F5F5BD539845 /* YapDatabaseViewTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = D653BE26B7A99661153069DAF16D83CB /* YapDatabaseViewTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		04E148442E97995074B8EE528BEA39C5 /* YapDatabaseConnectionDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 37C151B90C5FCF2D8043FFEB4A429879 /* YapDatabaseConnectionDefaults.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0576ACF3B0E87D02956EBEFC2183B55E /* YapDatabaseViewPage.h in Headers */ = {isa = PBXBuildFile; fileRef = F494133C04490CA3D8FC7E62CEE884C0 /* YapDatabaseViewPage.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0600CF953F3A3AB31492A85FD1C7834C /* YapMemoryTable.h in Headers */ = {isa = PBXBuildFile; fileRef = F04626AEBFE6457A271D954F7CA0D553 /* YapMemoryTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		08805ED592529C6775FBF1FE3A8524EE /* NSDictionary+YapDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = DA289EF9CA70E6A604040A2F59F322B4 /* NSDictionary+YapDatabase.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		08CF982D111FFA79CAC3653E45EEB4AC /* YapDatabaseCloudKitTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 267A9AA89552FC258F07308F9B38435C /* YapDatabaseCloudKitTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		098EBE80DDFC9CB575870E519A5DE302 /* YapDatabaseSearchResultsViewOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B6DEF61AA4581CA87266F8C56DB83A /* YapDatabaseSearchResultsViewOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B99BF1B7B07BD8FA21BEF07E6C2E3A3 /* YapDatabaseViewState.m in Sources */ = {isa = PBXBuildFile; fileRef = B92AE6EACFBDEE7B2B334CD4E8066E6F /* YapDatabaseViewState.m */; };
-		0EBF1BA9149B0AD36479E5A44B08E264 /* YapDatabaseViewState.h in Headers */ = {isa = PBXBuildFile; fileRef = 880F13116E8C6A5F63C531B128893E71 /* YapDatabaseViewState.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0EE577EC5BB5B2F7CB719DF2D31CF06B /* YapDatabaseOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = CC69A73AC48E67BCD250D1F12B6382A3 /* YapDatabaseOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		10E6A6CE536B13D9D49C7B1E7B36CE0D /* YapDatabaseFullTextSearchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 00EA9E27554304E93282EF5BF2E2F20E /* YapDatabaseFullTextSearchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		12C40074260E39955F2ED650A0677B10 /* YapDatabaseViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F42CE7A134CACC769CC43F3957390BC /* YapDatabaseViewTransaction.m */; };
-		14F82CD3064EC08B81CADCFF9B37262B /* YapDatabaseConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = 67C010093856E1FF19E3EA958E6C99A4 /* YapDatabaseConnectionState.m */; };
-		156F4E1FF3061708E3593B5554286DED /* YapDatabaseRelationshipConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = F190E14122FA297955A39058A14DADAA /* YapDatabaseRelationshipConnection.m */; };
-		16034079F04250DB23239218E29ABEF4 /* YapDatabaseSecondaryIndexHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = AECBB70932A98FE391CEE384ED25F3BE /* YapDatabaseSecondaryIndexHandler.m */; };
-		184F145E3AD0C24D984ED5657212924F /* YapDatabaseSecondaryIndexSetup.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DAAEC926B805B901CD33E8FED183A7D /* YapDatabaseSecondaryIndexSetup.m */; };
-		1A0BABF12635A41AB0427834C72B4F8C /* YapCache.h in Headers */ = {isa = PBXBuildFile; fileRef = AA1D1F3C59C1B72C6ADFAF92C866814B /* YapCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1CF32A72CF73C68E61E21BB899E5413B /* YapDatabaseViewConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = B216B4F4B0C0AD0647C1773C5411B0AF /* YapDatabaseViewConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0052DCA0BB2C599299DCF7959B8D19FD /* YapDatabaseOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 162D9FAD9D93CE3DDAEFA86842441C12 /* YapDatabaseOptions.m */; };
+		044D69FB400BE58D50A7F15F7CC6EB39 /* YapDatabaseViewRangeOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 61E46EC80448C8EFF19BB2C7964CC2B9 /* YapDatabaseViewRangeOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0545835D13DC12F701EAE172A2826179 /* YapDatabaseTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CFA4DACD9D17D57D8DB524B19AB3CB8 /* YapDatabaseTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		063D846DFF2139ACB0C80572A9D3EA58 /* YDBCKChangeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C8258F93F925D14536055202725330D /* YDBCKChangeSet.m */; };
+		0763A9B62BFAE510BDA852D3208B61FC /* YapDatabaseConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = 078C605F00CEEB5C2DFC1B245FB5EEAC /* YapDatabaseConnectionState.m */; };
+		0966B10349DC4693FF2EDAA975AD79DE /* YDBCKChangeQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5287261CF2C001B5EDF9407BD09BEB /* YDBCKChangeQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		09A9C0CE17B41B6BA998B4EA2AD06FE9 /* YapDatabaseFullTextSearchTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 3422204C401A303ED132EEC30520C8E4 /* YapDatabaseFullTextSearchTransaction.m */; };
+		0A0CF6EE221D537254577D6F651E3EA0 /* YapMurmurHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 38AE55FAD5B609795FBAE530C6F43A18 /* YapMurmurHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0AD3D149FC861A4DE6751E4B67EAD941 /* YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E71E4B9CDAF788A2A0BBE9BF195EF99 /* YapDatabase.m */; };
+		0B5C76380BE18724F6AF8A0636C6AD01 /* YapDatabaseSecondaryIndexOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = F2F5E67D00ACB410C6E912248E01D1C0 /* YapDatabaseSecondaryIndexOptions.m */; };
+		0B906A7F0132144753DE229DE82B5A4A /* YapDatabaseView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B6D235FBFBDA00EB1C229E2A64D1EA4 /* YapDatabaseView.m */; };
+		0BD1E0F43ED3C603C6BEDBA9E91C7310 /* YDBCKRecordTableInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = EBF43A8365E5A6D7C46B8B7D3D415E40 /* YDBCKRecordTableInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0E84BFCDA024D21036CD240467062961 /* YapDatabaseViewOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = DDC510E8CB2E54F0BA6D047EB208F209 /* YapDatabaseViewOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1083BFADC5602922E36CA7365859DE40 /* YapDatabaseFilteredView.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11C2496DB1803F7638E08D3492D68 /* YapDatabaseFilteredView.m */; };
+		12100F28EC093016F1D6FB7786E35017 /* YapDatabaseFilteredViewTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = FB00C2EB2AC33870D8D45FAB2C817702 /* YapDatabaseFilteredViewTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		129E51693FB1E76FBF5AB4BBF59BF271 /* YapDatabaseExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 205A1BB1019E926556F1C327165E05E7 /* YapDatabaseExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		145C85F0E4CEF0CD78E108CA575D2388 /* YapDatabaseCloudKitOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FB3B46CDE27687DBD28680B7CBBE90 /* YapDatabaseCloudKitOptions.m */; };
+		16203529550648AF674A035E2167C32A /* YapSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F267CC1687E514DE47803149EC22F46 /* YapSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		17A339183796C623F42028A3B3D860B1 /* YapDatabaseFullTextSearchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 223F025287AF6C7CF6F7EED41CAC94E4 /* YapDatabaseFullTextSearchHandler.m */; };
+		181BF7039492E946566B88D6F91FD529 /* YapDatabaseSearchResultsViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 620858EE8185FD9C37CAE749CFF95B5E /* YapDatabaseSearchResultsViewTransaction.m */; };
+		182BA6BB112EB99274A01DFC259498FF /* YapDatabaseRelationshipTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = EF159BA48F7565AE875E45187544A164 /* YapDatabaseRelationshipTransaction.m */; };
+		1837A7198FC4C673C70B17EB822DE48A /* YapDatabaseRTreeIndexOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 35276D85BBC346627857A00348F6BBD0 /* YapDatabaseRTreeIndexOptions.m */; };
+		1A33A3DC9F70D6A7CF8AF05F58FD528C /* YDBCKChangeSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 83FAA2CD04B052E630C86A9E85786558 /* YDBCKChangeSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1AD88C9AC3B7F07857888AC96032CBA7 /* YapMurmurHash.m in Sources */ = {isa = PBXBuildFile; fileRef = C35276CDCCD93A2440E921B2FD476499 /* YapMurmurHash.m */; };
+		1B87E357A87E9E93B79A67178105C49C /* YapDatabaseView.h in Headers */ = {isa = PBXBuildFile; fileRef = 170866E29089324B75A4AF806DEE1C8B /* YapDatabaseView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B96654C249E0E3440938EE0D6023632 /* YDBCKRecordTableInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 6219C4A647C73AB9631E933DAEA82790 /* YDBCKRecordTableInfo.m */; };
+		1D85DC7BCFCC62A960EE3A3C01D115DF /* YapDatabaseSecondaryIndexConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = AB2B65862BBA2CFE666E7089EDA28F60 /* YapDatabaseSecondaryIndexConnection.m */; };
+		1E48363AE5545ABC54E858306E2201C9 /* YapDatabaseQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B173A54339ED3F50B1422413FBC8206 /* YapDatabaseQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1E56678301E536B034CF41AABBB3329C /* YapDatabaseCloudKitTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B214AC0F2B4A9A5C40005E2CA2681AC /* YapDatabaseCloudKitTransaction.m */; };
 		1E6A591B3DEE6317BB014BD71A50B689 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = F9A095E75CC15921913AEFF327CA2D51 /* DDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1F78BC1B4954B6B51BC79CFDFA3D3EC4 /* YapProxyObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 698A0EDED4E43094B576B506684195AA /* YapProxyObject.m */; };
-		233AA695F18F55952778907D13AFE439 /* YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D7B1BF70DD1DB5336E6C6FB94A72E77 /* YapDatabase.m */; };
-		23AEA0B3910030CACD1CBFFFF6551603 /* YapDatabaseManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A3FBDA8346EF456658153A3FB190E7C6 /* YapDatabaseManager.m */; };
-		266BCEFEF756664E548526710D2BEC5F /* YapMurmurHash.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE4C86732572E873982D8B91A298 /* YapMurmurHash.m */; };
-		268D74969608D13368D93CD67BBB7F78 /* YapDatabaseStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = CEDF55596FEEF9B80E1E23E9A3E8ACAD /* YapDatabaseStatement.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		278D9193EDC7D11367906BC6891B2897 /* YapDatabaseRelationshipConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 44862C31C5156B32F61D4E2A185E0ED1 /* YapDatabaseRelationshipConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27FD0116639DFECB1E00CFE09D68056D /* YapDatabaseHooksConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B8924C50274B834DC4B53E2A78EA8B /* YapDatabaseHooksConnection.m */; };
-		2960383E5BF11CDF66733617000EC576 /* YapDatabaseSecondaryIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FE8E291DF9CC73A045A14E016662E78 /* YapDatabaseSecondaryIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		29B09567B817A90369B697CF3760719D /* YapDatabaseCloudKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 13B559B8B485AD1A1244C3AD0541DB8D /* YapDatabaseCloudKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A12EF52CA1E149BD92EF7B74C763075 /* YapDatabaseCloudKitOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = B80D211A6FF21072694CA06FED4E3B15 /* YapDatabaseCloudKitOptions.m */; };
-		2B19C2168FC950858A214291862C9F39 /* YapDatabaseRelationshipPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3736A93A853FCCE34D0B47664ACB2EA4 /* YapDatabaseRelationshipPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2B9979622557369F3ABACADF405BA203 /* YapDatabaseRTreeIndexHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = E9F551C4C330E91AA3C267195137C18F /* YapDatabaseRTreeIndexHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CA4C5901FAB7F32BD38F211A4608D13 /* YapDatabaseFilteredViewConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8622B6E617CACAC92567927E2787FD90 /* YapDatabaseFilteredViewConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CB33F208E86CBDB5698CA3E62423DBE /* YapDatabaseSearchResultsViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = C6685BFB15FE26BC0E6EE15AFD4E363D /* YapDatabaseSearchResultsViewConnection.m */; };
-		2CD3AA866E767EA39F0E837CA2CE34E8 /* YapDatabaseExtensionConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 13FF6186DF8800A4BFDC7FEC4F5059D7 /* YapDatabaseExtensionConnection.m */; };
-		2D2D1B52B6D6E4E64E56A3864671074B /* YapDatabaseRelationshipEdge.m in Sources */ = {isa = PBXBuildFile; fileRef = 2546001E7D901F1685DEF9BD07F3D899 /* YapDatabaseRelationshipEdge.m */; };
-		2D2DEF89718B29828550513EC7739EB8 /* YapDatabaseConnectionState.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B8685405FA425FB91DB19EC16615BF4 /* YapDatabaseConnectionState.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2D46D1DCB450F421B5A5BC34CAAC0840 /* YapMemoryTable.m in Sources */ = {isa = PBXBuildFile; fileRef = B0D001DB79BEC9B5E11BED4AC0F86F8E /* YapMemoryTable.m */; };
-		2DEC65B0611E4EFEC6FE32579BFCC5AE /* YapDatabaseRTreeIndexTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 47DE15CB269FE987356EB6B862B4B246 /* YapDatabaseRTreeIndexTransaction.m */; };
-		2E613F0ADCA711BF91650EB8D5644EA5 /* YapSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E9E2A2FADC98251BEA03528444D8045 /* YapSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		31D120F1E08D8B5530E506594BAD4E13 /* YapDatabaseViewMappings.h in Headers */ = {isa = PBXBuildFile; fileRef = BF0188B07281E05585455C8E1D0E4D2A /* YapDatabaseViewMappings.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		34B8AA30FD1919369781A8DDE0BDE467 /* YapDatabaseViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 33B199F7093926D3CB070BFFBBE791EC /* YapDatabaseViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		36584980D4A0420AC86B7F4162137AB1 /* YapDatabaseFilteredView.h in Headers */ = {isa = PBXBuildFile; fileRef = E2FE04078663E06BC8CF705B923FE2D1 /* YapDatabaseFilteredView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		36FCA08A0E91B77CA35497326F0B276D /* YapDatabaseSecondaryIndexPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A476950E6E65B2C0FF9CDE52F9DD63B5 /* YapDatabaseSecondaryIndexPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		379D2172E84279B55A06AF6B45918B7F /* YapDatabaseSearchResultsViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7571D738DE3587598B32E052F36E0203 /* YapDatabaseSearchResultsViewOptions.m */; };
-		38E7B80958F40C94C5B8E29782E389B7 /* YapDatabaseExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D92F2CCC8F831D0BD10B2F566419FB /* YapDatabaseExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3BFCBBD87B2B4E0BACCB88097FE2F3E9 /* YapDatabaseTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B934F8B990F20725EBBD74BB758687C /* YapDatabaseTransaction.m */; };
-		3C1977C9C888DA930F2108E9E076B135 /* YapDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A19399A3C2F620C0B834005E4E50328 /* YapDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D202DEEA12C732F3B0E5849A0225568 /* YapDatabaseRTreeIndexOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = D44C2C2892EF84F4B63827E49928FF93 /* YapDatabaseRTreeIndexOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D308951FCFCEC91E4190CC0912E9890 /* YapTouch.m in Sources */ = {isa = PBXBuildFile; fileRef = 09561652B20D0FA310DE3A34F27C4DBC /* YapTouch.m */; };
+		1EE3F7CD08754BC9ED960FE2305F0EF2 /* YapDatabaseSearchQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AA1348898013FE01A4F7F109422A9C1 /* YapDatabaseSearchQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		209850E62E237C3A40F216EBAC597022 /* YapDatabaseCloudKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 615B15C0A189EB4F392ED4A73C1204BC /* YapDatabaseCloudKit.m */; };
+		20AE57D9B772254D5CB2036C53406582 /* YapDatabaseHooksConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = DF30921F71F6AE3727A54D8ECA335AD2 /* YapDatabaseHooksConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		20CEF7CAF6459542143ECBCDE18D00F8 /* YapDatabaseRelationshipPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F03EC995FB3D70AE92C784A35808F09F /* YapDatabaseRelationshipPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		229826EFFDFB458B8A0692505C207B75 /* YapDatabaseSecondaryIndexConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 295A08A57D836839687D902AF3CAE16A /* YapDatabaseSecondaryIndexConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2350883BEF2B68075286E8B1E02F73DD /* YapDatabaseCloudKitTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 968FE15A56E59320F8425D094008397F /* YapDatabaseCloudKitTypes.m */; };
+		23B20C8A1FEF14A62DFC247E6E20726E /* yap_vfs_shim.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FA0E11325D54A0F5652B3346EE166A /* yap_vfs_shim.c */; };
+		2687774CEC15BBC46D1DF8177090BDE0 /* YDBCKMergeInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 970608F2FA6CC6E9306E6499A51F52D6 /* YDBCKMergeInfo.m */; };
+		28A47BDB25A5D20E1FDFF20C317030ED /* YapDatabaseSearchResultsViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A488CBE826207809B87F7DD719F75D3 /* YapDatabaseSearchResultsViewConnection.m */; };
+		28E8574965B95BDEA093AE2919E0F7B9 /* YapDatabaseExtensionConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = A6B2F562837AE04305DC8034E7F1F100 /* YapDatabaseExtensionConnection.m */; };
+		2921BAACCDB9725FCF4CDFADBA872EB7 /* YapDatabaseExtensionPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 78BD190D78621B561FBDA69ABB38E8B3 /* YapDatabaseExtensionPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		297A4E8BAE90C43453D33AC36F7DB8BB /* YapDatabase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8444A49016D7B4DE2FF5C6ACC4C5E76F /* YapDatabase-dummy.m */; };
+		2A4756672A66CAC9A686C259B11B2353 /* YapDatabaseHooksTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 12DD26FAC94AC9BCB815C05B60EE72FD /* YapDatabaseHooksTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D69BB1F4A5169784DBE2167512D6ED9 /* YapDatabaseConnectionDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = E90B26D03C1DA511FC49EFF009C1460E /* YapDatabaseConnectionDefaults.m */; };
+		2E4404ECA2C4BF7092AB092FBCF7152C /* YapDatabasePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = BBE986A59CE899195C796C5FBA41F766 /* YapDatabasePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2E5212EF76388EB24CEB925018AFE6EC /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = AE5494054F4C559747B1688783FB3DB2 /* YapDatabaseFullTextSearchSnippetOptions.m */; };
+		303B2662373CDA75ABB850492EC9FD11 /* YapDatabaseFilteredViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = C6AEEBF0CA4ECC952614A55B5739A94D /* YapDatabaseFilteredViewTransaction.m */; };
+		30784992AF8216AA1EC2C384A7AC9424 /* YapDatabaseRelationshipConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A75EF69C0AB72734960219A6BDE61096 /* YapDatabaseRelationshipConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3170DC4AA112B020A679AD92F7B7B730 /* YapDatabaseFullTextSearchConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F409BFD2D58D005C50238FF512DB514 /* YapDatabaseFullTextSearchConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		343121F502390984B0EF2F11886AA07A /* YapDatabaseRelationshipConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0301D1213B53FE972FA123E635BDC289 /* YapDatabaseRelationshipConnection.m */; };
+		362A0D6C66530BA3D799AD48E8804303 /* YapDatabaseRTreeIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 59BE28F82571F459A3315C11AC752CC7 /* YapDatabaseRTreeIndex.m */; };
+		36AE8EDEA06133D6699E71184AC1FF08 /* NSDictionary+YapDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 04E1D832E3826A3841B5F1824424B3D9 /* NSDictionary+YapDatabase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		36F53B78CEFDCF89AD1C209422B7225F /* YapDatabaseSecondaryIndexOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = F0B91693FF234B2D251787CE658795AA /* YapDatabaseSecondaryIndexOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39B68FC8B90E67AB9432EA7C175929CC /* YapDatabaseSearchResultsViewOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 64CEAA3119423C3CE45FE80C2C200E31 /* YapDatabaseSearchResultsViewOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39CB1B02039EC51F8A14C33D6D455286 /* YapDatabaseRTreeIndexHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E28868AA642F5D8B1ACB00729DC4483E /* YapDatabaseRTreeIndexHandler.m */; };
+		3A792E0EEE407D5067C9FA547311E129 /* YapDatabaseViewPageMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = B36F5E75B5CE6417346CBD8848F0E7FE /* YapDatabaseViewPageMetadata.m */; };
+		3DCA4AAA2CE8B28DD67F302842693996 /* YapDatabaseFilteredViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = E868B75168608DB425897317F664247E /* YapDatabaseFilteredViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3DDD0FB94D61AB71C8F5C727EC7A0BD9 /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A5E4B18696A542D02367C1B04D654FE7 /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3DEE69A0C9658F7A5B6705D1A167137B /* YapDatabaseViewChangePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 63B87551B56C58AFD97D02BC76F05121 /* YapDatabaseViewChangePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3E517D3F7B6202B0CF625E8EEB343534 /* YapDatabaseFilteredViewTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CC39064E94413754358BDB97002E700 /* YapDatabaseFilteredViewTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FAF8A623D5020FA9F64333D929D2E7B /* YapDatabaseRelationshipEdgePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FBF8D791F194AAF1409A2A9E6B3C074 /* YapDatabaseRelationshipEdgePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		40B263C91588190B54BD46ACF89DE75C /* YapDatabaseSearchResultsView.h in Headers */ = {isa = PBXBuildFile; fileRef = 72BE98F256B317494CE97276CE8D222E /* YapDatabaseSearchResultsView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4190103A3078F187417168F725CDF07B /* YapDatabaseString.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B931D61E8C05236749B4B6B1D2ACBC2 /* YapDatabaseString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41F221F9E8FDE456D3E9EB34B4C5EBF1 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C70497B4B7900D0D0AC99FE8AB395C6 /* DDFileLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		42687A4C9AD600844E744E3294E790D8 /* YDBCKRecordTableInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FA523887D399884DDE9EA2F1A4CBC40 /* YDBCKRecordTableInfo.m */; };
-		42A4B0F355B56C3E78E0D9CE7226FAE4 /* YapDatabaseConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = EF362363F3C411B948A61C437FE97D6C /* YapDatabaseConnection.m */; };
+		42B6C6B0829E4745B9AA5275FD93C47C /* YapDatabaseSearchResultsViewConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CF2C9C1A9FD4BEF4C95FFF21B9E9967 /* YapDatabaseSearchResultsViewConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		456BEEAD8F6C8D0B35D5A12E72068119 /* DDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = A169AE9A71FE7D86D03E35AEE1FAC6F8 /* DDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		45D5F45F51499657036E5A3DB42C0C39 /* YapDatabaseSearchQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 6210A508B0D0F7D302EEA81450939EE6 /* YapDatabaseSearchQueue.m */; };
-		45E510115B573B98ECE60AF76A3F6476 /* YapDatabaseHooksTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F4AA997F84CADD8CE2BFCA5E97397A /* YapDatabaseHooksTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		473E27EA39600681EA98037D087ACB10 /* YapDatabaseManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D9AFB9EB09D1C221A8B7C1EF68B2C0 /* YapDatabaseManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		478237571F3B81AE02688F2821A89757 /* YapDatabaseRelationship.m in Sources */ = {isa = PBXBuildFile; fileRef = 50E334B1113F8DA1A41E548D103FA35B /* YapDatabaseRelationship.m */; };
-		478A215D217E915BBFED7CC9F21EA4CF /* YapDatabaseCloudKitConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BBAB136DF1CDB8E26F4E50C5950B16E /* YapDatabaseCloudKitConnection.m */; };
+		4570F46C00C5118D6E70AF8DA9909868 /* YapDatabaseRTreeIndexConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 21FED17AA39661D6EE485EC0FC1E3AA9 /* YapDatabaseRTreeIndexConnection.m */; };
+		46F22361A8B680CF9A0A114A9C664B2B /* YapDatabaseConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = E5FDBE9C35D93F0FFED7EDFDD9354DB5 /* YapDatabaseConnection.m */; };
+		475F6E57FF82CB210B3FC57DE77AA6CB /* YapDatabaseRTreeIndexSetup.h in Headers */ = {isa = PBXBuildFile; fileRef = 648B3D971CEE5A228AB4538951600640 /* YapDatabaseRTreeIndexSetup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		47E656896B03152A9F609EC7BC2AACBE /* YapDatabaseExtensionConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D68F740C875DC86D4FF865A287CE9F /* YapDatabaseExtensionConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49EC96D778816168DD8C41AFEB7EF183 /* YapDatabaseRTreeIndexHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F9045309AEBBEBFFF9AAE54D6C58D81 /* YapDatabaseRTreeIndexHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CAAFD85FC04FBFFB61A22F14C8D4684 /* DDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 08D1257418C387D9D20F89315328D5EC /* DDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4F36A0A99C9DB33EED8D9C2A3817C576 /* YapNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 596E22310CB02C0DECC8A22453112FD1 /* YapNull.m */; };
-		5106C4189A895D5D375CE2C56AB8ACC3 /* YapDatabaseViewPageMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = F15811C648346381C353ACD0E715F6C4 /* YapDatabaseViewPageMetadata.m */; };
-		5263C0992A007DB20CD5CE04F33F8852 /* YapMutationStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 432443F2C87AC74636CAFA860D82301B /* YapMutationStack.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		529DAE23DFBABD303CAA7634FABBA19C /* YapDatabaseRelationshipNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C57B85A98AA85DE0693D4C3EC26E9F3 /* YapDatabaseRelationshipNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		54645C6CCCD947D1A3D247EA9796A6C4 /* YapDatabaseFullTextSearchConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = CF3FD8815BE891C39C141EDA084A9AA4 /* YapDatabaseFullTextSearchConnection.m */; };
+		4CEBEBE629F83E135AFF1302A73F3198 /* YDBCKRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 55D0E3A516998382A47D28A0D4D2E254 /* YDBCKRecord.m */; };
+		505CFCEB6129E67DE3A9BBBAE57EB9E9 /* YapProxyObjectPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = FD2F74CA4003143FE129C81EA016EC64 /* YapProxyObjectPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5163EDDB6ED60E8162CA695DF958916E /* YapDatabaseHooks.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF2C3162E4EB0EEBDDE88767F990355 /* YapDatabaseHooks.m */; };
+		53DEF7903C96D39291EA929B1390B706 /* YapDatabaseRelationship.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA43605B373DF0C40E2390216E48ECF /* YapDatabaseRelationship.m */; };
+		5400FBACFD14F219AB0F5469C88E1287 /* YapMutationStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F09193A28EAB2411721F2808F524FDE /* YapMutationStack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5539A292EFC958D90F290DBA5FF86220 /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = B2D8F80CB641FA7E4A87ABBB3B571EC7 /* DDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5908DFE23919F060F4ED3835CB328C95 /* YapDatabaseViewMappings.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C810AFBF3CF08D27EC329C1321F4EBA /* YapDatabaseViewMappings.m */; };
-		5B3CF6E4110B18035598EBDCA24EC8EB /* YapMutationStack.m in Sources */ = {isa = PBXBuildFile; fileRef = 149731DA986DB2C776E29A665147D713 /* YapMutationStack.m */; };
+		56C0D06DD64369F973D98BDF8DEC96B7 /* YapDatabaseRelationship.h in Headers */ = {isa = PBXBuildFile; fileRef = 03A8BB14AC12D63777DAD6779A5D1E24 /* YapDatabaseRelationship.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		573CA73E83E49AA210AF8897DDD91F51 /* YapDatabaseViewMappingsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AD95EE682E1AF47B4CAE1C6A932931 /* YapDatabaseViewMappingsPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		59C060923DD680FEC5F271F2521F6841 /* YapDatabaseViewTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = F449D5C641AC344CBFBA1D6A17A9FF95 /* YapDatabaseViewTypes.m */; };
+		5B8D5AF8370A793712DBCB42D7C057E9 /* YapDatabaseViewState.m in Sources */ = {isa = PBXBuildFile; fileRef = F58CA75CEE1992E2C027AB6579576826 /* YapDatabaseViewState.m */; };
 		5BF91CDA8B3E716D193A6F006EE6F869 /* Pods-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 272643F56613CA0D336AE3DBF19DC404 /* Pods-dummy.m */; };
-		5C652BEBA7AB9B468E5170773BBB1073 /* YapDatabaseViewMappingsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = CE5047FDBCCD6F256CE0FF5482FAE603 /* YapDatabaseViewMappingsPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5CF61E927832BA4277626D98AE498781 /* YapDatabaseExtensionTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = B6EC8A21DFB12A07ACFAFB0DFA5AD511 /* YapDatabaseExtensionTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5CD58EEFA00A6F5C08AE96A21D6A6E45 /* YapDatabaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D88E3EB5B05814AF2D64972ACF582CB /* YapDatabaseQuery.m */; };
+		5D3CF682BB27D593B24DC3B95550988E /* YapProxyObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A587587FC8AC10AD412E8D0F1B31B487 /* YapProxyObject.m */; };
 		5DCBA219BC81D9190F11EE56F93BB908 /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D52DFC863E4F234815A48FB6BCDBD3 /* DDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5E022A9DAB33A815D64F684F7FF4CD04 /* YapDatabaseFullTextSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = ABFA3A939380311EF51ED290F486CFCE /* YapDatabaseFullTextSearch.m */; };
+		5DE9CC983A8DB391196EED018429ACEB /* YapTouch.h in Headers */ = {isa = PBXBuildFile; fileRef = ABCA00D0BEAE94CBE28306B634823A57 /* YapTouch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6077EFC05DC2551A7F5A1CFAC0B90187 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EDC1117352B86A27F1B34547BDE01BC6 /* DDAbstractDatabaseLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		60E662F4D58F4B3248413E3EB804D60D /* YapDatabaseViewTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 85AE89F33CD6EAADDE7EE5163537AF6B /* YapDatabaseViewTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		61756DB5882D00093B8DE46B69B84069 /* YapDatabasePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAEEA1072C5BB9C6383833049A46A21 /* YapDatabasePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6099651C37E0FD54943FB892B05165FF /* YapDatabaseConnectionDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 29D1D37376D0FA2432D6E0EA8A81C99E /* YapDatabaseConnectionDefaults.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		612298C907D09DA643C123EC8DAD5BE4 /* YapDatabaseSecondaryIndexSetup.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B3BFEFC1F532C518EB872D61FE6E5C8 /* YapDatabaseSecondaryIndexSetup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6475050C8BA464772209BD6AF03F1EB1 /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = A28679B79F48C675D2A6BF74EF1BB967 /* DDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65560476067F435038CD79F6CB291806 /* YapWhitelistBlacklist.m in Sources */ = {isa = PBXBuildFile; fileRef = F162CB1516CD85C2342D998A4B1BC3A0 /* YapWhitelistBlacklist.m */; };
 		656479029A5A15463E080FD25F8903B2 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4AD99FCDF845B442B1B3F570D940FE /* DDASLLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		65E5BDEC5A8D9FD4DEEA8CC2287A8987 /* YDBCKChangeSet.h in Headers */ = {isa = PBXBuildFile; fileRef = B9F27EA9B8F64C54944653A856CA10BC /* YDBCKChangeSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66442206C1F4BCB3820C69F9A5626B37 /* YapDatabaseCloudKitConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FBDF0701466503F72A59322CA7DC764 /* YapDatabaseCloudKitConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6681032A8F7C098BA72A29A0AA514E26 /* YapDatabaseSecondaryIndexConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = ECCDD9066F57BE7318EBFA6731977C94 /* YapDatabaseSecondaryIndexConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		67E741D303696F9A1E863BC42E6A9C79 /* DDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 788BB22E7DBA508D141D8CDEE188080F /* DDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		68A4C5F5F69FAF87EBF5045690C06941 /* YapSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 17DEE28F34BA84F7EA660DE6ACD00739 /* YapSet.m */; };
-		6AB51294C00240C00234432ED8E33139 /* YapDatabaseFilteredViewTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 31C2DC894C76D3988286A29A4071294C /* YapDatabaseFilteredViewTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B8F1F3A4F73833DFB2E359C3317C328 /* YapDatabaseSecondaryIndexHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 93C31BCB1D65033585BC692A4E965BE2 /* YapDatabaseSecondaryIndexHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6BE77C1FF6C79CC249103CFB4BCFBC07 /* YapDatabaseViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9600FEBE9F2032F1A7B1A6EB4FE14636 /* YapDatabaseViewOptions.m */; };
-		6C501503B99B2CDB8995453450805D23 /* YapWhitelistBlacklist.m in Sources */ = {isa = PBXBuildFile; fileRef = 80A16A3C361F30A84E5ADF4E80A7801F /* YapWhitelistBlacklist.m */; };
-		6CE47D93F369F8EBC82309722B4D49B9 /* YDBCKAttachRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 21931CB46FD6E2EE321E637420D8BB40 /* YDBCKAttachRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		6D1A7F16035BFCA931157E82C20901E3 /* YapDatabaseHooksConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C0A1CC1E4EFA2E142C09A03BE57324 /* YapDatabaseHooksConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67F64FCFF346A66EA29FB077F065B0DF /* YapMemoryTable.h in Headers */ = {isa = PBXBuildFile; fileRef = A52484E4C7F65D155496644E3570E683 /* YapMemoryTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		681216D48E0D951027AF0D64B478FC9D /* YapDatabaseExtensionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B679094C87221EE41433C3B4F95928D /* YapDatabaseExtensionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A4E1688E6E6742F56BB93F117070B9E /* YapDatabaseViewConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = C1970060B264CDA0618FDCDECF12EC84 /* YapDatabaseViewConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BECCAA79A245EF625A7F418CD29342B /* NSDictionary+YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0565621CE9D4F1B820412F38426DE0A /* NSDictionary+YapDatabase.m */; };
 		6DAEF151B35D00265D60C4AD34431DD9 /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FC5551224D2BB2FCC7ECB3BC95508A98 /* DDContextFilterLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6DDD8E305F637A9DD21F077EAC7928EA /* YapDatabaseSecondaryIndexTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 18704AB521F27C897E10ABBACB212C2E /* YapDatabaseSecondaryIndexTransaction.m */; };
-		6F0920326A8E406417272EE0D433376D /* YDBCKMergeInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 195E5629ADEADF5E4027444230A2A9D5 /* YDBCKMergeInfo.m */; };
-		70120DF2E98FC6DF30AC9E09094256ED /* YapDatabaseString.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E1C881674CCFCEC3A7F5A6D542E5569 /* YapDatabaseString.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		73D371256220F117C4174D073AA75852 /* YapDatabaseCloudKitTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = CF6F2977CF5FA0116889A63D5A0158B1 /* YapDatabaseCloudKitTypes.m */; };
-		73DB6C2CEFE9748174FFE5200EE18E57 /* YDBCKChangeQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FB8F515D249AFB8461834F1092B7EE6 /* YDBCKChangeQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		74031B9DFEBBF10D05670147EA51EF21 /* YapDatabaseRelationshipTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F246F978EDFF63B74C3495A9170A56 /* YapDatabaseRelationshipTransaction.m */; };
-		750B324650BD93E465D19A01CA793F59 /* YapDatabaseLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C76B9EC26DD65C1F503FCDE46118C3 /* YapDatabaseLogging.m */; };
-		751FA935725ED627F86FFE6BE5CE5B48 /* YapDatabaseRTreeIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C764E8FAD35D9D4E07B8365D0718B30 /* YapDatabaseRTreeIndex.m */; };
-		754CC2181CD3DD612EE98CA72D9DFD77 /* YapDatabaseRTreeIndexConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 936249C808FB3FF760973692617734C0 /* YapDatabaseRTreeIndexConnection.m */; };
-		76AFC574495724006EF0583C41949F35 /* YDBCKRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = D8EA9A16976299252C72EDC3F1459A4A /* YDBCKRecord.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		77DC7234B563ECB9F576462C08E4211E /* YapCollectionKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EC8E4E6780E7D9C3867E12D2E68B83B /* YapCollectionKey.m */; };
-		78C0C14967F38CB0F4E79C73BEB77684 /* YapDatabaseRTreeIndexOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = C89497866A2668D8CFFA53D266232165 /* YapDatabaseRTreeIndexOptions.m */; };
-		792F8BE825637280329F3E67CBFE5175 /* YapDatabaseViewChange.h in Headers */ = {isa = PBXBuildFile; fileRef = C51D1904642322F43DDA853602B2E429 /* YapDatabaseViewChange.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7ACD4793935EE29894D683BD2596B7F9 /* YapDatabaseFilteredViewTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DFBB72BC17352E2BC6B3697E136A5AA /* YapDatabaseFilteredViewTypes.m */; };
-		7B0C69E4DC3F4B29C6A516500AC50FEB /* YapDatabaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 50AD9E691B386637203C026BECB09CCE /* YapDatabaseQuery.m */; };
-		7C6205454FA86A4FDDAC53A870A1817F /* YapRowidSet.h in Headers */ = {isa = PBXBuildFile; fileRef = D8AE2D97E5AA5E6C285933219688EFD8 /* YapRowidSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7DBE369AA7CB574AEED84707CF04A9AE /* YapDatabaseRTreeIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = E52BBDC32C5F7CA597C16A47D6890F81 /* YapDatabaseRTreeIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7DD4EFDD4A2C173C4D91D953C8D75D29 /* YapMurmurHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F988D4D181B3C805D977E323CED98A6 /* YapMurmurHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7DF85D908A13F2157BF3261B2DAED389 /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D7CCA9A8171410CE55B30EFB25B50A /* YapDatabaseFullTextSearchSnippetOptions.m */; };
-		7E57F03FD6B64C487B60558052CD03A4 /* YDBCKMergeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = D2A37FD4EBBBFC736C3A4C15656B107D /* YDBCKMergeInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7F68F0C4103A1B62FA489802019574C9 /* YDBCKRecordInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = E97503252DD189B9109FCD9E31F7F08F /* YDBCKRecordInfo.m */; };
-		822FB2C21B16FF428C9BE4DCA1F8F30A /* YapDatabaseFullTextSearchPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = B269906CAA0B3CB29EAC57F18614F88E /* YapDatabaseFullTextSearchPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8376DBAB103A6547C0CC9C7EAF44A45B /* YapProxyObject.h in Headers */ = {isa = PBXBuildFile; fileRef = B372C9DC0B4E2454F1527332E0887590 /* YapProxyObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		83EC30059533930DE5914B4C2F9131A4 /* YapDatabaseViewRangeOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4BE4D58E026DCFD3BDC8D7199E841E /* YapDatabaseViewRangeOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		84B9A84D598A200CFDDC2A70A2564FF0 /* YapDatabaseSecondaryIndexSetup.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EB897FE43917635821EFC32398C8D9D /* YapDatabaseSecondaryIndexSetup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		86128B5FDEFB7F2B9119D146DCED6BE9 /* YapDatabaseSecondaryIndexOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = A524A6DAB33248485739DC7A487CDB76 /* YapDatabaseSecondaryIndexOptions.m */; };
-		867B53220326EE73D7D823A553E301B2 /* YapDatabaseSecondaryIndexConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 16E86CDC2927006B4C7E0724E79A474A /* YapDatabaseSecondaryIndexConnection.m */; };
-		86CB06B4951DB700C9903A6BC975033E /* YapDatabaseViewPageMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 17A93D76A7C9D3B713D4D23351242550 /* YapDatabaseViewPageMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8D868CC868962C3296E0BC7706B1A93A /* YapDatabaseSearchQueuePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C277CE54037E425394097ED90BF5F4B /* YapDatabaseSearchQueuePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8ECEE147A0DA1D7BF2C1D082F3096C5D /* YapDatabaseExtensionConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 737BE1C70655CCB06A7FED1AC1F9082E /* YapDatabaseExtensionConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F8D4F7F8230103287AA172E0AB815C7 /* YapDatabaseViewRangeOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E62FAB527D4E84B59CC8917C0EEAB6 /* YapDatabaseViewRangeOptions.m */; };
-		8FA2E6C90FF9C12F5FC3D87B7D9291DC /* YapDatabaseLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CEFD4A0BD33464B5AC307F3BD6F598F /* YapDatabaseLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8FFD82E51BF55093AC240EC831D9B145 /* YapDatabaseRelationshipOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E4C1FB6D1F2FBEAC5DEEE5E42DC5224 /* YapDatabaseRelationshipOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DE61BD14333FD73AC9B1C043076581E /* YapDatabaseRTreeIndexTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DE13599F8EF3729EA813AB2976F1B3A /* YapDatabaseRTreeIndexTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6E05447A4601FFC931678669D7655E1A /* YapDatabaseFullTextSearchConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FDBD74F41BDA79D747FCB115C9B1372 /* YapDatabaseFullTextSearchConnection.m */; };
+		6FDCAF622DCA72758CC9B87166935C14 /* YapDatabaseRTreeIndexSetup.m in Sources */ = {isa = PBXBuildFile; fileRef = A480E75A3250D6453EEC1A16BA88627F /* YapDatabaseRTreeIndexSetup.m */; };
+		721B1B792804558616A28FCB3B823F23 /* YapDatabaseSearchResultsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B15FB5AC603FDDAECDEAC911D73B59A /* YapDatabaseSearchResultsView.m */; };
+		733EFD60D6AD4A76F10B5A4CD726368D /* YapDatabaseViewChange.m in Sources */ = {isa = PBXBuildFile; fileRef = 8579948E4B50037139942B4FD1B71FAA /* YapDatabaseViewChange.m */; };
+		7466E6E7398833E7F255F72C177C50F6 /* YapDatabaseManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AB98936AC74CDF038BF633D344E80558 /* YapDatabaseManager.m */; };
+		747640D0405C1AC66F1BE0AC53D9A8AE /* YapDatabaseFilteredViewTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 33F998CAAFC0BB728C266B47A2916E0B /* YapDatabaseFilteredViewTypes.m */; };
+		7701B3422BAB34836FC4ED7CE9BDEE19 /* YapCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ABB9105344311034ABFE100BE23208F /* YapCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B4DAAAC64771DCD622FE82D3DB6CFC2 /* YapDatabaseFullTextSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = 84418AA95E5334C72A4F3CA3FCB8EC74 /* YapDatabaseFullTextSearch.m */; };
+		7CBF4AF3ACFF38F848B7A1683D881933 /* YDBCKChangeRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = 65991F1294DA96B7EA0C8A6EE6D1896C /* YDBCKChangeRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7CC3E234BE3FA403043ED3B3F3614648 /* YapDatabaseCloudKitOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A59AB1E50836F2AC7ABCEE5F69EDFC6 /* YapDatabaseCloudKitOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7D24A82D2C75C39192A3C59D3356676A /* YapSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECB8D6BB6D127AA636DDE0D77683FD7 /* YapSet.m */; };
+		7F1E9A8A765B55F409C39D5E1BA029FA /* YapNull.h in Headers */ = {isa = PBXBuildFile; fileRef = 67B4169E7860520B798703A0E927FEC7 /* YapNull.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7F3EF298C2C1AC522EA6734A57A1B032 /* YDBCKMappingTableInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F62360F0833D4350ADDC3E77C7037A49 /* YDBCKMappingTableInfo.m */; };
+		80C89E262A95622C8A8F80F50D478B8B /* YapNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 08F365D1D3C859D8021FAE04FFCE75DA /* YapNull.m */; };
+		8195AAF714875E38C9472D7DF4190094 /* YapDatabaseSecondaryIndexTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = D707F82E96981C1B04D779CA7525DF18 /* YapDatabaseSecondaryIndexTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88EB187ADA227A9146E50E1634E4D200 /* YapDatabaseConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A30D13F41B487DA805F1654FE49FAD3C /* YapDatabaseConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BCCB470D23D4392D1D0F5A6F97B434F /* YapDatabaseManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F757BE152F8BE5B1C3BAD332ACD3FCDF /* YapDatabaseManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8C4BB1398C0EBE211DC2C412D82F3668 /* YapDatabaseRelationshipEdge.h in Headers */ = {isa = PBXBuildFile; fileRef = D63EBB0AC535EDBCF2B2381A5EC78930 /* YapDatabaseRelationshipEdge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8C73E1892D3A8EFA45DCD74DE8FFC9A0 /* YDBCKRecordInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = BFD894201317C2186263060EFFE317CE /* YDBCKRecordInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8D5DC82D175786E2A1C8DE6D5F233502 /* YDBCKRecordInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B6D524F63036E29C471D5BB8D4AA322 /* YDBCKRecordInfo.m */; };
+		8FCA1B1B8A8FDE08089EA0959E835CB0 /* YapDatabaseViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AD90CEAC695AE4FBF9585EDC068612 /* YapDatabaseViewConnection.m */; };
+		90231ACED987DADED8EE7CAF744B0E6D /* YapDatabaseSearchResultsViewTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = A51430A1EBABF5DDCFA14B41BC4F4AE2 /* YapDatabaseSearchResultsViewTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		906BA39B4449184A264475B0AAA9CD7B /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ECA9AE91B3BD36523C5A7E8398E2B1D /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		909D7B346E1F8E5E384C8B2E50F2F2FA /* YapCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FAC5D5D1E18105013013CB5CB52037 /* YapCache.m */; };
-		916AFC5EDE34B71E38AF67183EDE274B /* YapDatabaseFullTextSearchConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = D4B04409C68A525FC76B724CD9CD4E14 /* YapDatabaseFullTextSearchConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		91235E939BA0885A6C4DDC8EB5BECA0D /* YapDatabaseConnectionState.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C684A2B8CE9C13B3F15F3069166BEF /* YapDatabaseConnectionState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		915BA1AC82B8EEB5F6E7A9CA664136C9 /* YapDatabaseRelationshipEdge.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A7F146404765E5F41CCA63F2F6FB505 /* YapDatabaseRelationshipEdge.m */; };
+		91AA71697FAA691123941B503B17EA7B /* YapDatabaseViewMappings.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0DD15B9F52B8F95E8CC216CA766F02 /* YapDatabaseViewMappings.m */; };
 		9258A7B71D4C13DBFC66C4B8BE43B79A /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 94A49738BC61B921C3DC5971268AE019 /* DDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		927601B508E7270EE46E7530FDAC787F /* YapDatabaseConnectionDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2010C2C215274160D0D77DA6BF23CBD0 /* YapDatabaseConnectionDefaults.m */; };
-		93837BA1C646A79E4CE9F2286B0BF76F /* YapDatabaseRTreeIndexSetup.h in Headers */ = {isa = PBXBuildFile; fileRef = AA47DE97BA5921119D4DE805D025DF86 /* YapDatabaseRTreeIndexSetup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		94BDA2DA2D89A101E02A5E2732AF71A9 /* YapDatabaseFilteredViewTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D3D6B15F8905B28DF07D7D3710DB4A29 /* YapDatabaseFilteredViewTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		963356FC04C94BC1C6DE473659C7A4C1 /* YapDatabaseSearchResultsViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62AC2ED5547490F589AD92623B4C2B86 /* YapDatabaseSearchResultsViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		99F4B885AB08B87A93B9BEB95D602A10 /* YapDatabaseView.h in Headers */ = {isa = PBXBuildFile; fileRef = 156E19773AC758436E61E2C1CEAA6C38 /* YapDatabaseView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A2954DCA42B4779137A299D89B91A1C /* YapCollectionKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D4896ACDD3852EBB3B711D0653BA4A9 /* YapCollectionKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9CCCDB03543B8954B596255C477286B8 /* YapDatabaseSecondaryIndexOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B334FD2757B878AF6AB72CF388B275DE /* YapDatabaseSecondaryIndexOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9D1AA07CFCA36F88E5FF28E157E9ED6C /* YapDatabaseViewRangeOptionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C0DFB5F8E82644427FDA3A20399219 /* YapDatabaseViewRangeOptionsPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		9D68786F03B1271C44FCE4B930AB07FF /* YapDatabaseRelationshipEdge.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FF6210D530D2B43E944C23B0987C370 /* YapDatabaseRelationshipEdge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92B7A2955E52A0924D8AA28014A0C577 /* YapDatabaseViewTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C43A49A032BCB6035B5D5ECBF372974 /* YapDatabaseViewTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92FA43DB1B5D6C8EFD894D016565B87A /* YapDatabaseStatement.m in Sources */ = {isa = PBXBuildFile; fileRef = 727DC21DB4F3DCD303C9F53BA2EC02F0 /* YapDatabaseStatement.m */; };
+		951EA5F0DA4E7915F6F7599808D8EA63 /* YapDatabaseExtensionTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 30FA88DA054BAAD5760CAD45B4E7D54D /* YapDatabaseExtensionTransaction.m */; };
+		96108A9DA8860B0A03F4A24797B2B808 /* YapDatabaseRelationshipOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 20A80B0E1A92856E748F6C6BADE2A99A /* YapDatabaseRelationshipOptions.m */; };
+		961A588BA42A44315FCA655CA0A6C608 /* YDBCKRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = 70039F4F7773BA238D0818BCB1A56609 /* YDBCKRecord.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		96FD2FA6845B08E3D7DA67149055EBD5 /* YapDatabaseLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = E341274BEBD9EBCE121B38535B4A82E8 /* YapDatabaseLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		972E110DA1ADD98E17F3185246C6BFC1 /* YapDatabaseRelationshipNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 8359077804BD2E1A2DF11F8D19AC1604 /* YapDatabaseRelationshipNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98DAF5AF4EDFBDC02AAD594CB8E4A6AF /* YapDatabaseFilteredViewConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = BE8CCF1605338B010AAAD3DD2F96A3CB /* YapDatabaseFilteredViewConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99E57BE53DB0338F3B7F38B6B40CA2F0 /* YapDatabaseFullTextSearchPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 066DFBE6D611B4C32B67F4D64776E2F6 /* YapDatabaseFullTextSearchPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9B8C2A678D905351C1C663E842B8F241 /* YDBCKAttachRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B27DF70BDF04B97794AFC77BD6E45462 /* YDBCKAttachRequest.m */; };
+		9C0C7110D5513C6573A5E27B87505E1B /* YapDatabaseRTreeIndexPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 67AB9B55F95187CC2A6E269BA5608979 /* YapDatabaseRTreeIndexPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9DFB1378A337698012F7CE5D593DC04F /* DDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC9F995E016B3507790BD9090DC7D3A /* DDASLLogCapture.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		A0DB9BDA5DA4F348B3776F7564B0EC91 /* YapRowidSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1E84AC0D831FB5A826F174D4C6D72738 /* YapRowidSet.mm */; };
+		9FFEBFC646F5C64BFB64DDC228B91667 /* YapDatabaseFilteredView.h in Headers */ = {isa = PBXBuildFile; fileRef = FC915582FF9FA794CCC18D87F5BE1F01 /* YapDatabaseFilteredView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2D0EE5602557677B5D9AB8D46F2F1AF /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 892DC79F537D840BFDC4C18A3E3FA05E /* DDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A34EF7C35E4E0657AFC8B4BA0B343867 /* CocoaLumberjack-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 903B95EE0B69E01EBE26C7A903313D10 /* CocoaLumberjack-dummy.m */; };
-		A88EB9ED02FF0D26C14C32404E5D1DA1 /* YapDatabaseCloudKitOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8C29AE2373D16EA5D5C410547DE4F2 /* YapDatabaseCloudKitOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A8FDA4D9DAA171B7BCAC0E015C65C5E9 /* YapDatabaseSearchResultsViewConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A8502424CB22703A0E69AE8A12F3EC /* YapDatabaseSearchResultsViewConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA4E93F117D502A902AEA3263F81FFF3 /* YapDatabaseExtensionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = B8869D4F9803812B85B9B4C97868C90D /* YapDatabaseExtensionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AADFCF570B8FA7D7D6D275B64C701549 /* YapDatabaseViewChangePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3933EBB1C8D82723A3C236689E70A221 /* YapDatabaseViewChangePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ABDCC1DBD6E59E04B7AA73CAF8EEF633 /* YapDatabaseCloudKitTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 141EA78507E51434FB98CB56A16761A6 /* YapDatabaseCloudKitTransaction.m */; };
-		AD9964D5A81E379C81BAA210844E9EF8 /* YapDatabaseRTreeIndexTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EDC89F3C717A2A72179C3F65DE5FC82 /* YapDatabaseRTreeIndexTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ADE18C4317B6BAF739D38914CAA82F98 /* YapDatabaseConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = E1DF54396F791161B74F6D7CEA60B353 /* YapDatabaseConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AE6E3629187CA3A71ABAD2B52B0BE2D6 /* YapDatabaseSecondaryIndexTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 2101F63B89170E1A41654F2922290E8A /* YapDatabaseSecondaryIndexTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B0D252A8A4D2F75B9B8F9BAB51953FAB /* YapDatabaseOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4676F29F296CA30BB7FC6209AE36C3E0 /* YapDatabaseOptions.m */; };
-		B137EACFDC3221284A9A999F9E4C457A /* YDBCKChangeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 510DAEE7486A1189A8D8A338F1D29187 /* YDBCKChangeSet.m */; };
-		B1CCC050C335E43DE8F72EEC82F6ACDD /* YapDatabaseFilteredViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DDAD699DE6A3E4A065A579E15921F3C0 /* YapDatabaseFilteredViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B240E1C6FB234B2912BD552B04B9052F /* YDBCKAttachRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CCDB48ADD754701284662F157D166172 /* YDBCKAttachRequest.m */; };
-		B4E53E9E1C544456B8CC57CCA6633647 /* YapDatabaseQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = F8686DC7761936C0BB5AF781BF06BA58 /* YapDatabaseQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B7A2B22CD1C14FDD3C9074B2FAAA3DF2 /* YapDatabaseRTreeIndexSetup.m in Sources */ = {isa = PBXBuildFile; fileRef = AE2449FBD13E40FBFDFAFFD82F62E0A4 /* YapDatabaseRTreeIndexSetup.m */; };
-		BA83C7A5E19CE27B47E453C8683D109F /* YapDatabaseCloudKitTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F5F9A6B6EEFC47F3957A2B0FC1EDE93 /* YapDatabaseCloudKitTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A4B000966D30247FEE5FA2E8FF0D8EFA /* YapDatabaseExtensionTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B8E0042E7103C7F774B4E701BFD24A /* YapDatabaseExtensionTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A546508180EE8E63C9EAA635D43DC577 /* YapDatabaseCloudKitPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = C12FAF4C4AF7ADB9E520919F6934BC6B /* YapDatabaseCloudKitPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A6582D608B5B84712F642D67CC597DFE /* YapDatabaseSecondaryIndexSetup.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C88428F27576F6B98C55065A395D2 /* YapDatabaseSecondaryIndexSetup.m */; };
+		A74E67F6D42E1B7E1B76EDE9B7D808EB /* YapDatabaseRelationshipTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 095CD441C9F376C49A851B4E015140D9 /* YapDatabaseRelationshipTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ACB88E893352436F8E883F50303E5440 /* YapCollectionKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 54B8FCF040E027340763CA7A5F06BEE8 /* YapCollectionKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ACC474DCEFE86ABF4E58F8F88B9B7679 /* YapTouch.m in Sources */ = {isa = PBXBuildFile; fileRef = 9467D412C55FA91C9E59A66FFF6642E8 /* YapTouch.m */; };
+		AFA38CA3E13870ED1D6E778F9616A617 /* YapDatabaseHooksConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BAFD282AA4E753B936469759F6EFBF9 /* YapDatabaseHooksConnection.m */; };
+		B02BEBD8C7200FB86A8952F24FC10AAD /* YapDatabaseFullTextSearchSnippetOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B903CD7650F49A9B8BF5F2FC63FD8F4 /* YapDatabaseFullTextSearchSnippetOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B097CBD3A09320E92F178EFFCBEFF0BC /* YapDatabaseHooksPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = B0E76F58B315F27F42743B9E2B312020 /* YapDatabaseHooksPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B380A2293C966EA7600B741F8513A539 /* YapDatabaseViewRangeOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = B0805C0161B17B14CCE58BB7B17EFA48 /* YapDatabaseViewRangeOptions.m */; };
+		B715389142985DA5DD101253B5450108 /* YapDatabaseSearchResultsViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF85CC72B4157D186F6138A0FB87803 /* YapDatabaseSearchResultsViewOptions.m */; };
+		B8233C383C320F41B9DB01276481511D /* YapDatabaseOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B9196FCB61B02E9E7F90F95429D711B1 /* YapDatabaseOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B8F17A1F539E61732460783CE27F8E73 /* YapDatabaseHooksTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD782FB05B37D290DB3F30EF1DBE418 /* YapDatabaseHooksTransaction.m */; };
+		B9662429B2407F4A56E940F0B62D5F84 /* yap_vfs_shim.h in Headers */ = {isa = PBXBuildFile; fileRef = F42B15397090DA467277D997A95E6B74 /* yap_vfs_shim.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B9E666E0908611F66C0924F83FF8BEEC /* YapDatabaseSecondaryIndexHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C15792960C9B4E76899F3D73B536E9BE /* YapDatabaseSecondaryIndexHandler.m */; };
+		BB19440F4CBA4434DAAF5EF1776DFC40 /* YapDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3743600F62D86F75F23ABAF40B755D44 /* YapDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BBCA69A708A7B3DD861FB839B3A251B3 /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 07D14B15A24A77A47840C41A54B498AE /* DDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC6A30C283CBAF85D7AE15EBF1B8F426 /* YDBCKChangeQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BEEE8E2D1FFB3CF92CE3D4981BA6233 /* YDBCKChangeQueue.m */; };
-		BC6F376743E870B8FEE653D85684B369 /* YapWhitelistBlacklist.h in Headers */ = {isa = PBXBuildFile; fileRef = 40B5BD446EB2C743507304B2FF4E8274 /* YapWhitelistBlacklist.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC9B7BF941B175ACA70385ED3952C90F /* YapMutationStack.m in Sources */ = {isa = PBXBuildFile; fileRef = A63865E864081744239BACE7B6773881 /* YapMutationStack.m */; };
+		BE1F2D1A77DFD0A2CBFE2ABA214FEFD1 /* YapDatabaseRTreeIndexOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = C50144B6F76F8A17B1E80BDD26681815 /* YapDatabaseRTreeIndexOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEA81CB20CC828E5C73536449BEEBF02 /* YapDatabaseSearchResultsViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = FD979328F012B407CD9889DAEE3A33F5 /* YapDatabaseSearchResultsViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BF5128F1A18B0CBAC309A63E40F35AD0 /* YapCollectionKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 4286818F79DF6399D8C80A55C8698748 /* YapCollectionKey.m */; };
 		BF525D162B9ABC5DFA69FB7A8779F76E /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A48E2707F82BB1204E9FE86C722BC38 /* DDTTYLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C02F6ADDC6B73E43C54C303CB26FC248 /* YapDatabaseHooks.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B9A7DE3B087B7CAFE90F3116050359 /* YapDatabaseHooks.m */; };
-		C0530AEE9E0A6DC5D5B6E712759F0B28 /* NSDictionary+YapDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1B6787B788A3A59A25A84E9CF996BA /* NSDictionary+YapDatabase.m */; };
+		C083C53A259A12DB1BDA44D2D79412D3 /* YapDatabaseViewChange.h in Headers */ = {isa = PBXBuildFile; fileRef = FF39DEEFA75ACC10333D55D3CC56EAB1 /* YapDatabaseViewChange.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C515A390D549AF8A16A76DD72388BD2C /* DDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 4ECBC81DB84A5A4288984BC5417A1458 /* DDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C53C676181F4BEAE48621854DF0E2696 /* YDBCKRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 78EB621E14C92766E184142532332E40 /* YDBCKRecord.m */; };
-		C5948BB0F3CE15BC544BB69C24F4A55A /* YapDatabaseRTreeIndexPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EE925426226F66EBE27083E21D2EF47 /* YapDatabaseRTreeIndexPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		C6500778F20C01AB6E15349BA0355105 /* YDBCKMappingTableInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F23FBBECC8D76022977869F9D2241A /* YDBCKMappingTableInfo.m */; };
-		C68FFF658A09735C143A9574B1FB6B20 /* YapDatabaseRelationship.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CD090CEA67216801022BC73F5A62D60 /* YapDatabaseRelationship.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C7FE492557ECB4AA3481BE984D14CEB6 /* YapDatabaseRelationshipOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A942442BCAC527656452418D4B09824 /* YapDatabaseRelationshipOptions.m */; };
-		C99A43D87150B060AF1F52D16FC5267A /* YapNull.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3E1593B93BC0F42009D6AECDDDF07A /* YapNull.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		C9D2CFB82AB07EC6D4D33DAE3A7394EA /* YDBCKChangeRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 45305F54F84DF41BA8DB7C4012E00270 /* YDBCKChangeRecord.m */; };
-		CA7FC90945F43ABF67B245B385DA5A4D /* YapDatabaseExtensionPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A9820A657836B6C624D6DE9E9D80902E /* YapDatabaseExtensionPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C51F3082EA87568D0E3CE8B85461799A /* YapDatabaseCloudKitConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D504F6C221082ABB60D4079DFB13C8 /* YapDatabaseCloudKitConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C5DC6B0136247022F78EF957649F60FF /* YapDatabaseSecondaryIndexHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DFF61612C4E5FD1CB120178A27E856A5 /* YapDatabaseSecondaryIndexHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBB6BB497EC1A4C36506AD74ECDCD99F /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4FEEADE0984F8E5187E582BA6E6D0B /* CocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CDC58BF93062D93A5397F6E416017CB6 /* YapProxyObjectPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 58B6FDF2CED9797B8405C338F805A26F /* YapProxyObjectPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D0378E9DFFDA42CFA7658A604E8B38E5 /* YapDatabaseViewOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = ED5C5B9F01F610A77020315FBF987883 /* YapDatabaseViewOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D05DCEB15DBFEAD19F24E63335A70028 /* YDBCKRecordInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5969815061047E5B9B5CE3BC662CCB23 /* YDBCKRecordInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D21697F8AA4C395F3726222602988A3E /* YapDatabaseTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D3B88A40FFCE0CE1CEADED6AF5B79E /* YapDatabaseTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D3609484FD90551A513D6AFE3A3CFBA3 /* YapDatabaseViewTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 87585AA8B12E51B9B4233FC88BFA95F8 /* YapDatabaseViewTypes.m */; };
-		D4AC47077A161D54C78E26B97CF61D71 /* YapDatabaseViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = BDAEAB76F993E8A4DF83A79E9E5D7070 /* YapDatabaseViewConnection.m */; };
+		CCABA9A6467D27FBB3A70B132C83E7C4 /* YapDatabaseViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = BE560E7B3149571B0A469AA39AB98984 /* YapDatabaseViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CD58D1E311DC4D6B19E774D495011125 /* YDBCKChangeRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 735271F6634176AD4065ACD204D9EC42 /* YDBCKChangeRecord.m */; };
+		CE6C36423E960AFFAC6E1F43B29980C1 /* YapDatabaseHooks.h in Headers */ = {isa = PBXBuildFile; fileRef = BBEADEFD536D7F431820BE5C7EBE8AA2 /* YapDatabaseHooks.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D22EB49E2F913CD595D63490F8CC1212 /* YapDatabaseFullTextSearchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F01A4D165CA692868A25E9BBF6A669 /* YapDatabaseFullTextSearchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D2832BD806E4514C46900E166A7B88A3 /* YapDatabaseViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DA84C17FFE47FE9FF08141A7B2C0C5A /* YapDatabaseViewTransaction.m */; };
+		D3BE609B61572EDD6137C149F797986A /* YapDatabaseFullTextSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = 431FC0D824F9F536AB27E17B7B906BB6 /* YapDatabaseFullTextSearch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D70BDFA09F4803DCFEAD7AF5DFE21C6A /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D749143D5F49E3C9BD48FA7BB7165C /* DDLog.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D832DAE0712F4E653463AC17EDBB0A26 /* YapDatabaseFilteredView.m in Sources */ = {isa = PBXBuildFile; fileRef = 664025F9111D77C497EB5EBDAFF7352F /* YapDatabaseFilteredView.m */; };
-		D86EE9EEB088F63F1DDA9052248BDB68 /* YapDatabaseSecondaryIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 2716E98730A2DAAEF16039603747F920 /* YapDatabaseSecondaryIndex.m */; };
+		D804343D3D515A62C05989E1489E095B /* YapDatabaseViewMappings.h in Headers */ = {isa = PBXBuildFile; fileRef = 588DE00AF617A40108D4B6FDF899ED77 /* YapDatabaseViewMappings.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D86F62CA5DFEB5481E009AF3C783B179 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
-		D8D556F3B02D709BCB214A6A1E02DFF9 /* YapDatabaseFullTextSearchTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = C493DA727F3B7F13334385C13B309485 /* YapDatabaseFullTextSearchTransaction.m */; };
-		D9D7FE5D7994204382EFC796141CF126 /* YapTouch.h in Headers */ = {isa = PBXBuildFile; fileRef = D8420F3D2C225CF265C25AC2E358F17D /* YapTouch.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D9E1B34E9F3B29871237756EF77F3C77 /* YapDatabaseFullTextSearchSnippetOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = A804F15716B4BE0A90BBB90D6F09EDC0 /* YapDatabaseFullTextSearchSnippetOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D9EC99F3DD12C8C2554BDAF1A30235F0 /* YapDatabaseSearchResultsView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EF33C8840C10AC6CC78BB9C934E01EA /* YapDatabaseSearchResultsView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DD66598AC4CBB61F1745584BC392387A /* YapDatabaseExtensionTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 6711DB9B11835A6D6114733CCFBF0B9F /* YapDatabaseExtensionTransaction.m */; };
-		E00C27B1724FA780C8F0238E11A35FD8 /* YapDatabaseExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DBA2ADD656A4154896386B957F00012 /* YapDatabaseExtension.m */; };
-		E04079EAF9A401CCA4B6E02BA5E3BBDF /* YapDatabaseCloudKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 39D1CAA38DED1469A692AF43F6CEE8F7 /* YapDatabaseCloudKit.m */; };
+		D91DCD2494C573A63946AD00A639F31C /* YapDatabaseSecondaryIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = EE6AF2034EAF0FE35C064E21F3E641CD /* YapDatabaseSecondaryIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9B1018C11E5CADDADA1F273D52CDF3C /* YapDatabaseViewRangeOptionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A88823955B2CF23404237E0DC4A7035 /* YapDatabaseViewRangeOptionsPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DD5F5689D9AFFC255F4B8DF61299E2C4 /* YapDatabaseSearchQueuePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = E4C86A1A38C819E98F8FE401E90C39B1 /* YapDatabaseSearchQueuePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E0474A8E92215052568E5431037D6D4A /* YapDatabaseSearchQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 335C9C17B90B28EB9DD85EB8781699C2 /* YapDatabaseSearchQueue.m */; };
+		E083FAADCD30319104455635E651DA89 /* YapDatabaseViewState.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B59B37AC17C28B187B3C09D4643996 /* YapDatabaseViewState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E153E8CA07EBCA8F10740E6057AB07BD /* YapWhitelistBlacklist.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D411C477E3CD68B33537133E141EE39 /* YapWhitelistBlacklist.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1B5745E0C972329160CE8A1EAD77CFD /* YapDatabaseViewPage.mm in Sources */ = {isa = PBXBuildFile; fileRef = F154C204602290FC80C2C026EDF9C13F /* YapDatabaseViewPage.mm */; };
 		E1ED34DB49C6A05D740B8425F88CEC20 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = E0B6669DD9DFCA4DA310C01E3382CC12 /* DDMultiFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E23084FC5F07D46C4F162CA3A58FF89F /* YapDatabaseRelationshipEdgePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 72791598ECD2F055D4426C09D504B8E5 /* YapDatabaseRelationshipEdgePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E368AF6624699AD6E5766B19ABCC5980 /* YapDatabaseSearchResultsView.m in Sources */ = {isa = PBXBuildFile; fileRef = DD359AE3E025D48F2D646D8DE4DEB153 /* YapDatabaseSearchResultsView.m */; };
-		E50CEAAD702118FA08956E479B2A96C9 /* YapDatabaseCloudKitPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5457EC80185B03E121EEBCE5322D0A /* YapDatabaseCloudKitPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E570326A40FAB23225371D1EA5E3BC93 /* YapDatabaseViewPage.mm in Sources */ = {isa = PBXBuildFile; fileRef = E081F26EDC1B8A42C4FD3963DC37D439 /* YapDatabaseViewPage.mm */; };
-		E62E2A96500B41384CAE4C1FFF2E6FDC /* YapDatabaseHooks.h in Headers */ = {isa = PBXBuildFile; fileRef = 4264DA79BA4E0AAB911889ED58534F86 /* YapDatabaseHooks.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E78466BE25AE02C87FABAE0A20B4C5C6 /* YapDatabaseRelationshipTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = B4823D8979398FB49D4F0711FDC40086 /* YapDatabaseRelationshipTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E93EE1ED6B51197ABC1695A4C099C81C /* YapDatabaseFullTextSearchTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = FC0169A057F34239D824035BF8BF70E2 /* YapDatabaseFullTextSearchTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E9EB5D3E166360A358E6BE999B0B2C02 /* YapDatabaseFullTextSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = 36E21A8119699FDB374CB3262F227E97 /* YapDatabaseFullTextSearch.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E9FAB73235EAFA1F8BACF17C837DECAA /* YDBCKChangeRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = 007FBB4E43B8A81EBBEBBE6F02BB498D /* YDBCKChangeRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EA6C2212F71700FFBC9428C6274E8EBD /* YapDatabaseHooksTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = B76BF2AEB1ED1C1CD557B0D8201060A7 /* YapDatabaseHooksTransaction.m */; };
-		EADC363BD2BE6F25A2ADE6C9DD10F617 /* YapDatabaseFullTextSearchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 31D41B028047C6A2120B960CDF3873EE /* YapDatabaseFullTextSearchHandler.m */; };
-		EB7BF161A0F9A5C3E10DBE428A891FA8 /* YDBCKRecordTableInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 406AF711EAD3928320CF20A6A8EDB7AD /* YDBCKRecordTableInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDE185716C3C61927A1B35F6F52B0039 /* YapDatabaseViewChange.m in Sources */ = {isa = PBXBuildFile; fileRef = 887496371A927B96DB904DAF6CEAFD5C /* YapDatabaseViewChange.m */; };
-		F095A542DBD5D5B116135F8D4004B838 /* YapDatabaseRTreeIndexConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = BD438CBD6985592ACBDCDA7FFB555002 /* YapDatabaseRTreeIndexConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F238476CDDDFF709EBAD06DF4B20C551 /* YapDatabaseSearchResultsViewTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8839EA01057AEB7F503BF26037735AC1 /* YapDatabaseSearchResultsViewTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F4699653CD000EB5F093FF533C59C3FC /* YapDatabaseSearchResultsViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 961C6B5676175CEC649B82DC721C8E79 /* YapDatabaseSearchResultsViewTransaction.m */; };
-		F5C7281CA959AF788516BC641F95563A /* YapDatabase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8444A49016D7B4DE2FF5C6ACC4C5E76F /* YapDatabase-dummy.m */; };
-		F64AA423D0BE9D25FE17F5ACE38E84C9 /* YapDatabaseFilteredViewTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = AFF892BFEFDFFBFA0F707291720BD75F /* YapDatabaseFilteredViewTransaction.m */; };
+		E26FE555508A95DD7E9784CAF00FD88E /* YapDatabaseViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3433CD6CA599FE0F2A43D00ABCEB9AD0 /* YapDatabaseViewOptions.m */; };
+		E488E755566BEE79E30962154BF4A3C6 /* YapDatabaseFilteredViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 92D2842C01718447F2E5C2D43A31FEB6 /* YapDatabaseFilteredViewConnection.m */; };
+		E564F94F334CB5991CC363D0C3088B16 /* YapDatabaseLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A731B4CF2411668A2A3E5F5606DBF36 /* YapDatabaseLogging.m */; };
+		E56AC57FF6BF8B110C4F2183B3CF27C0 /* YapCache.m in Sources */ = {isa = PBXBuildFile; fileRef = EEA9FC47CCDB0BC42CAE7B40F58B9608 /* YapCache.m */; };
+		E768D256E7AE3253A4FEE145EEE0A3FF /* YapDatabaseCloudKitConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = A5EA313B3FE5E4B0D1FF792CFE9C65E2 /* YapDatabaseCloudKitConnection.m */; };
+		E8DABF5F1CB54E483227AAF5EC26CED2 /* YapDatabaseExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 85F0BD09A3E638982B9C7D19F91A2241 /* YapDatabaseExtension.m */; };
+		E9E7EFE6F8DD4D4BE38F58709FCD0365 /* YDBCKMergeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 925D7AABFC58BAB22BC407AEEAEBA1BD /* YDBCKMergeInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA5E8BC140E1DED4A02000E16BB973E0 /* YapRowidSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6332E5C2A5A9E92E463CAB56FBDF4442 /* YapRowidSet.mm */; };
+		EB5D5C2E77B4108A13B76E7EC322B356 /* YapDatabaseViewPageMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = D1D9BA99F5891F1FDF30595A4835DD57 /* YapDatabaseViewPageMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB5E6D02113BFD07D15304F5D873CA45 /* YDBCKMappingTableInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = E1936902513F202C2C297FABFA27C4BF /* YDBCKMappingTableInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ECCE55284A1707A2AFD4BE58C41E1618 /* YapDatabaseFullTextSearchTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C42EFA4176B229F3F2A364D5C06F47D /* YapDatabaseFullTextSearchTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECE111F94DEE964104CCB11D824749F4 /* YapDatabaseRelationshipOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = D552320B282048236DBC0CA1C1A4885F /* YapDatabaseRelationshipOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED5D7AC47325195B903512E16965381A /* YapProxyObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 512DA652F7AA2E773925FC581870FAA4 /* YapProxyObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED69B7F521A8F3E6AAD2A64C9ECDD61B /* YapRowidSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BB4891AEDDBC9A49BB90CEB8084B248 /* YapRowidSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EF9F25714176EC39EBE501175098CA44 /* YapDatabaseRTreeIndexConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 45AEBB0826B6D6EA9148625A13E87DD7 /* YapDatabaseRTreeIndexConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F2797BF960D828722CCFBF263CA6E6F4 /* YapDatabaseViewPage.h in Headers */ = {isa = PBXBuildFile; fileRef = 14152B0E81AC743C88A84BAF743014DB /* YapDatabaseViewPage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F27FCC444876B5E74C992529B329DDC1 /* YapDatabaseTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = E356EAB8387563F6A2981CDA2674F93F /* YapDatabaseTransaction.m */; };
+		F4B57C6AA4323BEDA4525F7862A71884 /* YapDatabaseRTreeIndexTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 67A760F20E66FD73996418756D4F36A8 /* YapDatabaseRTreeIndexTransaction.m */; };
+		F571370F530D6DF2F13D32944D140949 /* YapDatabaseSecondaryIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 618EFE0F8E01768F6B136A6625B56F85 /* YapDatabaseSecondaryIndex.m */; };
+		F595E02D65FB67C6A256017C08E4CF66 /* YapDatabaseCloudKitTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = B13E5D4CD2A169A97A3C431BE59D399E /* YapDatabaseCloudKitTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F5FADDFCD90E501799869B3BAA83DA52 /* YDBCKAttachRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A91CCD9279E9FDC37A131C25F0B0079 /* YDBCKAttachRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F6936CEB6D15BB0B81EBBBBF2D74CF9B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
 		F76169493792D19A7D19F648A4E2BB6A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
-		F7ED854C5396CB2D97B28D8665A2A751 /* YDBCKMappingTableInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 22CA4E953C53469E4E4B6059608F8E19 /* YDBCKMappingTableInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F9B033B6CF260AF75B54D363279E72E3 /* YapDatabaseHooksPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 06C6ED641F3F6FB4942EB50C07CC3577 /* YapDatabaseHooksPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FA56C3CF85F9B1F9035E18EB28CD4CEA /* YapDatabaseView.m in Sources */ = {isa = PBXBuildFile; fileRef = 15AE9590A34649AD395416642C192072 /* YapDatabaseView.m */; };
-		FCA086EFC13567301D9E956E5E8959C5 /* YapDatabaseSearchQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = DE3294276C924F16704CC165C4549040 /* YapDatabaseSearchQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FCB6070AF48A3E65B4FCAC1A0F91DC6C /* YapDatabaseRTreeIndexHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9940A1D73FF6AA9B60856DA512BD05CC /* YapDatabaseRTreeIndexHandler.m */; };
-		FDC72DD6896206ED1AE63A8CB25C97F5 /* YapDatabaseFilteredViewConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = CB2CA8D16215C695CBDAE264EF79D2DF /* YapDatabaseFilteredViewConnection.m */; };
-		FDD5EF992EA748F75D4BACFA2C4175E6 /* YapDatabaseStatement.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CBBFC8456EC190EF17380BB3BBBB246 /* YapDatabaseStatement.m */; };
+		F863178D9D99A5CD40890871533DD31D /* YapDatabaseSecondaryIndexTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 9046F142368EAC233E0104100D0A9F9E /* YapDatabaseSecondaryIndexTransaction.m */; };
+		F8DB2224EC35009A92BF819B0E36E089 /* YapDatabaseViewTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = AF738860A95B5CA35BD3B7D327E6A167 /* YapDatabaseViewTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F9540C1ED83692973709C68F8607EDA7 /* YapMemoryTable.m in Sources */ = {isa = PBXBuildFile; fileRef = C6A13E18CA4A10DD8EB7EA051F41F671 /* YapMemoryTable.m */; };
+		FA062F8ECE31623E5C2E3B077491AA59 /* YapDatabaseRTreeIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = E862240EFD43D88973D14F5C89041DD8 /* YapDatabaseRTreeIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB3612DCC9116C86981F735394C8FDFF /* YapDatabaseCloudKitTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ADD94D94B918BED82B04E8A24822FF4 /* YapDatabaseCloudKitTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC72CDDEA4A05B3413FF02E0AD737A66 /* YapDatabaseStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = B42484D2DC02355DCC0432F4B3B61C66 /* YapDatabaseStatement.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FCE97D46E93F223B3656326BFA523321 /* YDBCKChangeQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 785A6EBAB877052B9D64302D41BE1CE3 /* YDBCKChangeQueue.m */; };
 		FE6239BDE2049B920243DC0F907F57B9 /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3674FFD7C40D6DC34AC17AB452D2D62A /* DDDispatchQueueLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		FF7BF12DFD112AB97971340DC7CAEB37 /* YapDatabaseCloudKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 70148D1193160616A141B898741CED14 /* YapDatabaseCloudKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FFD47FAC7D522D27CF95128AC9C306E3 /* YapDatabaseSecondaryIndexPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A34389BF4250F17A7DC6236D2602F2F1 /* YapDatabaseSecondaryIndexPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -251,235 +253,237 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		007FBB4E43B8A81EBBEBBE6F02BB498D /* YDBCKChangeRecord.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKChangeRecord.h; sourceTree = "<group>"; };
-		00E62FAB527D4E84B59CC8917C0EEAB6 /* YapDatabaseViewRangeOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewRangeOptions.m; sourceTree = "<group>"; };
-		00EA9E27554304E93282EF5BF2E2F20E /* YapDatabaseFullTextSearchHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchHandler.h; sourceTree = "<group>"; };
-		01D92F2CCC8F831D0BD10B2F566419FB /* YapDatabaseExtension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtension.h; sourceTree = "<group>"; };
-		06C6ED641F3F6FB4942EB50C07CC3577 /* YapDatabaseHooksPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooksPrivate.h; sourceTree = "<group>"; };
+		0301D1213B53FE972FA123E635BDC289 /* YapDatabaseRelationshipConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipConnection.m; sourceTree = "<group>"; };
+		03A8BB14AC12D63777DAD6779A5D1E24 /* YapDatabaseRelationship.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationship.h; sourceTree = "<group>"; };
+		04E1D832E3826A3841B5F1824424B3D9 /* NSDictionary+YapDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+YapDatabase.h"; sourceTree = "<group>"; };
+		066DFBE6D611B4C32B67F4D64776E2F6 /* YapDatabaseFullTextSearchPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchPrivate.h; sourceTree = "<group>"; };
+		078C605F00CEEB5C2DFC1B245FB5EEAC /* YapDatabaseConnectionState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionState.m; sourceTree = "<group>"; };
+		07B8E0042E7103C7F774B4E701BFD24A /* YapDatabaseExtensionTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionTransaction.h; sourceTree = "<group>"; };
 		07D14B15A24A77A47840C41A54B498AE /* DDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLegacyMacros.h; path = Classes/DDLegacyMacros.h; sourceTree = "<group>"; };
 		08D1257418C387D9D20F89315328D5EC /* DDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDContextFilterLogFormatter.h; path = Classes/Extensions/DDContextFilterLogFormatter.h; sourceTree = "<group>"; };
-		08FAC5D5D1E18105013013CB5CB52037 /* YapCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapCache.m; sourceTree = "<group>"; };
-		09561652B20D0FA310DE3A34F27C4DBC /* YapTouch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapTouch.m; sourceTree = "<group>"; };
-		0CBBFC8456EC190EF17380BB3BBBB246 /* YapDatabaseStatement.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseStatement.m; sourceTree = "<group>"; };
-		0E1C881674CCFCEC3A7F5A6D542E5569 /* YapDatabaseString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseString.h; sourceTree = "<group>"; };
+		08F365D1D3C859D8021FAE04FFCE75DA /* YapNull.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapNull.m; sourceTree = "<group>"; };
+		095CD441C9F376C49A851B4E015140D9 /* YapDatabaseRelationshipTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipTransaction.h; sourceTree = "<group>"; };
+		0BAFD282AA4E753B936469759F6EFBF9 /* YapDatabaseHooksConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseHooksConnection.m; sourceTree = "<group>"; };
+		0C43A49A032BCB6035B5D5ECBF372974 /* YapDatabaseViewTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTransaction.h; sourceTree = "<group>"; };
+		0F267CC1687E514DE47803149EC22F46 /* YapSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapSet.h; sourceTree = "<group>"; };
 		10834806BD7B412BC24F347361FA2C8E /* Pods-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-acknowledgements.plist"; sourceTree = "<group>"; };
-		13B559B8B485AD1A1244C3AD0541DB8D /* YapDatabaseCloudKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKit.h; sourceTree = "<group>"; };
-		13FF6186DF8800A4BFDC7FEC4F5059D7 /* YapDatabaseExtensionConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseExtensionConnection.m; sourceTree = "<group>"; };
-		141EA78507E51434FB98CB56A16761A6 /* YapDatabaseCloudKitTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitTransaction.m; sourceTree = "<group>"; };
-		149731DA986DB2C776E29A665147D713 /* YapMutationStack.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapMutationStack.m; sourceTree = "<group>"; };
-		156E19773AC758436E61E2C1CEAA6C38 /* YapDatabaseView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseView.h; sourceTree = "<group>"; };
-		15AE9590A34649AD395416642C192072 /* YapDatabaseView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseView.m; sourceTree = "<group>"; };
-		16E86CDC2927006B4C7E0724E79A474A /* YapDatabaseSecondaryIndexConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexConnection.m; sourceTree = "<group>"; };
-		17A93D76A7C9D3B713D4D23351242550 /* YapDatabaseViewPageMetadata.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPageMetadata.h; sourceTree = "<group>"; };
-		17DEE28F34BA84F7EA660DE6ACD00739 /* YapSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapSet.m; sourceTree = "<group>"; };
-		17F23FBBECC8D76022977869F9D2241A /* YDBCKMappingTableInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKMappingTableInfo.m; sourceTree = "<group>"; };
-		17F246F978EDFF63B74C3495A9170A56 /* YapDatabaseRelationshipTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipTransaction.m; sourceTree = "<group>"; };
-		18704AB521F27C897E10ABBACB212C2E /* YapDatabaseSecondaryIndexTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexTransaction.m; sourceTree = "<group>"; };
-		195E5629ADEADF5E4027444230A2A9D5 /* YDBCKMergeInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKMergeInfo.m; sourceTree = "<group>"; };
-		1A19399A3C2F620C0B834005E4E50328 /* YapDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabase.h; sourceTree = "<group>"; };
-		1A3E1593B93BC0F42009D6AECDDDF07A /* YapNull.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapNull.h; sourceTree = "<group>"; };
-		1C277CE54037E425394097ED90BF5F4B /* YapDatabaseSearchQueuePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchQueuePrivate.h; sourceTree = "<group>"; };
-		1DFBB72BC17352E2BC6B3697E136A5AA /* YapDatabaseFilteredViewTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewTypes.m; sourceTree = "<group>"; };
-		1E84AC0D831FB5A826F174D4C6D72738 /* YapRowidSet.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = YapRowidSet.mm; sourceTree = "<group>"; };
+		12DD26FAC94AC9BCB815C05B60EE72FD /* YapDatabaseHooksTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooksTransaction.h; sourceTree = "<group>"; };
+		14152B0E81AC743C88A84BAF743014DB /* YapDatabaseViewPage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPage.h; sourceTree = "<group>"; };
+		162D9FAD9D93CE3DDAEFA86842441C12 /* YapDatabaseOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseOptions.m; sourceTree = "<group>"; };
+		170866E29089324B75A4AF806DEE1C8B /* YapDatabaseView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseView.h; sourceTree = "<group>"; };
+		1B214AC0F2B4A9A5C40005E2CA2681AC /* YapDatabaseCloudKitTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitTransaction.m; sourceTree = "<group>"; };
+		1B6D524F63036E29C471D5BB8D4AA322 /* YDBCKRecordInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKRecordInfo.m; sourceTree = "<group>"; };
+		1DE13599F8EF3729EA813AB2976F1B3A /* YapDatabaseRTreeIndexTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexTransaction.h; sourceTree = "<group>"; };
 		1ECA9AE91B3BD36523C5A7E8398E2B1D /* DDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAssertMacros.h; path = Classes/DDAssertMacros.h; sourceTree = "<group>"; };
-		1EDC89F3C717A2A72179C3F65DE5FC82 /* YapDatabaseRTreeIndexTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexTransaction.h; sourceTree = "<group>"; };
-		2010C2C215274160D0D77DA6BF23CBD0 /* YapDatabaseConnectionDefaults.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionDefaults.m; sourceTree = "<group>"; };
-		2101F63B89170E1A41654F2922290E8A /* YapDatabaseSecondaryIndexTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexTransaction.h; sourceTree = "<group>"; };
-		21931CB46FD6E2EE321E637420D8BB40 /* YDBCKAttachRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKAttachRequest.h; sourceTree = "<group>"; };
-		22CA4E953C53469E4E4B6059608F8E19 /* YDBCKMappingTableInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKMappingTableInfo.h; sourceTree = "<group>"; };
-		2546001E7D901F1685DEF9BD07F3D899 /* YapDatabaseRelationshipEdge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipEdge.m; sourceTree = "<group>"; };
-		267A9AA89552FC258F07308F9B38435C /* YapDatabaseCloudKitTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitTransaction.h; sourceTree = "<group>"; };
-		2716E98730A2DAAEF16039603747F920 /* YapDatabaseSecondaryIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndex.m; sourceTree = "<group>"; };
+		1FA43605B373DF0C40E2390216E48ECF /* YapDatabaseRelationship.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationship.m; sourceTree = "<group>"; };
+		205A1BB1019E926556F1C327165E05E7 /* YapDatabaseExtension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtension.h; sourceTree = "<group>"; };
+		20A80B0E1A92856E748F6C6BADE2A99A /* YapDatabaseRelationshipOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipOptions.m; sourceTree = "<group>"; };
+		21FED17AA39661D6EE485EC0FC1E3AA9 /* YapDatabaseRTreeIndexConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexConnection.m; sourceTree = "<group>"; };
+		223F025287AF6C7CF6F7EED41CAC94E4 /* YapDatabaseFullTextSearchHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchHandler.m; sourceTree = "<group>"; };
 		272643F56613CA0D336AE3DBF19DC404 /* Pods-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-dummy.m"; sourceTree = "<group>"; };
-		2CD090CEA67216801022BC73F5A62D60 /* YapDatabaseRelationship.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationship.h; sourceTree = "<group>"; };
-		2E9E2A2FADC98251BEA03528444D8045 /* YapSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapSet.h; sourceTree = "<group>"; };
-		2EE925426226F66EBE27083E21D2EF47 /* YapDatabaseRTreeIndexPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexPrivate.h; sourceTree = "<group>"; };
-		2EF33C8840C10AC6CC78BB9C934E01EA /* YapDatabaseSearchResultsView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsView.h; sourceTree = "<group>"; };
-		2F5457EC80185B03E121EEBCE5322D0A /* YapDatabaseCloudKitPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitPrivate.h; sourceTree = "<group>"; };
-		31C2DC894C76D3988286A29A4071294C /* YapDatabaseFilteredViewTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTransaction.h; sourceTree = "<group>"; };
-		31D41B028047C6A2120B960CDF3873EE /* YapDatabaseFullTextSearchHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchHandler.m; sourceTree = "<group>"; };
-		33B199F7093926D3CB070BFFBBE791EC /* YapDatabaseViewPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPrivate.h; sourceTree = "<group>"; };
-		35B9A7DE3B087B7CAFE90F3116050359 /* YapDatabaseHooks.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseHooks.m; sourceTree = "<group>"; };
+		295A08A57D836839687D902AF3CAE16A /* YapDatabaseSecondaryIndexConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexConnection.h; sourceTree = "<group>"; };
+		29D1D37376D0FA2432D6E0EA8A81C99E /* YapDatabaseConnectionDefaults.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionDefaults.h; sourceTree = "<group>"; };
+		2A59AB1E50836F2AC7ABCEE5F69EDFC6 /* YapDatabaseCloudKitOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitOptions.h; sourceTree = "<group>"; };
+		2A91CCD9279E9FDC37A131C25F0B0079 /* YDBCKAttachRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKAttachRequest.h; sourceTree = "<group>"; };
+		2B15FB5AC603FDDAECDEAC911D73B59A /* YapDatabaseSearchResultsView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsView.m; sourceTree = "<group>"; };
+		2D411C477E3CD68B33537133E141EE39 /* YapWhitelistBlacklist.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapWhitelistBlacklist.h; sourceTree = "<group>"; };
+		30FA88DA054BAAD5760CAD45B4E7D54D /* YapDatabaseExtensionTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseExtensionTransaction.m; sourceTree = "<group>"; };
+		32FB3B46CDE27687DBD28680B7CBBE90 /* YapDatabaseCloudKitOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitOptions.m; sourceTree = "<group>"; };
+		335C9C17B90B28EB9DD85EB8781699C2 /* YapDatabaseSearchQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchQueue.m; sourceTree = "<group>"; };
+		33F998CAAFC0BB728C266B47A2916E0B /* YapDatabaseFilteredViewTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewTypes.m; sourceTree = "<group>"; };
+		3422204C401A303ED132EEC30520C8E4 /* YapDatabaseFullTextSearchTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchTransaction.m; sourceTree = "<group>"; };
+		3433CD6CA599FE0F2A43D00ABCEB9AD0 /* YapDatabaseViewOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewOptions.m; sourceTree = "<group>"; };
+		35276D85BBC346627857A00348F6BBD0 /* YapDatabaseRTreeIndexOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexOptions.m; sourceTree = "<group>"; };
 		3674FFD7C40D6DC34AC17AB452D2D62A /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDDispatchQueueLogFormatter.m; path = Classes/Extensions/DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		36E21A8119699FDB374CB3262F227E97 /* YapDatabaseFullTextSearch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearch.h; sourceTree = "<group>"; };
-		3736A93A853FCCE34D0B47664ACB2EA4 /* YapDatabaseRelationshipPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipPrivate.h; sourceTree = "<group>"; };
-		37C151B90C5FCF2D8043FFEB4A429879 /* YapDatabaseConnectionDefaults.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionDefaults.h; sourceTree = "<group>"; };
+		3743600F62D86F75F23ABAF40B755D44 /* YapDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabase.h; sourceTree = "<group>"; };
 		37DB56D75062CC75FCB0966E1C6E8A8E /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
-		3933EBB1C8D82723A3C236689E70A221 /* YapDatabaseViewChangePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChangePrivate.h; sourceTree = "<group>"; };
-		39D1CAA38DED1469A692AF43F6CEE8F7 /* YapDatabaseCloudKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKit.m; sourceTree = "<group>"; };
+		38AE55FAD5B609795FBAE530C6F43A18 /* YapMurmurHash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapMurmurHash.h; sourceTree = "<group>"; };
+		3A488CBE826207809B87F7DD719F75D3 /* YapDatabaseSearchResultsViewConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsViewConnection.m; sourceTree = "<group>"; };
+		3ADD94D94B918BED82B04E8A24822FF4 /* YapDatabaseCloudKitTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitTransaction.h; sourceTree = "<group>"; };
+		3B6D235FBFBDA00EB1C229E2A64D1EA4 /* YapDatabaseView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseView.m; sourceTree = "<group>"; };
+		3B903CD7650F49A9B8BF5F2FC63FD8F4 /* YapDatabaseFullTextSearchSnippetOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchSnippetOptions.h; sourceTree = "<group>"; };
+		3BB4891AEDDBC9A49BB90CEB8084B248 /* YapRowidSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapRowidSet.h; sourceTree = "<group>"; };
+		3CF2C9C1A9FD4BEF4C95FFF21B9E9967 /* YapDatabaseSearchResultsViewConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewConnection.h; sourceTree = "<group>"; };
 		3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		3EC8E4E6780E7D9C3867E12D2E68B83B /* YapCollectionKey.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapCollectionKey.m; sourceTree = "<group>"; };
-		3FF6210D530D2B43E944C23B0987C370 /* YapDatabaseRelationshipEdge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipEdge.h; sourceTree = "<group>"; };
-		406AF711EAD3928320CF20A6A8EDB7AD /* YDBCKRecordTableInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKRecordTableInfo.h; sourceTree = "<group>"; };
-		40B5BD446EB2C743507304B2FF4E8274 /* YapWhitelistBlacklist.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapWhitelistBlacklist.h; sourceTree = "<group>"; };
-		4264DA79BA4E0AAB911889ED58534F86 /* YapDatabaseHooks.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooks.h; sourceTree = "<group>"; };
-		432443F2C87AC74636CAFA860D82301B /* YapMutationStack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapMutationStack.h; sourceTree = "<group>"; };
-		44862C31C5156B32F61D4E2A185E0ED1 /* YapDatabaseRelationshipConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipConnection.h; sourceTree = "<group>"; };
-		45305F54F84DF41BA8DB7C4012E00270 /* YDBCKChangeRecord.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKChangeRecord.m; sourceTree = "<group>"; };
-		4676F29F296CA30BB7FC6209AE36C3E0 /* YapDatabaseOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseOptions.m; sourceTree = "<group>"; };
-		47C0A1CC1E4EFA2E142C09A03BE57324 /* YapDatabaseHooksConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooksConnection.h; sourceTree = "<group>"; };
-		47DE15CB269FE987356EB6B862B4B246 /* YapDatabaseRTreeIndexTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexTransaction.m; sourceTree = "<group>"; };
-		4BBAB136DF1CDB8E26F4E50C5950B16E /* YapDatabaseCloudKitConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitConnection.m; sourceTree = "<group>"; };
-		4DBA2ADD656A4154896386B957F00012 /* YapDatabaseExtension.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseExtension.m; sourceTree = "<group>"; };
+		4286818F79DF6399D8C80A55C8698748 /* YapCollectionKey.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapCollectionKey.m; sourceTree = "<group>"; };
+		431FC0D824F9F536AB27E17B7B906BB6 /* YapDatabaseFullTextSearch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearch.h; sourceTree = "<group>"; };
+		45AEBB0826B6D6EA9148625A13E87DD7 /* YapDatabaseRTreeIndexConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexConnection.h; sourceTree = "<group>"; };
+		4C8258F93F925D14536055202725330D /* YDBCKChangeSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKChangeSet.m; sourceTree = "<group>"; };
+		4E6C88428F27576F6B98C55065A395D2 /* YapDatabaseSecondaryIndexSetup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexSetup.m; sourceTree = "<group>"; };
 		4E762F23EC34ED4A6FF3312D84E33A40 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.debug.xcconfig; sourceTree = "<group>"; };
 		4ECBC81DB84A5A4288984BC5417A1458 /* DDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDFileLogger.h; path = Classes/DDFileLogger.h; sourceTree = "<group>"; };
-		4FB7FE4C86732572E873982D8B91A298 /* YapMurmurHash.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapMurmurHash.m; sourceTree = "<group>"; };
-		50AD9E691B386637203C026BECB09CCE /* YapDatabaseQuery.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseQuery.m; sourceTree = "<group>"; };
-		50E334B1113F8DA1A41E548D103FA35B /* YapDatabaseRelationship.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationship.m; sourceTree = "<group>"; };
-		510DAEE7486A1189A8D8A338F1D29187 /* YDBCKChangeSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKChangeSet.m; sourceTree = "<group>"; };
-		58B6FDF2CED9797B8405C338F805A26F /* YapProxyObjectPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapProxyObjectPrivate.h; sourceTree = "<group>"; };
-		5969815061047E5B9B5CE3BC662CCB23 /* YDBCKRecordInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKRecordInfo.h; sourceTree = "<group>"; };
-		596E22310CB02C0DECC8A22453112FD1 /* YapNull.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapNull.m; sourceTree = "<group>"; };
-		5B8685405FA425FB91DB19EC16615BF4 /* YapDatabaseConnectionState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionState.h; sourceTree = "<group>"; };
-		5B934F8B990F20725EBBD74BB758687C /* YapDatabaseTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseTransaction.m; sourceTree = "<group>"; };
-		5CEFD4A0BD33464B5AC307F3BD6F598F /* YapDatabaseLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseLogging.h; sourceTree = "<group>"; };
-		5E4C1FB6D1F2FBEAC5DEEE5E42DC5224 /* YapDatabaseRelationshipOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipOptions.h; sourceTree = "<group>"; };
-		5F5F9A6B6EEFC47F3957A2B0FC1EDE93 /* YapDatabaseCloudKitTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitTypes.h; sourceTree = "<group>"; };
-		5FE8E291DF9CC73A045A14E016662E78 /* YapDatabaseSecondaryIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndex.h; sourceTree = "<group>"; };
-		61B6DEF61AA4581CA87266F8C56DB83A /* YapDatabaseSearchResultsViewOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewOptions.h; sourceTree = "<group>"; };
-		6210A508B0D0F7D302EEA81450939EE6 /* YapDatabaseSearchQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchQueue.m; sourceTree = "<group>"; };
-		62AC2ED5547490F589AD92623B4C2B86 /* YapDatabaseSearchResultsViewPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewPrivate.h; sourceTree = "<group>"; };
-		664025F9111D77C497EB5EBDAFF7352F /* YapDatabaseFilteredView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredView.m; sourceTree = "<group>"; };
-		6711DB9B11835A6D6114733CCFBF0B9F /* YapDatabaseExtensionTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseExtensionTransaction.m; sourceTree = "<group>"; };
-		67C010093856E1FF19E3EA958E6C99A4 /* YapDatabaseConnectionState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionState.m; sourceTree = "<group>"; };
+		4F09193A28EAB2411721F2808F524FDE /* YapMutationStack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapMutationStack.h; sourceTree = "<group>"; };
+		4F9045309AEBBEBFFF9AAE54D6C58D81 /* YapDatabaseRTreeIndexHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexHandler.h; sourceTree = "<group>"; };
+		512DA652F7AA2E773925FC581870FAA4 /* YapProxyObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapProxyObject.h; sourceTree = "<group>"; };
+		54B8FCF040E027340763CA7A5F06BEE8 /* YapCollectionKey.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapCollectionKey.h; sourceTree = "<group>"; };
+		55D0E3A516998382A47D28A0D4D2E254 /* YDBCKRecord.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKRecord.m; sourceTree = "<group>"; };
+		588DE00AF617A40108D4B6FDF899ED77 /* YapDatabaseViewMappings.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappings.h; sourceTree = "<group>"; };
+		59BE28F82571F459A3315C11AC752CC7 /* YapDatabaseRTreeIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndex.m; sourceTree = "<group>"; };
+		5A7F146404765E5F41CCA63F2F6FB505 /* YapDatabaseRelationshipEdge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipEdge.m; sourceTree = "<group>"; };
+		5AF85CC72B4157D186F6138A0FB87803 /* YapDatabaseSearchResultsViewOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsViewOptions.m; sourceTree = "<group>"; };
+		5B931D61E8C05236749B4B6B1D2ACBC2 /* YapDatabaseString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseString.h; sourceTree = "<group>"; };
+		5D88E3EB5B05814AF2D64972ACF582CB /* YapDatabaseQuery.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseQuery.m; sourceTree = "<group>"; };
+		5DA84C17FFE47FE9FF08141A7B2C0C5A /* YapDatabaseViewTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewTransaction.m; sourceTree = "<group>"; };
+		5E71E4B9CDAF788A2A0BBE9BF195EF99 /* YapDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabase.m; sourceTree = "<group>"; };
+		5F409BFD2D58D005C50238FF512DB514 /* YapDatabaseFullTextSearchConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchConnection.h; sourceTree = "<group>"; };
+		60F01A4D165CA692868A25E9BBF6A669 /* YapDatabaseFullTextSearchHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchHandler.h; sourceTree = "<group>"; };
+		615B15C0A189EB4F392ED4A73C1204BC /* YapDatabaseCloudKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKit.m; sourceTree = "<group>"; };
+		618EFE0F8E01768F6B136A6625B56F85 /* YapDatabaseSecondaryIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndex.m; sourceTree = "<group>"; };
+		61E46EC80448C8EFF19BB2C7964CC2B9 /* YapDatabaseViewRangeOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptions.h; sourceTree = "<group>"; };
+		620858EE8185FD9C37CAE749CFF95B5E /* YapDatabaseSearchResultsViewTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsViewTransaction.m; sourceTree = "<group>"; };
+		6219C4A647C73AB9631E933DAEA82790 /* YDBCKRecordTableInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKRecordTableInfo.m; sourceTree = "<group>"; };
+		6332E5C2A5A9E92E463CAB56FBDF4442 /* YapRowidSet.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = YapRowidSet.mm; sourceTree = "<group>"; };
+		63B87551B56C58AFD97D02BC76F05121 /* YapDatabaseViewChangePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChangePrivate.h; sourceTree = "<group>"; };
+		648B3D971CEE5A228AB4538951600640 /* YapDatabaseRTreeIndexSetup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexSetup.h; sourceTree = "<group>"; };
+		64CEAA3119423C3CE45FE80C2C200E31 /* YapDatabaseSearchResultsViewOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewOptions.h; sourceTree = "<group>"; };
+		65991F1294DA96B7EA0C8A6EE6D1896C /* YDBCKChangeRecord.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKChangeRecord.h; sourceTree = "<group>"; };
+		67A760F20E66FD73996418756D4F36A8 /* YapDatabaseRTreeIndexTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexTransaction.m; sourceTree = "<group>"; };
+		67AB9B55F95187CC2A6E269BA5608979 /* YapDatabaseRTreeIndexPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexPrivate.h; sourceTree = "<group>"; };
+		67B4169E7860520B798703A0E927FEC7 /* YapNull.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapNull.h; sourceTree = "<group>"; };
 		6911BECA35E7518D864239B7E898EEF3 /* Pods-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-frameworks.sh"; sourceTree = "<group>"; };
-		698A0EDED4E43094B576B506684195AA /* YapProxyObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapProxyObject.m; sourceTree = "<group>"; };
 		6A48E2707F82BB1204E9FE86C722BC38 /* DDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDTTYLogger.m; path = Classes/DDTTYLogger.m; sourceTree = "<group>"; };
 		6A94949FDBA8DDEDE26D368F6681F14C /* CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
-		6AAEEA1072C5BB9C6383833049A46A21 /* YapDatabasePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabasePrivate.h; sourceTree = "<group>"; };
-		6C810AFBF3CF08D27EC329C1321F4EBA /* YapDatabaseViewMappings.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewMappings.m; sourceTree = "<group>"; };
-		6DAAEC926B805B901CD33E8FED183A7D /* YapDatabaseSecondaryIndexSetup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexSetup.m; sourceTree = "<group>"; };
+		6ABB9105344311034ABFE100BE23208F /* YapCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapCache.h; sourceTree = "<group>"; };
+		6B173A54339ED3F50B1422413FBC8206 /* YapDatabaseQuery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseQuery.h; sourceTree = "<group>"; };
+		6CFA4DACD9D17D57D8DB524B19AB3CB8 /* YapDatabaseTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseTransaction.h; sourceTree = "<group>"; };
 		6E8A5E2C34A7F268ED856D3E45F53E10 /* YapDatabase-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "YapDatabase-prefix.pch"; sourceTree = "<group>"; };
-		6F42CE7A134CACC769CC43F3957390BC /* YapDatabaseViewTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewTransaction.m; sourceTree = "<group>"; };
-		72791598ECD2F055D4426C09D504B8E5 /* YapDatabaseRelationshipEdgePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipEdgePrivate.h; sourceTree = "<group>"; };
-		737BE1C70655CCB06A7FED1AC1F9082E /* YapDatabaseExtensionConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionConnection.h; sourceTree = "<group>"; };
-		7571D738DE3587598B32E052F36E0203 /* YapDatabaseSearchResultsViewOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsViewOptions.m; sourceTree = "<group>"; };
+		6FBF8D791F194AAF1409A2A9E6B3C074 /* YapDatabaseRelationshipEdgePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipEdgePrivate.h; sourceTree = "<group>"; };
+		70039F4F7773BA238D0818BCB1A56609 /* YDBCKRecord.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKRecord.h; sourceTree = "<group>"; };
+		70148D1193160616A141B898741CED14 /* YapDatabaseCloudKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKit.h; sourceTree = "<group>"; };
+		727DC21DB4F3DCD303C9F53BA2EC02F0 /* YapDatabaseStatement.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseStatement.m; sourceTree = "<group>"; };
+		72BE98F256B317494CE97276CE8D222E /* YapDatabaseSearchResultsView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsView.h; sourceTree = "<group>"; };
+		735271F6634176AD4065ACD204D9EC42 /* YDBCKChangeRecord.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKChangeRecord.m; sourceTree = "<group>"; };
+		785A6EBAB877052B9D64302D41BE1CE3 /* YDBCKChangeQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKChangeQueue.m; sourceTree = "<group>"; };
 		788BB22E7DBA508D141D8CDEE188080F /* DDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogger.h; path = Classes/DDASLLogger.h; sourceTree = "<group>"; };
-		78EB621E14C92766E184142532332E40 /* YDBCKRecord.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKRecord.m; sourceTree = "<group>"; };
-		80A16A3C361F30A84E5ADF4E80A7801F /* YapWhitelistBlacklist.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapWhitelistBlacklist.m; sourceTree = "<group>"; };
-		80A8502424CB22703A0E69AE8A12F3EC /* YapDatabaseSearchResultsViewConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewConnection.h; sourceTree = "<group>"; };
+		78BD190D78621B561FBDA69ABB38E8B3 /* YapDatabaseExtensionPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionPrivate.h; sourceTree = "<group>"; };
+		7C42EFA4176B229F3F2A364D5C06F47D /* YapDatabaseFullTextSearchTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchTransaction.h; sourceTree = "<group>"; };
+		7CC39064E94413754358BDB97002E700 /* YapDatabaseFilteredViewTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTypes.h; sourceTree = "<group>"; };
+		7E0DD15B9F52B8F95E8CC216CA766F02 /* YapDatabaseViewMappings.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewMappings.m; sourceTree = "<group>"; };
+		8359077804BD2E1A2DF11F8D19AC1604 /* YapDatabaseRelationshipNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipNode.h; sourceTree = "<group>"; };
+		83FAA2CD04B052E630C86A9E85786558 /* YDBCKChangeSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKChangeSet.h; sourceTree = "<group>"; };
+		84418AA95E5334C72A4F3CA3FCB8EC74 /* YapDatabaseFullTextSearch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearch.m; sourceTree = "<group>"; };
 		8444A49016D7B4DE2FF5C6ACC4C5E76F /* YapDatabase-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "YapDatabase-dummy.m"; sourceTree = "<group>"; };
-		85AE89F33CD6EAADDE7EE5163537AF6B /* YapDatabaseViewTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTypes.h; sourceTree = "<group>"; };
-		8622B6E617CACAC92567927E2787FD90 /* YapDatabaseFilteredViewConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewConnection.h; sourceTree = "<group>"; };
-		87585AA8B12E51B9B4233FC88BFA95F8 /* YapDatabaseViewTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewTypes.m; sourceTree = "<group>"; };
-		880F13116E8C6A5F63C531B128893E71 /* YapDatabaseViewState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewState.h; sourceTree = "<group>"; };
-		8839EA01057AEB7F503BF26037735AC1 /* YapDatabaseSearchResultsViewTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewTransaction.h; sourceTree = "<group>"; };
-		887496371A927B96DB904DAF6CEAFD5C /* YapDatabaseViewChange.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewChange.m; sourceTree = "<group>"; };
+		8579948E4B50037139942B4FD1B71FAA /* YapDatabaseViewChange.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewChange.m; sourceTree = "<group>"; };
+		85F0BD09A3E638982B9C7D19F91A2241 /* YapDatabaseExtension.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseExtension.m; sourceTree = "<group>"; };
+		87AD95EE682E1AF47B4CAE1C6A932931 /* YapDatabaseViewMappingsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappingsPrivate.h; sourceTree = "<group>"; };
 		892DC79F537D840BFDC4C18A3E3FA05E /* DDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDLog+LOGV.h"; path = "Classes/DDLog+LOGV.h"; sourceTree = "<group>"; };
-		8BEEE8E2D1FFB3CF92CE3D4981BA6233 /* YDBCKChangeQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKChangeQueue.m; sourceTree = "<group>"; };
-		8C57B85A98AA85DE0693D4C3EC26E9F3 /* YapDatabaseRelationshipNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipNode.h; sourceTree = "<group>"; };
+		8A731B4CF2411668A2A3E5F5606DBF36 /* YapDatabaseLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseLogging.m; sourceTree = "<group>"; };
+		8A88823955B2CF23404237E0DC4A7035 /* YapDatabaseViewRangeOptionsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptionsPrivate.h; sourceTree = "<group>"; };
+		8AA1348898013FE01A4F7F109422A9C1 /* YapDatabaseSearchQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchQueue.h; sourceTree = "<group>"; };
+		8B3BFEFC1F532C518EB872D61FE6E5C8 /* YapDatabaseSecondaryIndexSetup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexSetup.h; sourceTree = "<group>"; };
+		8B679094C87221EE41433C3B4F95928D /* YapDatabaseExtensionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionTypes.h; sourceTree = "<group>"; };
 		8C70497B4B7900D0D0AC99FE8AB395C6 /* DDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDFileLogger.m; path = Classes/DDFileLogger.m; sourceTree = "<group>"; };
-		8D4896ACDD3852EBB3B711D0653BA4A9 /* YapCollectionKey.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapCollectionKey.h; sourceTree = "<group>"; };
-		8D7B1BF70DD1DB5336E6C6FB94A72E77 /* YapDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabase.m; sourceTree = "<group>"; };
-		8EB897FE43917635821EFC32398C8D9D /* YapDatabaseSecondaryIndexSetup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexSetup.h; sourceTree = "<group>"; };
-		8FA523887D399884DDE9EA2F1A4CBC40 /* YDBCKRecordTableInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKRecordTableInfo.m; sourceTree = "<group>"; };
-		8FB8F515D249AFB8461834F1092B7EE6 /* YDBCKChangeQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKChangeQueue.h; sourceTree = "<group>"; };
+		8ECB8D6BB6D127AA636DDE0D77683FD7 /* YapSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapSet.m; sourceTree = "<group>"; };
+		8FDBD74F41BDA79D747FCB115C9B1372 /* YapDatabaseFullTextSearchConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchConnection.m; sourceTree = "<group>"; };
 		903B95EE0B69E01EBE26C7A903313D10 /* CocoaLumberjack-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CocoaLumberjack-dummy.m"; sourceTree = "<group>"; };
-		936249C808FB3FF760973692617734C0 /* YapDatabaseRTreeIndexConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexConnection.m; sourceTree = "<group>"; };
-		93C31BCB1D65033585BC692A4E965BE2 /* YapDatabaseSecondaryIndexHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexHandler.h; sourceTree = "<group>"; };
+		9046F142368EAC233E0104100D0A9F9E /* YapDatabaseSecondaryIndexTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexTransaction.m; sourceTree = "<group>"; };
+		925D7AABFC58BAB22BC407AEEAEBA1BD /* YDBCKMergeInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKMergeInfo.h; sourceTree = "<group>"; };
+		92D2842C01718447F2E5C2D43A31FEB6 /* YapDatabaseFilteredViewConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewConnection.m; sourceTree = "<group>"; };
+		9467D412C55FA91C9E59A66FFF6642E8 /* YapTouch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapTouch.m; sourceTree = "<group>"; };
 		94A49738BC61B921C3DC5971268AE019 /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAbstractDatabaseLogger.h; path = Classes/DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
-		9600FEBE9F2032F1A7B1A6EB4FE14636 /* YapDatabaseViewOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewOptions.m; sourceTree = "<group>"; };
-		961C6B5676175CEC649B82DC721C8E79 /* YapDatabaseSearchResultsViewTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsViewTransaction.m; sourceTree = "<group>"; };
-		97C0DFB5F8E82644427FDA3A20399219 /* YapDatabaseViewRangeOptionsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptionsPrivate.h; sourceTree = "<group>"; };
+		968FE15A56E59320F8425D094008397F /* YapDatabaseCloudKitTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitTypes.m; sourceTree = "<group>"; };
+		970608F2FA6CC6E9306E6499A51F52D6 /* YDBCKMergeInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKMergeInfo.m; sourceTree = "<group>"; };
 		98C98CDFB3F20F2925F6CD1F141BB14F /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.release.xcconfig; sourceTree = "<group>"; };
 		98D52DFC863E4F234815A48FB6BCDBD3 /* DDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDTTYLogger.h; path = Classes/DDTTYLogger.h; sourceTree = "<group>"; };
-		9940A1D73FF6AA9B60856DA512BD05CC /* YapDatabaseRTreeIndexHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexHandler.m; sourceTree = "<group>"; };
 		9A545ADDA42B9C577F26075E5A0246AC /* CocoaLumberjack.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CocoaLumberjack.xcconfig; sourceTree = "<group>"; };
-		9A942442BCAC527656452418D4B09824 /* YapDatabaseRelationshipOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipOptions.m; sourceTree = "<group>"; };
-		9C764E8FAD35D9D4E07B8365D0718B30 /* YapDatabaseRTreeIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndex.m; sourceTree = "<group>"; };
-		9F988D4D181B3C805D977E323CED98A6 /* YapMurmurHash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapMurmurHash.h; sourceTree = "<group>"; };
-		9FBDF0701466503F72A59322CA7DC764 /* YapDatabaseCloudKitConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitConnection.h; sourceTree = "<group>"; };
+		9DD782FB05B37D290DB3F30EF1DBE418 /* YapDatabaseHooksTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseHooksTransaction.m; sourceTree = "<group>"; };
 		A169AE9A71FE7D86D03E35AEE1FAC6F8 /* DDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLog.h; path = Classes/DDLog.h; sourceTree = "<group>"; };
 		A1A36D34413696BE466E2CA0AFF194DA /* Pods-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-resources.sh"; sourceTree = "<group>"; };
 		A28679B79F48C675D2A6BF74EF1BB967 /* DDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDMultiFormatter.h; path = Classes/Extensions/DDMultiFormatter.h; sourceTree = "<group>"; };
-		A3FBDA8346EF456658153A3FB190E7C6 /* YapDatabaseManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseManager.m; sourceTree = "<group>"; };
-		A476950E6E65B2C0FF9CDE52F9DD63B5 /* YapDatabaseSecondaryIndexPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexPrivate.h; sourceTree = "<group>"; };
-		A524A6DAB33248485739DC7A487CDB76 /* YapDatabaseSecondaryIndexOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexOptions.m; sourceTree = "<group>"; };
+		A30D13F41B487DA805F1654FE49FAD3C /* YapDatabaseConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnection.h; sourceTree = "<group>"; };
+		A34389BF4250F17A7DC6236D2602F2F1 /* YapDatabaseSecondaryIndexPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexPrivate.h; sourceTree = "<group>"; };
+		A480E75A3250D6453EEC1A16BA88627F /* YapDatabaseRTreeIndexSetup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexSetup.m; sourceTree = "<group>"; };
+		A51430A1EBABF5DDCFA14B41BC4F4AE2 /* YapDatabaseSearchResultsViewTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewTransaction.h; sourceTree = "<group>"; };
+		A52484E4C7F65D155496644E3570E683 /* YapMemoryTable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapMemoryTable.h; sourceTree = "<group>"; };
+		A587587FC8AC10AD412E8D0F1B31B487 /* YapProxyObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapProxyObject.m; sourceTree = "<group>"; };
 		A5E4B18696A542D02367C1B04D654FE7 /* DDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLogMacros.h; path = Classes/DDLogMacros.h; sourceTree = "<group>"; };
-		A804F15716B4BE0A90BBB90D6F09EDC0 /* YapDatabaseFullTextSearchSnippetOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchSnippetOptions.h; sourceTree = "<group>"; };
-		A9820A657836B6C624D6DE9E9D80902E /* YapDatabaseExtensionPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionPrivate.h; sourceTree = "<group>"; };
-		AA1D1F3C59C1B72C6ADFAF92C866814B /* YapCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapCache.h; sourceTree = "<group>"; };
-		AA47DE97BA5921119D4DE805D025DF86 /* YapDatabaseRTreeIndexSetup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexSetup.h; sourceTree = "<group>"; };
-		AA4BE4D58E026DCFD3BDC8D7199E841E /* YapDatabaseViewRangeOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewRangeOptions.h; sourceTree = "<group>"; };
-		ABFA3A939380311EF51ED290F486CFCE /* YapDatabaseFullTextSearch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearch.m; sourceTree = "<group>"; };
-		AE2449FBD13E40FBFDFAFFD82F62E0A4 /* YapDatabaseRTreeIndexSetup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexSetup.m; sourceTree = "<group>"; };
-		AECBB70932A98FE391CEE384ED25F3BE /* YapDatabaseSecondaryIndexHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexHandler.m; sourceTree = "<group>"; };
-		AFF892BFEFDFFBFA0F707291720BD75F /* YapDatabaseFilteredViewTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewTransaction.m; sourceTree = "<group>"; };
+		A5EA313B3FE5E4B0D1FF792CFE9C65E2 /* YapDatabaseCloudKitConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitConnection.m; sourceTree = "<group>"; };
+		A63865E864081744239BACE7B6773881 /* YapMutationStack.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapMutationStack.m; sourceTree = "<group>"; };
+		A6B2F562837AE04305DC8034E7F1F100 /* YapDatabaseExtensionConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseExtensionConnection.m; sourceTree = "<group>"; };
+		A75EF69C0AB72734960219A6BDE61096 /* YapDatabaseRelationshipConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipConnection.h; sourceTree = "<group>"; };
+		AB2B65862BBA2CFE666E7089EDA28F60 /* YapDatabaseSecondaryIndexConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexConnection.m; sourceTree = "<group>"; };
+		AB98936AC74CDF038BF633D344E80558 /* YapDatabaseManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseManager.m; sourceTree = "<group>"; };
+		ABCA00D0BEAE94CBE28306B634823A57 /* YapTouch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapTouch.h; sourceTree = "<group>"; };
+		AE5494054F4C559747B1688783FB3DB2 /* YapDatabaseFullTextSearchSnippetOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchSnippetOptions.m; sourceTree = "<group>"; };
+		AF738860A95B5CA35BD3B7D327E6A167 /* YapDatabaseViewTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTypes.h; sourceTree = "<group>"; };
+		B0805C0161B17B14CCE58BB7B17EFA48 /* YapDatabaseViewRangeOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewRangeOptions.m; sourceTree = "<group>"; };
 		B0C96F75D470D9C217541151865CC747 /* YapDatabase.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YapDatabase.xcconfig; sourceTree = "<group>"; };
-		B0D001DB79BEC9B5E11BED4AC0F86F8E /* YapMemoryTable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapMemoryTable.m; sourceTree = "<group>"; };
+		B0E76F58B315F27F42743B9E2B312020 /* YapDatabaseHooksPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooksPrivate.h; sourceTree = "<group>"; };
+		B13E5D4CD2A169A97A3C431BE59D399E /* YapDatabaseCloudKitTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitTypes.h; sourceTree = "<group>"; };
 		B1E54DC4203A6517E20838AA0581B682 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B216B4F4B0C0AD0647C1773C5411B0AF /* YapDatabaseViewConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewConnection.h; sourceTree = "<group>"; };
-		B269906CAA0B3CB29EAC57F18614F88E /* YapDatabaseFullTextSearchPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchPrivate.h; sourceTree = "<group>"; };
-		B2D7CCA9A8171410CE55B30EFB25B50A /* YapDatabaseFullTextSearchSnippetOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchSnippetOptions.m; sourceTree = "<group>"; };
+		B27DF70BDF04B97794AFC77BD6E45462 /* YDBCKAttachRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKAttachRequest.m; sourceTree = "<group>"; };
 		B2D8F80CB641FA7E4A87ABBB3B571EC7 /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDDispatchQueueLogFormatter.h; path = Classes/Extensions/DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		B334FD2757B878AF6AB72CF388B275DE /* YapDatabaseSecondaryIndexOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexOptions.h; sourceTree = "<group>"; };
-		B372C9DC0B4E2454F1527332E0887590 /* YapProxyObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapProxyObject.h; sourceTree = "<group>"; };
-		B3D3B88A40FFCE0CE1CEADED6AF5B79E /* YapDatabaseTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseTransaction.h; sourceTree = "<group>"; };
-		B3F4AA997F84CADD8CE2BFCA5E97397A /* YapDatabaseHooksTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooksTransaction.h; sourceTree = "<group>"; };
-		B4823D8979398FB49D4F0711FDC40086 /* YapDatabaseRelationshipTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipTransaction.h; sourceTree = "<group>"; };
-		B6EC8A21DFB12A07ACFAFB0DFA5AD511 /* YapDatabaseExtensionTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionTransaction.h; sourceTree = "<group>"; };
-		B76BF2AEB1ED1C1CD557B0D8201060A7 /* YapDatabaseHooksTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseHooksTransaction.m; sourceTree = "<group>"; };
-		B80D211A6FF21072694CA06FED4E3B15 /* YapDatabaseCloudKitOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitOptions.m; sourceTree = "<group>"; };
-		B8869D4F9803812B85B9B4C97868C90D /* YapDatabaseExtensionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionTypes.h; sourceTree = "<group>"; };
-		B92AE6EACFBDEE7B2B334CD4E8066E6F /* YapDatabaseViewState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewState.m; sourceTree = "<group>"; };
-		B9F27EA9B8F64C54944653A856CA10BC /* YDBCKChangeSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKChangeSet.h; sourceTree = "<group>"; };
+		B36F5E75B5CE6417346CBD8848F0E7FE /* YapDatabaseViewPageMetadata.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewPageMetadata.m; sourceTree = "<group>"; };
+		B42484D2DC02355DCC0432F4B3B61C66 /* YapDatabaseStatement.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseStatement.h; sourceTree = "<group>"; };
+		B4B59B37AC17C28B187B3C09D4643996 /* YapDatabaseViewState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewState.h; sourceTree = "<group>"; };
+		B5AD90CEAC695AE4FBF9585EDC068612 /* YapDatabaseViewConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewConnection.m; sourceTree = "<group>"; };
+		B9196FCB61B02E9E7F90F95429D711B1 /* YapDatabaseOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseOptions.h; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BBE986A59CE899195C796C5FBA41F766 /* YapDatabasePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabasePrivate.h; sourceTree = "<group>"; };
+		BBEADEFD536D7F431820BE5C7EBE8AA2 /* YapDatabaseHooks.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooks.h; sourceTree = "<group>"; };
 		BC4FEEADE0984F8E5187E582BA6E6D0B /* CocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CocoaLumberjack.h; path = Classes/CocoaLumberjack.h; sourceTree = "<group>"; };
-		BD438CBD6985592ACBDCDA7FFB555002 /* YapDatabaseRTreeIndexConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexConnection.h; sourceTree = "<group>"; };
-		BDAEAB76F993E8A4DF83A79E9E5D7070 /* YapDatabaseViewConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewConnection.m; sourceTree = "<group>"; };
-		BE1B6787B788A3A59A25A84E9CF996BA /* NSDictionary+YapDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+YapDatabase.m"; sourceTree = "<group>"; };
-		BF0188B07281E05585455C8E1D0E4D2A /* YapDatabaseViewMappings.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappings.h; sourceTree = "<group>"; };
+		BDD11C2496DB1803F7638E08D3492D68 /* YapDatabaseFilteredView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredView.m; sourceTree = "<group>"; };
+		BE560E7B3149571B0A469AA39AB98984 /* YapDatabaseViewPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPrivate.h; sourceTree = "<group>"; };
+		BE8CCF1605338B010AAAD3DD2F96A3CB /* YapDatabaseFilteredViewConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewConnection.h; sourceTree = "<group>"; };
+		BFD894201317C2186263060EFFE317CE /* YDBCKRecordInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKRecordInfo.h; sourceTree = "<group>"; };
+		C0565621CE9D4F1B820412F38426DE0A /* NSDictionary+YapDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+YapDatabase.m"; sourceTree = "<group>"; };
+		C12FAF4C4AF7ADB9E520919F6934BC6B /* YapDatabaseCloudKitPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitPrivate.h; sourceTree = "<group>"; };
+		C15792960C9B4E76899F3D73B536E9BE /* YapDatabaseSecondaryIndexHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexHandler.m; sourceTree = "<group>"; };
+		C1970060B264CDA0618FDCDECF12EC84 /* YapDatabaseViewConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewConnection.h; sourceTree = "<group>"; };
 		C2D749143D5F49E3C9BD48FA7BB7165C /* DDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDLog.m; path = Classes/DDLog.m; sourceTree = "<group>"; };
-		C493DA727F3B7F13334385C13B309485 /* YapDatabaseFullTextSearchTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchTransaction.m; sourceTree = "<group>"; };
-		C51D1904642322F43DDA853602B2E429 /* YapDatabaseViewChange.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChange.h; sourceTree = "<group>"; };
-		C6685BFB15FE26BC0E6EE15AFD4E363D /* YapDatabaseSearchResultsViewConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsViewConnection.m; sourceTree = "<group>"; };
-		C89497866A2668D8CFFA53D266232165 /* YapDatabaseRTreeIndexOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexOptions.m; sourceTree = "<group>"; };
-		CB2CA8D16215C695CBDAE264EF79D2DF /* YapDatabaseFilteredViewConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewConnection.m; sourceTree = "<group>"; };
-		CC69A73AC48E67BCD250D1F12B6382A3 /* YapDatabaseOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseOptions.h; sourceTree = "<group>"; };
+		C35276CDCCD93A2440E921B2FD476499 /* YapMurmurHash.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapMurmurHash.m; sourceTree = "<group>"; };
+		C50144B6F76F8A17B1E80BDD26681815 /* YapDatabaseRTreeIndexOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexOptions.h; sourceTree = "<group>"; };
+		C6A13E18CA4A10DD8EB7EA051F41F671 /* YapMemoryTable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapMemoryTable.m; sourceTree = "<group>"; };
+		C6AEEBF0CA4ECC952614A55B5739A94D /* YapDatabaseFilteredViewTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFilteredViewTransaction.m; sourceTree = "<group>"; };
+		CB5287261CF2C001B5EDF9407BD09BEB /* YDBCKChangeQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKChangeQueue.h; sourceTree = "<group>"; };
 		CCC9F995E016B3507790BD9090DC7D3A /* DDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogCapture.m; path = Classes/DDASLLogCapture.m; sourceTree = "<group>"; };
-		CCDB48ADD754701284662F157D166172 /* YDBCKAttachRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKAttachRequest.m; sourceTree = "<group>"; };
-		CE5047FDBCCD6F256CE0FF5482FAE603 /* YapDatabaseViewMappingsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewMappingsPrivate.h; sourceTree = "<group>"; };
-		CEDF55596FEEF9B80E1E23E9A3E8ACAD /* YapDatabaseStatement.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseStatement.h; sourceTree = "<group>"; };
-		CF3FD8815BE891C39C141EDA084A9AA4 /* YapDatabaseFullTextSearchConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseFullTextSearchConnection.m; sourceTree = "<group>"; };
-		CF6F2977CF5FA0116889A63D5A0158B1 /* YapDatabaseCloudKitTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseCloudKitTypes.m; sourceTree = "<group>"; };
-		D0C76B9EC26DD65C1F503FCDE46118C3 /* YapDatabaseLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseLogging.m; sourceTree = "<group>"; };
-		D2A37FD4EBBBFC736C3A4C15656B107D /* YDBCKMergeInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKMergeInfo.h; sourceTree = "<group>"; };
-		D3D6B15F8905B28DF07D7D3710DB4A29 /* YapDatabaseFilteredViewTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTypes.h; sourceTree = "<group>"; };
-		D44C2C2892EF84F4B63827E49928FF93 /* YapDatabaseRTreeIndexOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexOptions.h; sourceTree = "<group>"; };
-		D4B04409C68A525FC76B724CD9CD4E14 /* YapDatabaseFullTextSearchConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchConnection.h; sourceTree = "<group>"; };
-		D4B8924C50274B834DC4B53E2A78EA8B /* YapDatabaseHooksConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseHooksConnection.m; sourceTree = "<group>"; };
-		D653BE26B7A99661153069DAF16D83CB /* YapDatabaseViewTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewTransaction.h; sourceTree = "<group>"; };
-		D8420F3D2C225CF265C25AC2E358F17D /* YapTouch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapTouch.h; sourceTree = "<group>"; };
-		D8AE2D97E5AA5E6C285933219688EFD8 /* YapRowidSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapRowidSet.h; sourceTree = "<group>"; };
-		D8EA9A16976299252C72EDC3F1459A4A /* YDBCKRecord.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKRecord.h; sourceTree = "<group>"; };
-		DA289EF9CA70E6A604040A2F59F322B4 /* NSDictionary+YapDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+YapDatabase.h"; sourceTree = "<group>"; };
+		D1D9BA99F5891F1FDF30595A4835DD57 /* YapDatabaseViewPageMetadata.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPageMetadata.h; sourceTree = "<group>"; };
+		D552320B282048236DBC0CA1C1A4885F /* YapDatabaseRelationshipOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipOptions.h; sourceTree = "<group>"; };
+		D63EBB0AC535EDBCF2B2381A5EC78930 /* YapDatabaseRelationshipEdge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipEdge.h; sourceTree = "<group>"; };
+		D707F82E96981C1B04D779CA7525DF18 /* YapDatabaseSecondaryIndexTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexTransaction.h; sourceTree = "<group>"; };
 		DA4AD99FCDF845B442B1B3F570D940FE /* DDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogger.m; path = Classes/DDASLLogger.m; sourceTree = "<group>"; };
 		DD1B2B2FC0F1ED4FC0C29800D7578F9B /* libYapDatabase.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libYapDatabase.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		DD359AE3E025D48F2D646D8DE4DEB153 /* YapDatabaseSearchResultsView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSearchResultsView.m; sourceTree = "<group>"; };
-		DDAD699DE6A3E4A065A579E15921F3C0 /* YapDatabaseFilteredViewPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewPrivate.h; sourceTree = "<group>"; };
-		DE3294276C924F16704CC165C4549040 /* YapDatabaseSearchQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchQueue.h; sourceTree = "<group>"; };
-		E081F26EDC1B8A42C4FD3963DC37D439 /* YapDatabaseViewPage.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = YapDatabaseViewPage.mm; sourceTree = "<group>"; };
+		DDC510E8CB2E54F0BA6D047EB208F209 /* YapDatabaseViewOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewOptions.h; sourceTree = "<group>"; };
+		DEF2C3162E4EB0EEBDDE88767F990355 /* YapDatabaseHooks.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseHooks.m; sourceTree = "<group>"; };
+		DF30921F71F6AE3727A54D8ECA335AD2 /* YapDatabaseHooksConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseHooksConnection.h; sourceTree = "<group>"; };
+		DFF61612C4E5FD1CB120178A27E856A5 /* YapDatabaseSecondaryIndexHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexHandler.h; sourceTree = "<group>"; };
 		E0B6669DD9DFCA4DA310C01E3382CC12 /* DDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDMultiFormatter.m; path = Classes/Extensions/DDMultiFormatter.m; sourceTree = "<group>"; };
-		E1DF54396F791161B74F6D7CEA60B353 /* YapDatabaseConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnection.h; sourceTree = "<group>"; };
-		E2FE04078663E06BC8CF705B923FE2D1 /* YapDatabaseFilteredView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredView.h; sourceTree = "<group>"; };
-		E52BBDC32C5F7CA597C16A47D6890F81 /* YapDatabaseRTreeIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndex.h; sourceTree = "<group>"; };
-		E97503252DD189B9109FCD9E31F7F08F /* YDBCKRecordInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKRecordInfo.m; sourceTree = "<group>"; };
-		E9F551C4C330E91AA3C267195137C18F /* YapDatabaseRTreeIndexHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndexHandler.h; sourceTree = "<group>"; };
+		E1936902513F202C2C297FABFA27C4BF /* YDBCKMappingTableInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKMappingTableInfo.h; sourceTree = "<group>"; };
+		E28868AA642F5D8B1ACB00729DC4483E /* YapDatabaseRTreeIndexHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRTreeIndexHandler.m; sourceTree = "<group>"; };
+		E341274BEBD9EBCE121B38535B4A82E8 /* YapDatabaseLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseLogging.h; sourceTree = "<group>"; };
+		E356EAB8387563F6A2981CDA2674F93F /* YapDatabaseTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseTransaction.m; sourceTree = "<group>"; };
+		E3C684A2B8CE9C13B3F15F3069166BEF /* YapDatabaseConnectionState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseConnectionState.h; sourceTree = "<group>"; };
+		E4C86A1A38C819E98F8FE401E90C39B1 /* YapDatabaseSearchQueuePrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchQueuePrivate.h; sourceTree = "<group>"; };
+		E5D68F740C875DC86D4FF865A287CE9F /* YapDatabaseExtensionConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseExtensionConnection.h; sourceTree = "<group>"; };
+		E5FDBE9C35D93F0FFED7EDFDD9354DB5 /* YapDatabaseConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnection.m; sourceTree = "<group>"; };
+		E7FA0E11325D54A0F5652B3346EE166A /* yap_vfs_shim.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = yap_vfs_shim.c; sourceTree = "<group>"; };
+		E862240EFD43D88973D14F5C89041DD8 /* YapDatabaseRTreeIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRTreeIndex.h; sourceTree = "<group>"; };
+		E868B75168608DB425897317F664247E /* YapDatabaseFilteredViewPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewPrivate.h; sourceTree = "<group>"; };
+		E90B26D03C1DA511FC49EFF009C1460E /* YapDatabaseConnectionDefaults.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnectionDefaults.m; sourceTree = "<group>"; };
 		EB0945BFFB5ACFB3B929CF7C6146503D /* libCocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		ECCDD9066F57BE7318EBFA6731977C94 /* YapDatabaseSecondaryIndexConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexConnection.h; sourceTree = "<group>"; };
-		ED5C5B9F01F610A77020315FBF987883 /* YapDatabaseViewOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewOptions.h; sourceTree = "<group>"; };
+		EBF43A8365E5A6D7C46B8B7D3D415E40 /* YDBCKRecordTableInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YDBCKRecordTableInfo.h; sourceTree = "<group>"; };
 		EDC1117352B86A27F1B34547BDE01BC6 /* DDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDAbstractDatabaseLogger.m; path = Classes/DDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
-		EF362363F3C411B948A61C437FE97D6C /* YapDatabaseConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseConnection.m; sourceTree = "<group>"; };
-		F04626AEBFE6457A271D954F7CA0D553 /* YapMemoryTable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapMemoryTable.h; sourceTree = "<group>"; };
-		F15811C648346381C353ACD0E715F6C4 /* YapDatabaseViewPageMetadata.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewPageMetadata.m; sourceTree = "<group>"; };
-		F190E14122FA297955A39058A14DADAA /* YapDatabaseRelationshipConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipConnection.m; sourceTree = "<group>"; };
-		F494133C04490CA3D8FC7E62CEE884C0 /* YapDatabaseViewPage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewPage.h; sourceTree = "<group>"; };
-		F6D9AFB9EB09D1C221A8B7C1EF68B2C0 /* YapDatabaseManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseManager.h; sourceTree = "<group>"; };
-		F8686DC7761936C0BB5AF781BF06BA58 /* YapDatabaseQuery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseQuery.h; sourceTree = "<group>"; };
+		EE6AF2034EAF0FE35C064E21F3E641CD /* YapDatabaseSecondaryIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndex.h; sourceTree = "<group>"; };
+		EEA9FC47CCDB0BC42CAE7B40F58B9608 /* YapCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapCache.m; sourceTree = "<group>"; };
+		EF159BA48F7565AE875E45187544A164 /* YapDatabaseRelationshipTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseRelationshipTransaction.m; sourceTree = "<group>"; };
+		F03EC995FB3D70AE92C784A35808F09F /* YapDatabaseRelationshipPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseRelationshipPrivate.h; sourceTree = "<group>"; };
+		F0B91693FF234B2D251787CE658795AA /* YapDatabaseSecondaryIndexOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSecondaryIndexOptions.h; sourceTree = "<group>"; };
+		F154C204602290FC80C2C026EDF9C13F /* YapDatabaseViewPage.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = YapDatabaseViewPage.mm; sourceTree = "<group>"; };
+		F162CB1516CD85C2342D998A4B1BC3A0 /* YapWhitelistBlacklist.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapWhitelistBlacklist.m; sourceTree = "<group>"; };
+		F2F5E67D00ACB410C6E912248E01D1C0 /* YapDatabaseSecondaryIndexOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseSecondaryIndexOptions.m; sourceTree = "<group>"; };
+		F42B15397090DA467277D997A95E6B74 /* yap_vfs_shim.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = yap_vfs_shim.h; sourceTree = "<group>"; };
+		F449D5C641AC344CBFBA1D6A17A9FF95 /* YapDatabaseViewTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewTypes.m; sourceTree = "<group>"; };
+		F58CA75CEE1992E2C027AB6579576826 /* YapDatabaseViewState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YapDatabaseViewState.m; sourceTree = "<group>"; };
+		F62360F0833D4350ADDC3E77C7037A49 /* YDBCKMappingTableInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = YDBCKMappingTableInfo.m; sourceTree = "<group>"; };
+		F6D504F6C221082ABB60D4079DFB13C8 /* YapDatabaseCloudKitConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitConnection.h; sourceTree = "<group>"; };
+		F757BE152F8BE5B1C3BAD332ACD3FCDF /* YapDatabaseManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseManager.h; sourceTree = "<group>"; };
 		F9A095E75CC15921913AEFF327CA2D51 /* DDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogCapture.h; path = Classes/DDASLLogCapture.h; sourceTree = "<group>"; };
-		FA8C29AE2373D16EA5D5C410547DE4F2 /* YapDatabaseCloudKitOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseCloudKitOptions.h; sourceTree = "<group>"; };
-		FC0169A057F34239D824035BF8BF70E2 /* YapDatabaseFullTextSearchTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFullTextSearchTransaction.h; sourceTree = "<group>"; };
+		FB00C2EB2AC33870D8D45FAB2C817702 /* YapDatabaseFilteredViewTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredViewTransaction.h; sourceTree = "<group>"; };
 		FC5551224D2BB2FCC7ECB3BC95508A98 /* DDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDContextFilterLogFormatter.m; path = Classes/Extensions/DDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		FC915582FF9FA794CCC18D87F5BE1F01 /* YapDatabaseFilteredView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseFilteredView.h; sourceTree = "<group>"; };
+		FD2F74CA4003143FE129C81EA016EC64 /* YapProxyObjectPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapProxyObjectPrivate.h; sourceTree = "<group>"; };
+		FD979328F012B407CD9889DAEE3A33F5 /* YapDatabaseSearchResultsViewPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseSearchResultsViewPrivate.h; sourceTree = "<group>"; };
+		FF39DEEFA75ACC10333D55D3CC56EAB1 /* YapDatabaseViewChange.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = YapDatabaseViewChange.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -510,6 +514,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		023697BF5BD03CE94E40B52E72D3E66B /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				83FAA2CD04B052E630C86A9E85786558 /* YDBCKChangeSet.h */,
+				4C8258F93F925D14536055202725330D /* YDBCKChangeSet.m */,
+				925D7AABFC58BAB22BC407AEEAEBA1BD /* YDBCKMergeInfo.h */,
+				970608F2FA6CC6E9306E6499A51F52D6 /* YDBCKMergeInfo.m */,
+				70039F4F7773BA238D0818BCB1A56609 /* YDBCKRecord.h */,
+				55D0E3A516998382A47D28A0D4D2E254 /* YDBCKRecord.m */,
+				BFD894201317C2186263060EFFE317CE /* YDBCKRecordInfo.h */,
+				1B6D524F63036E29C471D5BB8D4AA322 /* YDBCKRecordInfo.m */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		037C0CA694176A3C0915F62C9D20B3E6 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -518,29 +537,72 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		0B42D9FA004947C011FBB424160D1AD1 /* Internal */ = {
+		06C67FFDC640381CB574567FA5F2A546 /* RTreeIndex */ = {
 			isa = PBXGroup;
 			children = (
-				DDAD699DE6A3E4A065A579E15921F3C0 /* YapDatabaseFilteredViewPrivate.h */,
+				E862240EFD43D88973D14F5C89041DD8 /* YapDatabaseRTreeIndex.h */,
+				59BE28F82571F459A3315C11AC752CC7 /* YapDatabaseRTreeIndex.m */,
+				45AEBB0826B6D6EA9148625A13E87DD7 /* YapDatabaseRTreeIndexConnection.h */,
+				21FED17AA39661D6EE485EC0FC1E3AA9 /* YapDatabaseRTreeIndexConnection.m */,
+				4F9045309AEBBEBFFF9AAE54D6C58D81 /* YapDatabaseRTreeIndexHandler.h */,
+				E28868AA642F5D8B1ACB00729DC4483E /* YapDatabaseRTreeIndexHandler.m */,
+				C50144B6F76F8A17B1E80BDD26681815 /* YapDatabaseRTreeIndexOptions.h */,
+				35276D85BBC346627857A00348F6BBD0 /* YapDatabaseRTreeIndexOptions.m */,
+				648B3D971CEE5A228AB4538951600640 /* YapDatabaseRTreeIndexSetup.h */,
+				A480E75A3250D6453EEC1A16BA88627F /* YapDatabaseRTreeIndexSetup.m */,
+				1DE13599F8EF3729EA813AB2976F1B3A /* YapDatabaseRTreeIndexTransaction.h */,
+				67A760F20E66FD73996418756D4F36A8 /* YapDatabaseRTreeIndexTransaction.m */,
+				2BFD2D99487FF889709374608FDE2D1D /* Internal */,
+			);
+			path = RTreeIndex;
+			sourceTree = "<group>";
+		};
+		0E03360C75D497DDAD13C0057C8B0E22 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				066DFBE6D611B4C32B67F4D64776E2F6 /* YapDatabaseFullTextSearchPrivate.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
 		};
-		133CAB030AA9066D4D5AB714618A2E60 /* Extensions */ = {
+		0FC0FB074781E182C3657DFE6BDC9211 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				441D82E192374DF94C7DD8E7708342F5 /* CloudKit */,
-				C7B4402592DB273AC1C28D415B5384A1 /* FilteredViews */,
-				EF76006DDAD410A8A689EA077A9F4530 /* FullTextSearch */,
-				A02713F7293C9F4382C4AB75BA6BFF52 /* Hooks */,
-				25304E4AD93B88C7B6573A84F8DD67B0 /* Protocol */,
-				BF79C454DBF380029EC2B504C0B86C9E /* Relationships */,
-				F7C6962771B5D3E82810C89C73EB80D0 /* RTreeIndex */,
-				CD87AA625B4D2782E710B8F69DC39D30 /* SearchResults */,
-				167077D1F11C9C638170941B075F93AA /* SecondaryIndex */,
-				47C109231CE1A6A94546140B803515CA /* Views */,
+				78BD190D78621B561FBDA69ABB38E8B3 /* YapDatabaseExtensionPrivate.h */,
 			);
-			path = Extensions;
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		11B45F2D7BF5ECC35C67E3DA5F2BAB98 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				04E1D832E3826A3841B5F1824424B3D9 /* NSDictionary+YapDatabase.h */,
+				C0565621CE9D4F1B820412F38426DE0A /* NSDictionary+YapDatabase.m */,
+				E7FA0E11325D54A0F5652B3346EE166A /* yap_vfs_shim.c */,
+				F42B15397090DA467277D997A95E6B74 /* yap_vfs_shim.h */,
+				29D1D37376D0FA2432D6E0EA8A81C99E /* YapDatabaseConnectionDefaults.h */,
+				E90B26D03C1DA511FC49EFF009C1460E /* YapDatabaseConnectionDefaults.m */,
+				E3C684A2B8CE9C13B3F15F3069166BEF /* YapDatabaseConnectionState.h */,
+				078C605F00CEEB5C2DFC1B245FB5EEAC /* YapDatabaseConnectionState.m */,
+				E341274BEBD9EBCE121B38535B4A82E8 /* YapDatabaseLogging.h */,
+				8A731B4CF2411668A2A3E5F5606DBF36 /* YapDatabaseLogging.m */,
+				F757BE152F8BE5B1C3BAD332ACD3FCDF /* YapDatabaseManager.h */,
+				AB98936AC74CDF038BF633D344E80558 /* YapDatabaseManager.m */,
+				BBE986A59CE899195C796C5FBA41F766 /* YapDatabasePrivate.h */,
+				B42484D2DC02355DCC0432F4B3B61C66 /* YapDatabaseStatement.h */,
+				727DC21DB4F3DCD303C9F53BA2EC02F0 /* YapDatabaseStatement.m */,
+				5B931D61E8C05236749B4B6B1D2ACBC2 /* YapDatabaseString.h */,
+				A52484E4C7F65D155496644E3570E683 /* YapMemoryTable.h */,
+				C6A13E18CA4A10DD8EB7EA051F41F671 /* YapMemoryTable.m */,
+				67B4169E7860520B798703A0E927FEC7 /* YapNull.h */,
+				08F365D1D3C859D8021FAE04FFCE75DA /* YapNull.m */,
+				FD2F74CA4003143FE129C81EA016EC64 /* YapProxyObjectPrivate.h */,
+				3BB4891AEDDBC9A49BB90CEB8084B248 /* YapRowidSet.h */,
+				6332E5C2A5A9E92E463CAB56FBDF4442 /* YapRowidSet.mm */,
+				ABCA00D0BEAE94CBE28306B634823A57 /* YapTouch.h */,
+				9467D412C55FA91C9E59A66FFF6642E8 /* YapTouch.m */,
+			);
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		13B19D8E726752BB68523ED2AB6F9821 /* Support Files */ = {
@@ -554,86 +616,28 @@
 			path = "Examples/SearchResultsExample/Pods/Target Support Files/YapDatabase";
 			sourceTree = "<group>";
 		};
-		167077D1F11C9C638170941B075F93AA /* SecondaryIndex */ = {
+		1F86F5DE0E843156D360DBC142DB7EF6 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				5FE8E291DF9CC73A045A14E016662E78 /* YapDatabaseSecondaryIndex.h */,
-				2716E98730A2DAAEF16039603747F920 /* YapDatabaseSecondaryIndex.m */,
-				ECCDD9066F57BE7318EBFA6731977C94 /* YapDatabaseSecondaryIndexConnection.h */,
-				16E86CDC2927006B4C7E0724E79A474A /* YapDatabaseSecondaryIndexConnection.m */,
-				93C31BCB1D65033585BC692A4E965BE2 /* YapDatabaseSecondaryIndexHandler.h */,
-				AECBB70932A98FE391CEE384ED25F3BE /* YapDatabaseSecondaryIndexHandler.m */,
-				B334FD2757B878AF6AB72CF388B275DE /* YapDatabaseSecondaryIndexOptions.h */,
-				A524A6DAB33248485739DC7A487CDB76 /* YapDatabaseSecondaryIndexOptions.m */,
-				8EB897FE43917635821EFC32398C8D9D /* YapDatabaseSecondaryIndexSetup.h */,
-				6DAAEC926B805B901CD33E8FED183A7D /* YapDatabaseSecondaryIndexSetup.m */,
-				2101F63B89170E1A41654F2922290E8A /* YapDatabaseSecondaryIndexTransaction.h */,
-				18704AB521F27C897E10ABBACB212C2E /* YapDatabaseSecondaryIndexTransaction.m */,
-				E16622659B3FF97AA314F19C79F74EFD /* Internal */,
-			);
-			path = SecondaryIndex;
-			sourceTree = "<group>";
-		};
-		183D5A2D079BB85C99F11AD1AC354CDB /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				DA289EF9CA70E6A604040A2F59F322B4 /* NSDictionary+YapDatabase.h */,
-				BE1B6787B788A3A59A25A84E9CF996BA /* NSDictionary+YapDatabase.m */,
-				37C151B90C5FCF2D8043FFEB4A429879 /* YapDatabaseConnectionDefaults.h */,
-				2010C2C215274160D0D77DA6BF23CBD0 /* YapDatabaseConnectionDefaults.m */,
-				5B8685405FA425FB91DB19EC16615BF4 /* YapDatabaseConnectionState.h */,
-				67C010093856E1FF19E3EA958E6C99A4 /* YapDatabaseConnectionState.m */,
-				5CEFD4A0BD33464B5AC307F3BD6F598F /* YapDatabaseLogging.h */,
-				D0C76B9EC26DD65C1F503FCDE46118C3 /* YapDatabaseLogging.m */,
-				F6D9AFB9EB09D1C221A8B7C1EF68B2C0 /* YapDatabaseManager.h */,
-				A3FBDA8346EF456658153A3FB190E7C6 /* YapDatabaseManager.m */,
-				6AAEEA1072C5BB9C6383833049A46A21 /* YapDatabasePrivate.h */,
-				CEDF55596FEEF9B80E1E23E9A3E8ACAD /* YapDatabaseStatement.h */,
-				0CBBFC8456EC190EF17380BB3BBBB246 /* YapDatabaseStatement.m */,
-				0E1C881674CCFCEC3A7F5A6D542E5569 /* YapDatabaseString.h */,
-				F04626AEBFE6457A271D954F7CA0D553 /* YapMemoryTable.h */,
-				B0D001DB79BEC9B5E11BED4AC0F86F8E /* YapMemoryTable.m */,
-				1A3E1593B93BC0F42009D6AECDDDF07A /* YapNull.h */,
-				596E22310CB02C0DECC8A22453112FD1 /* YapNull.m */,
-				58B6FDF2CED9797B8405C338F805A26F /* YapProxyObjectPrivate.h */,
-				D8AE2D97E5AA5E6C285933219688EFD8 /* YapRowidSet.h */,
-				1E84AC0D831FB5A826F174D4C6D72738 /* YapRowidSet.mm */,
-				D8420F3D2C225CF265C25AC2E358F17D /* YapTouch.h */,
-				09561652B20D0FA310DE3A34F27C4DBC /* YapTouch.m */,
+				E868B75168608DB425897317F664247E /* YapDatabaseFilteredViewPrivate.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
 		};
-		24C504E9FA50D81916BE96AD85595130 /* Internal */ = {
+		22634192E0B634FBE9646A4F4A42CD1F /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				3933EBB1C8D82723A3C236689E70A221 /* YapDatabaseViewChangePrivate.h */,
-				CE5047FDBCCD6F256CE0FF5482FAE603 /* YapDatabaseViewMappingsPrivate.h */,
-				F494133C04490CA3D8FC7E62CEE884C0 /* YapDatabaseViewPage.h */,
-				E081F26EDC1B8A42C4FD3963DC37D439 /* YapDatabaseViewPage.mm */,
-				17A93D76A7C9D3B713D4D23351242550 /* YapDatabaseViewPageMetadata.h */,
-				F15811C648346381C353ACD0E715F6C4 /* YapDatabaseViewPageMetadata.m */,
-				33B199F7093926D3CB070BFFBBE791EC /* YapDatabaseViewPrivate.h */,
-				97C0DFB5F8E82644427FDA3A20399219 /* YapDatabaseViewRangeOptionsPrivate.h */,
-				880F13116E8C6A5F63C531B128893E71 /* YapDatabaseViewState.h */,
-				B92AE6EACFBDEE7B2B334CD4E8066E6F /* YapDatabaseViewState.m */,
+				B0E76F58B315F27F42743B9E2B312020 /* YapDatabaseHooksPrivate.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
 		};
-		25304E4AD93B88C7B6573A84F8DD67B0 /* Protocol */ = {
+		2BFD2D99487FF889709374608FDE2D1D /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				01D92F2CCC8F831D0BD10B2F566419FB /* YapDatabaseExtension.h */,
-				4DBA2ADD656A4154896386B957F00012 /* YapDatabaseExtension.m */,
-				737BE1C70655CCB06A7FED1AC1F9082E /* YapDatabaseExtensionConnection.h */,
-				13FF6186DF8800A4BFDC7FEC4F5059D7 /* YapDatabaseExtensionConnection.m */,
-				B6EC8A21DFB12A07ACFAFB0DFA5AD511 /* YapDatabaseExtensionTransaction.h */,
-				6711DB9B11835A6D6114733CCFBF0B9F /* YapDatabaseExtensionTransaction.m */,
-				B8869D4F9803812B85B9B4C97868C90D /* YapDatabaseExtensionTypes.h */,
-				94311FD930B7F566544589468992A9D8 /* Internal */,
+				67AB9B55F95187CC2A6E269BA5608979 /* YapDatabaseRTreeIndexPrivate.h */,
 			);
-			path = Protocol;
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		2E5C059D724246362F6AE7F4A0CE92AF /* Development Pods */ = {
@@ -644,42 +648,56 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		441D82E192374DF94C7DD8E7708342F5 /* CloudKit */ = {
+		35A331989C07CBC1F6305D4A0ABFF43E /* SearchResults */ = {
 			isa = PBXGroup;
 			children = (
-				13B559B8B485AD1A1244C3AD0541DB8D /* YapDatabaseCloudKit.h */,
-				39D1CAA38DED1469A692AF43F6CEE8F7 /* YapDatabaseCloudKit.m */,
-				9FBDF0701466503F72A59322CA7DC764 /* YapDatabaseCloudKitConnection.h */,
-				4BBAB136DF1CDB8E26F4E50C5950B16E /* YapDatabaseCloudKitConnection.m */,
-				FA8C29AE2373D16EA5D5C410547DE4F2 /* YapDatabaseCloudKitOptions.h */,
-				B80D211A6FF21072694CA06FED4E3B15 /* YapDatabaseCloudKitOptions.m */,
-				267A9AA89552FC258F07308F9B38435C /* YapDatabaseCloudKitTransaction.h */,
-				141EA78507E51434FB98CB56A16761A6 /* YapDatabaseCloudKitTransaction.m */,
-				5F5F9A6B6EEFC47F3957A2B0FC1EDE93 /* YapDatabaseCloudKitTypes.h */,
-				CF6F2977CF5FA0116889A63D5A0158B1 /* YapDatabaseCloudKitTypes.m */,
-				D2F77A928B397011F7F064DF5C1493F3 /* Internal */,
-				9617A9CD74813ADDC3494F26E6F662FB /* Utilities */,
+				8AA1348898013FE01A4F7F109422A9C1 /* YapDatabaseSearchQueue.h */,
+				335C9C17B90B28EB9DD85EB8781699C2 /* YapDatabaseSearchQueue.m */,
+				72BE98F256B317494CE97276CE8D222E /* YapDatabaseSearchResultsView.h */,
+				2B15FB5AC603FDDAECDEAC911D73B59A /* YapDatabaseSearchResultsView.m */,
+				3CF2C9C1A9FD4BEF4C95FFF21B9E9967 /* YapDatabaseSearchResultsViewConnection.h */,
+				3A488CBE826207809B87F7DD719F75D3 /* YapDatabaseSearchResultsViewConnection.m */,
+				64CEAA3119423C3CE45FE80C2C200E31 /* YapDatabaseSearchResultsViewOptions.h */,
+				5AF85CC72B4157D186F6138A0FB87803 /* YapDatabaseSearchResultsViewOptions.m */,
+				A51430A1EBABF5DDCFA14B41BC4F4AE2 /* YapDatabaseSearchResultsViewTransaction.h */,
+				620858EE8185FD9C37CAE749CFF95B5E /* YapDatabaseSearchResultsViewTransaction.m */,
+				A4BE56999F822C0F4629ED2CC47EA80D /* Internal */,
 			);
-			path = CloudKit;
+			path = SearchResults;
 			sourceTree = "<group>";
 		};
-		47C109231CE1A6A94546140B803515CA /* Views */ = {
+		3E102672BF8E041B4F41132B238B9764 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				156E19773AC758436E61E2C1CEAA6C38 /* YapDatabaseView.h */,
-				15AE9590A34649AD395416642C192072 /* YapDatabaseView.m */,
-				B216B4F4B0C0AD0647C1773C5411B0AF /* YapDatabaseViewConnection.h */,
-				BDAEAB76F993E8A4DF83A79E9E5D7070 /* YapDatabaseViewConnection.m */,
-				ED5C5B9F01F610A77020315FBF987883 /* YapDatabaseViewOptions.h */,
-				9600FEBE9F2032F1A7B1A6EB4FE14636 /* YapDatabaseViewOptions.m */,
-				D653BE26B7A99661153069DAF16D83CB /* YapDatabaseViewTransaction.h */,
-				6F42CE7A134CACC769CC43F3957390BC /* YapDatabaseViewTransaction.m */,
-				85AE89F33CD6EAADDE7EE5163537AF6B /* YapDatabaseViewTypes.h */,
-				87585AA8B12E51B9B4233FC88BFA95F8 /* YapDatabaseViewTypes.m */,
-				24C504E9FA50D81916BE96AD85595130 /* Internal */,
-				782FE899E2C994D087923544D7EAB935 /* Utilities */,
+				6FBF8D791F194AAF1409A2A9E6B3C074 /* YapDatabaseRelationshipEdgePrivate.h */,
+				F03EC995FB3D70AE92C784A35808F09F /* YapDatabaseRelationshipPrivate.h */,
 			);
-			path = Views;
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		41823D92C85313B4D15DBF50D8488F93 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A4A2490B7DDF70D68B4E3DEE8C19854E /* CloudKit */,
+				DDEC16CA66E2601A3107D28D42A893CD /* FilteredViews */,
+				FD98B9BA6E8982EC508CB74497B7B826 /* FullTextSearch */,
+				D87A9831733A155FFBB00F5323AC5209 /* Hooks */,
+				80D40B390B69178901C92C5882BB1AFD /* Protocol */,
+				6F9120A20183B9A8BE6EAD70A103ED82 /* Relationships */,
+				06C67FFDC640381CB574567FA5F2A546 /* RTreeIndex */,
+				35A331989C07CBC1F6305D4A0ABFF43E /* SearchResults */,
+				67779B5DCBE817D49B44794743D9B9FC /* SecondaryIndex */,
+				9C09408B10C00CED917518BE943AF7A8 /* Views */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		4A19DBC8DD24426A151C37F9A3AED652 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				A34389BF4250F17A7DC6236D2602F2F1 /* YapDatabaseSecondaryIndexPrivate.h */,
+			);
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		5C5ADCACB7CD40E797DC397E0D5FF1B4 /* Extensions */ = {
@@ -729,15 +747,6 @@
 			path = "../Target Support Files/CocoaLumberjack";
 			sourceTree = "<group>";
 		};
-		63D3687802AAC51107481ABB13FB7357 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				1C277CE54037E425394097ED90BF5F4B /* YapDatabaseSearchQueuePrivate.h */,
-				62AC2ED5547490F589AD92623B4C2B86 /* YapDatabaseSearchResultsViewPrivate.h */,
-			);
-			path = Internal;
-			sourceTree = "<group>";
-		};
 		65F673BDC5AFF765188C458C9CC5AF65 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -748,25 +757,43 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		6F9935544237C2AEADCB9432B92C8617 /* Internal */ = {
+		67779B5DCBE817D49B44794743D9B9FC /* SecondaryIndex */ = {
 			isa = PBXGroup;
 			children = (
-				06C6ED641F3F6FB4942EB50C07CC3577 /* YapDatabaseHooksPrivate.h */,
+				EE6AF2034EAF0FE35C064E21F3E641CD /* YapDatabaseSecondaryIndex.h */,
+				618EFE0F8E01768F6B136A6625B56F85 /* YapDatabaseSecondaryIndex.m */,
+				295A08A57D836839687D902AF3CAE16A /* YapDatabaseSecondaryIndexConnection.h */,
+				AB2B65862BBA2CFE666E7089EDA28F60 /* YapDatabaseSecondaryIndexConnection.m */,
+				DFF61612C4E5FD1CB120178A27E856A5 /* YapDatabaseSecondaryIndexHandler.h */,
+				C15792960C9B4E76899F3D73B536E9BE /* YapDatabaseSecondaryIndexHandler.m */,
+				F0B91693FF234B2D251787CE658795AA /* YapDatabaseSecondaryIndexOptions.h */,
+				F2F5E67D00ACB410C6E912248E01D1C0 /* YapDatabaseSecondaryIndexOptions.m */,
+				8B3BFEFC1F532C518EB872D61FE6E5C8 /* YapDatabaseSecondaryIndexSetup.h */,
+				4E6C88428F27576F6B98C55065A395D2 /* YapDatabaseSecondaryIndexSetup.m */,
+				D707F82E96981C1B04D779CA7525DF18 /* YapDatabaseSecondaryIndexTransaction.h */,
+				9046F142368EAC233E0104100D0A9F9E /* YapDatabaseSecondaryIndexTransaction.m */,
+				4A19DBC8DD24426A151C37F9A3AED652 /* Internal */,
 			);
-			path = Internal;
+			path = SecondaryIndex;
 			sourceTree = "<group>";
 		};
-		782FE899E2C994D087923544D7EAB935 /* Utilities */ = {
+		6F9120A20183B9A8BE6EAD70A103ED82 /* Relationships */ = {
 			isa = PBXGroup;
 			children = (
-				C51D1904642322F43DDA853602B2E429 /* YapDatabaseViewChange.h */,
-				887496371A927B96DB904DAF6CEAFD5C /* YapDatabaseViewChange.m */,
-				BF0188B07281E05585455C8E1D0E4D2A /* YapDatabaseViewMappings.h */,
-				6C810AFBF3CF08D27EC329C1321F4EBA /* YapDatabaseViewMappings.m */,
-				AA4BE4D58E026DCFD3BDC8D7199E841E /* YapDatabaseViewRangeOptions.h */,
-				00E62FAB527D4E84B59CC8917C0EEAB6 /* YapDatabaseViewRangeOptions.m */,
+				03A8BB14AC12D63777DAD6779A5D1E24 /* YapDatabaseRelationship.h */,
+				1FA43605B373DF0C40E2390216E48ECF /* YapDatabaseRelationship.m */,
+				A75EF69C0AB72734960219A6BDE61096 /* YapDatabaseRelationshipConnection.h */,
+				0301D1213B53FE972FA123E635BDC289 /* YapDatabaseRelationshipConnection.m */,
+				D63EBB0AC535EDBCF2B2381A5EC78930 /* YapDatabaseRelationshipEdge.h */,
+				5A7F146404765E5F41CCA63F2F6FB505 /* YapDatabaseRelationshipEdge.m */,
+				8359077804BD2E1A2DF11F8D19AC1604 /* YapDatabaseRelationshipNode.h */,
+				D552320B282048236DBC0CA1C1A4885F /* YapDatabaseRelationshipOptions.h */,
+				20A80B0E1A92856E748F6C6BADE2A99A /* YapDatabaseRelationshipOptions.m */,
+				095CD441C9F376C49A851B4E015140D9 /* YapDatabaseRelationshipTransaction.h */,
+				EF159BA48F7565AE875E45187544A164 /* YapDatabaseRelationshipTransaction.m */,
+				3E102672BF8E041B4F41132B238B9764 /* Internal */,
 			);
-			path = Utilities;
+			path = Relationships;
 			sourceTree = "<group>";
 		};
 		7DB346D0F39D3F0E887471402A8071AB = {
@@ -781,97 +808,118 @@
 			);
 			sourceTree = "<group>";
 		};
-		8069FB48AE694693243E8B205D2FEB48 /* Internal */ = {
+		80D40B390B69178901C92C5882BB1AFD /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
-				72791598ECD2F055D4426C09D504B8E5 /* YapDatabaseRelationshipEdgePrivate.h */,
-				3736A93A853FCCE34D0B47664ACB2EA4 /* YapDatabaseRelationshipPrivate.h */,
+				205A1BB1019E926556F1C327165E05E7 /* YapDatabaseExtension.h */,
+				85F0BD09A3E638982B9C7D19F91A2241 /* YapDatabaseExtension.m */,
+				E5D68F740C875DC86D4FF865A287CE9F /* YapDatabaseExtensionConnection.h */,
+				A6B2F562837AE04305DC8034E7F1F100 /* YapDatabaseExtensionConnection.m */,
+				07B8E0042E7103C7F774B4E701BFD24A /* YapDatabaseExtensionTransaction.h */,
+				30FA88DA054BAAD5760CAD45B4E7D54D /* YapDatabaseExtensionTransaction.m */,
+				8B679094C87221EE41433C3B4F95928D /* YapDatabaseExtensionTypes.h */,
+				0FC0FB074781E182C3657DFE6BDC9211 /* Internal */,
 			);
-			path = Internal;
+			path = Protocol;
 			sourceTree = "<group>";
 		};
-		91DF849EDB8D6CD58E24F7AF1BBEE6F9 /* Utilities */ = {
+		864AC29166C3DC013B601B350A5468A7 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				AA1D1F3C59C1B72C6ADFAF92C866814B /* YapCache.h */,
-				08FAC5D5D1E18105013013CB5CB52037 /* YapCache.m */,
-				8D4896ACDD3852EBB3B711D0653BA4A9 /* YapCollectionKey.h */,
-				3EC8E4E6780E7D9C3867E12D2E68B83B /* YapCollectionKey.m */,
-				F8686DC7761936C0BB5AF781BF06BA58 /* YapDatabaseQuery.h */,
-				50AD9E691B386637203C026BECB09CCE /* YapDatabaseQuery.m */,
-				9F988D4D181B3C805D977E323CED98A6 /* YapMurmurHash.h */,
-				4FB7FE4C86732572E873982D8B91A298 /* YapMurmurHash.m */,
-				432443F2C87AC74636CAFA860D82301B /* YapMutationStack.h */,
-				149731DA986DB2C776E29A665147D713 /* YapMutationStack.m */,
-				B372C9DC0B4E2454F1527332E0887590 /* YapProxyObject.h */,
-				698A0EDED4E43094B576B506684195AA /* YapProxyObject.m */,
-				2E9E2A2FADC98251BEA03528444D8045 /* YapSet.h */,
-				17DEE28F34BA84F7EA660DE6ACD00739 /* YapSet.m */,
-				40B5BD446EB2C743507304B2FF4E8274 /* YapWhitelistBlacklist.h */,
-				80A16A3C361F30A84E5ADF4E80A7801F /* YapWhitelistBlacklist.m */,
-			);
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		94311FD930B7F566544589468992A9D8 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				A9820A657836B6C624D6DE9E9D80902E /* YapDatabaseExtensionPrivate.h */,
-			);
-			path = Internal;
-			sourceTree = "<group>";
-		};
-		9617A9CD74813ADDC3494F26E6F662FB /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				B9F27EA9B8F64C54944653A856CA10BC /* YDBCKChangeSet.h */,
-				510DAEE7486A1189A8D8A338F1D29187 /* YDBCKChangeSet.m */,
-				D2A37FD4EBBBFC736C3A4C15656B107D /* YDBCKMergeInfo.h */,
-				195E5629ADEADF5E4027444230A2A9D5 /* YDBCKMergeInfo.m */,
-				D8EA9A16976299252C72EDC3F1459A4A /* YDBCKRecord.h */,
-				78EB621E14C92766E184142532332E40 /* YDBCKRecord.m */,
-				5969815061047E5B9B5CE3BC662CCB23 /* YDBCKRecordInfo.h */,
-				E97503252DD189B9109FCD9E31F7F08F /* YDBCKRecordInfo.m */,
+				6ABB9105344311034ABFE100BE23208F /* YapCache.h */,
+				EEA9FC47CCDB0BC42CAE7B40F58B9608 /* YapCache.m */,
+				54B8FCF040E027340763CA7A5F06BEE8 /* YapCollectionKey.h */,
+				4286818F79DF6399D8C80A55C8698748 /* YapCollectionKey.m */,
+				6B173A54339ED3F50B1422413FBC8206 /* YapDatabaseQuery.h */,
+				5D88E3EB5B05814AF2D64972ACF582CB /* YapDatabaseQuery.m */,
+				38AE55FAD5B609795FBAE530C6F43A18 /* YapMurmurHash.h */,
+				C35276CDCCD93A2440E921B2FD476499 /* YapMurmurHash.m */,
+				4F09193A28EAB2411721F2808F524FDE /* YapMutationStack.h */,
+				A63865E864081744239BACE7B6773881 /* YapMutationStack.m */,
+				512DA652F7AA2E773925FC581870FAA4 /* YapProxyObject.h */,
+				A587587FC8AC10AD412E8D0F1B31B487 /* YapProxyObject.m */,
+				0F267CC1687E514DE47803149EC22F46 /* YapSet.h */,
+				8ECB8D6BB6D127AA636DDE0D77683FD7 /* YapSet.m */,
+				2D411C477E3CD68B33537133E141EE39 /* YapWhitelistBlacklist.h */,
+				F162CB1516CD85C2342D998A4B1BC3A0 /* YapWhitelistBlacklist.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
 		};
-		99EB378693425C174F6FC25D305661E9 /* YapDatabase */ = {
+		882ED8169F6A5183DBFF6DDA4BDD6297 /* YapDatabase */ = {
 			isa = PBXGroup;
 			children = (
-				1A19399A3C2F620C0B834005E4E50328 /* YapDatabase.h */,
-				8D7B1BF70DD1DB5336E6C6FB94A72E77 /* YapDatabase.m */,
-				E1DF54396F791161B74F6D7CEA60B353 /* YapDatabaseConnection.h */,
-				EF362363F3C411B948A61C437FE97D6C /* YapDatabaseConnection.m */,
-				CC69A73AC48E67BCD250D1F12B6382A3 /* YapDatabaseOptions.h */,
-				4676F29F296CA30BB7FC6209AE36C3E0 /* YapDatabaseOptions.m */,
-				B3D3B88A40FFCE0CE1CEADED6AF5B79E /* YapDatabaseTransaction.h */,
-				5B934F8B990F20725EBBD74BB758687C /* YapDatabaseTransaction.m */,
-				133CAB030AA9066D4D5AB714618A2E60 /* Extensions */,
-				183D5A2D079BB85C99F11AD1AC354CDB /* Internal */,
-				91DF849EDB8D6CD58E24F7AF1BBEE6F9 /* Utilities */,
+				3743600F62D86F75F23ABAF40B755D44 /* YapDatabase.h */,
+				5E71E4B9CDAF788A2A0BBE9BF195EF99 /* YapDatabase.m */,
+				A30D13F41B487DA805F1654FE49FAD3C /* YapDatabaseConnection.h */,
+				E5FDBE9C35D93F0FFED7EDFDD9354DB5 /* YapDatabaseConnection.m */,
+				B9196FCB61B02E9E7F90F95429D711B1 /* YapDatabaseOptions.h */,
+				162D9FAD9D93CE3DDAEFA86842441C12 /* YapDatabaseOptions.m */,
+				6CFA4DACD9D17D57D8DB524B19AB3CB8 /* YapDatabaseTransaction.h */,
+				E356EAB8387563F6A2981CDA2674F93F /* YapDatabaseTransaction.m */,
+				41823D92C85313B4D15DBF50D8488F93 /* Extensions */,
+				11B45F2D7BF5ECC35C67E3DA5F2BAB98 /* Internal */,
+				864AC29166C3DC013B601B350A5468A7 /* Utilities */,
 			);
 			path = YapDatabase;
 			sourceTree = "<group>";
 		};
-		A02713F7293C9F4382C4AB75BA6BFF52 /* Hooks */ = {
+		9A0704E431656F2DEC3CE29834E98F35 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				4264DA79BA4E0AAB911889ED58534F86 /* YapDatabaseHooks.h */,
-				35B9A7DE3B087B7CAFE90F3116050359 /* YapDatabaseHooks.m */,
-				47C0A1CC1E4EFA2E142C09A03BE57324 /* YapDatabaseHooksConnection.h */,
-				D4B8924C50274B834DC4B53E2A78EA8B /* YapDatabaseHooksConnection.m */,
-				B3F4AA997F84CADD8CE2BFCA5E97397A /* YapDatabaseHooksTransaction.h */,
-				B76BF2AEB1ED1C1CD557B0D8201060A7 /* YapDatabaseHooksTransaction.m */,
-				6F9935544237C2AEADCB9432B92C8617 /* Internal */,
+				FF39DEEFA75ACC10333D55D3CC56EAB1 /* YapDatabaseViewChange.h */,
+				8579948E4B50037139942B4FD1B71FAA /* YapDatabaseViewChange.m */,
+				588DE00AF617A40108D4B6FDF899ED77 /* YapDatabaseViewMappings.h */,
+				7E0DD15B9F52B8F95E8CC216CA766F02 /* YapDatabaseViewMappings.m */,
+				61E46EC80448C8EFF19BB2C7964CC2B9 /* YapDatabaseViewRangeOptions.h */,
+				B0805C0161B17B14CCE58BB7B17EFA48 /* YapDatabaseViewRangeOptions.m */,
 			);
-			path = Hooks;
+			path = Utilities;
 			sourceTree = "<group>";
 		};
-		AA4D747A7920A87845710937362C7300 /* Internal */ = {
+		9C09408B10C00CED917518BE943AF7A8 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				B269906CAA0B3CB29EAC57F18614F88E /* YapDatabaseFullTextSearchPrivate.h */,
+				170866E29089324B75A4AF806DEE1C8B /* YapDatabaseView.h */,
+				3B6D235FBFBDA00EB1C229E2A64D1EA4 /* YapDatabaseView.m */,
+				C1970060B264CDA0618FDCDECF12EC84 /* YapDatabaseViewConnection.h */,
+				B5AD90CEAC695AE4FBF9585EDC068612 /* YapDatabaseViewConnection.m */,
+				DDC510E8CB2E54F0BA6D047EB208F209 /* YapDatabaseViewOptions.h */,
+				3433CD6CA599FE0F2A43D00ABCEB9AD0 /* YapDatabaseViewOptions.m */,
+				0C43A49A032BCB6035B5D5ECBF372974 /* YapDatabaseViewTransaction.h */,
+				5DA84C17FFE47FE9FF08141A7B2C0C5A /* YapDatabaseViewTransaction.m */,
+				AF738860A95B5CA35BD3B7D327E6A167 /* YapDatabaseViewTypes.h */,
+				F449D5C641AC344CBFBA1D6A17A9FF95 /* YapDatabaseViewTypes.m */,
+				DC712F43CA11C06FDDC94FB7729522AD /* Internal */,
+				9A0704E431656F2DEC3CE29834E98F35 /* Utilities */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		A4A2490B7DDF70D68B4E3DEE8C19854E /* CloudKit */ = {
+			isa = PBXGroup;
+			children = (
+				70148D1193160616A141B898741CED14 /* YapDatabaseCloudKit.h */,
+				615B15C0A189EB4F392ED4A73C1204BC /* YapDatabaseCloudKit.m */,
+				F6D504F6C221082ABB60D4079DFB13C8 /* YapDatabaseCloudKitConnection.h */,
+				A5EA313B3FE5E4B0D1FF792CFE9C65E2 /* YapDatabaseCloudKitConnection.m */,
+				2A59AB1E50836F2AC7ABCEE5F69EDFC6 /* YapDatabaseCloudKitOptions.h */,
+				32FB3B46CDE27687DBD28680B7CBBE90 /* YapDatabaseCloudKitOptions.m */,
+				3ADD94D94B918BED82B04E8A24822FF4 /* YapDatabaseCloudKitTransaction.h */,
+				1B214AC0F2B4A9A5C40005E2CA2681AC /* YapDatabaseCloudKitTransaction.m */,
+				B13E5D4CD2A169A97A3C431BE59D399E /* YapDatabaseCloudKitTypes.h */,
+				968FE15A56E59320F8425D094008397F /* YapDatabaseCloudKitTypes.m */,
+				F0881096A46CEE97E98F96052E28D4CC /* Internal */,
+				023697BF5BD03CE94E40B52E72D3E66B /* Utilities */,
+			);
+			path = CloudKit;
+			sourceTree = "<group>";
+		};
+		A4BE56999F822C0F4629ED2CC47EA80D /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				E4C86A1A38C819E98F8FE401E90C39B1 /* YapDatabaseSearchQueuePrivate.h */,
+				FD979328F012B407CD9889DAEE3A33F5 /* YapDatabaseSearchResultsViewPrivate.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -926,25 +974,6 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		BF79C454DBF380029EC2B504C0B86C9E /* Relationships */ = {
-			isa = PBXGroup;
-			children = (
-				2CD090CEA67216801022BC73F5A62D60 /* YapDatabaseRelationship.h */,
-				50E334B1113F8DA1A41E548D103FA35B /* YapDatabaseRelationship.m */,
-				44862C31C5156B32F61D4E2A185E0ED1 /* YapDatabaseRelationshipConnection.h */,
-				F190E14122FA297955A39058A14DADAA /* YapDatabaseRelationshipConnection.m */,
-				3FF6210D530D2B43E944C23B0987C370 /* YapDatabaseRelationshipEdge.h */,
-				2546001E7D901F1685DEF9BD07F3D899 /* YapDatabaseRelationshipEdge.m */,
-				8C57B85A98AA85DE0693D4C3EC26E9F3 /* YapDatabaseRelationshipNode.h */,
-				5E4C1FB6D1F2FBEAC5DEEE5E42DC5224 /* YapDatabaseRelationshipOptions.h */,
-				9A942442BCAC527656452418D4B09824 /* YapDatabaseRelationshipOptions.m */,
-				B4823D8979398FB49D4F0711FDC40086 /* YapDatabaseRelationshipTransaction.h */,
-				17F246F978EDFF63B74C3495A9170A56 /* YapDatabaseRelationshipTransaction.m */,
-				8069FB48AE694693243E8B205D2FEB48 /* Internal */,
-			);
-			path = Relationships;
-			sourceTree = "<group>";
-		};
 		C1A4596FEEA33244F771DE4D33DDB230 /* YapDatabase */ = {
 			isa = PBXGroup;
 			children = (
@@ -955,72 +984,59 @@
 			path = ../../..;
 			sourceTree = "<group>";
 		};
-		C7B4402592DB273AC1C28D415B5384A1 /* FilteredViews */ = {
-			isa = PBXGroup;
-			children = (
-				E2FE04078663E06BC8CF705B923FE2D1 /* YapDatabaseFilteredView.h */,
-				664025F9111D77C497EB5EBDAFF7352F /* YapDatabaseFilteredView.m */,
-				8622B6E617CACAC92567927E2787FD90 /* YapDatabaseFilteredViewConnection.h */,
-				CB2CA8D16215C695CBDAE264EF79D2DF /* YapDatabaseFilteredViewConnection.m */,
-				31C2DC894C76D3988286A29A4071294C /* YapDatabaseFilteredViewTransaction.h */,
-				AFF892BFEFDFFBFA0F707291720BD75F /* YapDatabaseFilteredViewTransaction.m */,
-				D3D6B15F8905B28DF07D7D3710DB4A29 /* YapDatabaseFilteredViewTypes.h */,
-				1DFBB72BC17352E2BC6B3697E136A5AA /* YapDatabaseFilteredViewTypes.m */,
-				0B42D9FA004947C011FBB424160D1AD1 /* Internal */,
-			);
-			path = FilteredViews;
-			sourceTree = "<group>";
-		};
 		C8695568278D69295B96D27A6FDCDE4C /* standard */ = {
 			isa = PBXGroup;
 			children = (
-				99EB378693425C174F6FC25D305661E9 /* YapDatabase */,
+				882ED8169F6A5183DBFF6DDA4BDD6297 /* YapDatabase */,
 			);
 			name = standard;
 			sourceTree = "<group>";
 		};
-		CD87AA625B4D2782E710B8F69DC39D30 /* SearchResults */ = {
+		D87A9831733A155FFBB00F5323AC5209 /* Hooks */ = {
 			isa = PBXGroup;
 			children = (
-				DE3294276C924F16704CC165C4549040 /* YapDatabaseSearchQueue.h */,
-				6210A508B0D0F7D302EEA81450939EE6 /* YapDatabaseSearchQueue.m */,
-				2EF33C8840C10AC6CC78BB9C934E01EA /* YapDatabaseSearchResultsView.h */,
-				DD359AE3E025D48F2D646D8DE4DEB153 /* YapDatabaseSearchResultsView.m */,
-				80A8502424CB22703A0E69AE8A12F3EC /* YapDatabaseSearchResultsViewConnection.h */,
-				C6685BFB15FE26BC0E6EE15AFD4E363D /* YapDatabaseSearchResultsViewConnection.m */,
-				61B6DEF61AA4581CA87266F8C56DB83A /* YapDatabaseSearchResultsViewOptions.h */,
-				7571D738DE3587598B32E052F36E0203 /* YapDatabaseSearchResultsViewOptions.m */,
-				8839EA01057AEB7F503BF26037735AC1 /* YapDatabaseSearchResultsViewTransaction.h */,
-				961C6B5676175CEC649B82DC721C8E79 /* YapDatabaseSearchResultsViewTransaction.m */,
-				63D3687802AAC51107481ABB13FB7357 /* Internal */,
+				BBEADEFD536D7F431820BE5C7EBE8AA2 /* YapDatabaseHooks.h */,
+				DEF2C3162E4EB0EEBDDE88767F990355 /* YapDatabaseHooks.m */,
+				DF30921F71F6AE3727A54D8ECA335AD2 /* YapDatabaseHooksConnection.h */,
+				0BAFD282AA4E753B936469759F6EFBF9 /* YapDatabaseHooksConnection.m */,
+				12DD26FAC94AC9BCB815C05B60EE72FD /* YapDatabaseHooksTransaction.h */,
+				9DD782FB05B37D290DB3F30EF1DBE418 /* YapDatabaseHooksTransaction.m */,
+				22634192E0B634FBE9646A4F4A42CD1F /* Internal */,
 			);
-			path = SearchResults;
+			path = Hooks;
 			sourceTree = "<group>";
 		};
-		D2F77A928B397011F7F064DF5C1493F3 /* Internal */ = {
+		DC712F43CA11C06FDDC94FB7729522AD /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				2F5457EC80185B03E121EEBCE5322D0A /* YapDatabaseCloudKitPrivate.h */,
-				21931CB46FD6E2EE321E637420D8BB40 /* YDBCKAttachRequest.h */,
-				CCDB48ADD754701284662F157D166172 /* YDBCKAttachRequest.m */,
-				8FB8F515D249AFB8461834F1092B7EE6 /* YDBCKChangeQueue.h */,
-				8BEEE8E2D1FFB3CF92CE3D4981BA6233 /* YDBCKChangeQueue.m */,
-				007FBB4E43B8A81EBBEBBE6F02BB498D /* YDBCKChangeRecord.h */,
-				45305F54F84DF41BA8DB7C4012E00270 /* YDBCKChangeRecord.m */,
-				22CA4E953C53469E4E4B6059608F8E19 /* YDBCKMappingTableInfo.h */,
-				17F23FBBECC8D76022977869F9D2241A /* YDBCKMappingTableInfo.m */,
-				406AF711EAD3928320CF20A6A8EDB7AD /* YDBCKRecordTableInfo.h */,
-				8FA523887D399884DDE9EA2F1A4CBC40 /* YDBCKRecordTableInfo.m */,
+				63B87551B56C58AFD97D02BC76F05121 /* YapDatabaseViewChangePrivate.h */,
+				87AD95EE682E1AF47B4CAE1C6A932931 /* YapDatabaseViewMappingsPrivate.h */,
+				14152B0E81AC743C88A84BAF743014DB /* YapDatabaseViewPage.h */,
+				F154C204602290FC80C2C026EDF9C13F /* YapDatabaseViewPage.mm */,
+				D1D9BA99F5891F1FDF30595A4835DD57 /* YapDatabaseViewPageMetadata.h */,
+				B36F5E75B5CE6417346CBD8848F0E7FE /* YapDatabaseViewPageMetadata.m */,
+				BE560E7B3149571B0A469AA39AB98984 /* YapDatabaseViewPrivate.h */,
+				8A88823955B2CF23404237E0DC4A7035 /* YapDatabaseViewRangeOptionsPrivate.h */,
+				B4B59B37AC17C28B187B3C09D4643996 /* YapDatabaseViewState.h */,
+				F58CA75CEE1992E2C027AB6579576826 /* YapDatabaseViewState.m */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
 		};
-		E16622659B3FF97AA314F19C79F74EFD /* Internal */ = {
+		DDEC16CA66E2601A3107D28D42A893CD /* FilteredViews */ = {
 			isa = PBXGroup;
 			children = (
-				A476950E6E65B2C0FF9CDE52F9DD63B5 /* YapDatabaseSecondaryIndexPrivate.h */,
+				FC915582FF9FA794CCC18D87F5BE1F01 /* YapDatabaseFilteredView.h */,
+				BDD11C2496DB1803F7638E08D3492D68 /* YapDatabaseFilteredView.m */,
+				BE8CCF1605338B010AAAD3DD2F96A3CB /* YapDatabaseFilteredViewConnection.h */,
+				92D2842C01718447F2E5C2D43A31FEB6 /* YapDatabaseFilteredViewConnection.m */,
+				FB00C2EB2AC33870D8D45FAB2C817702 /* YapDatabaseFilteredViewTransaction.h */,
+				C6AEEBF0CA4ECC952614A55B5739A94D /* YapDatabaseFilteredViewTransaction.m */,
+				7CC39064E94413754358BDB97002E700 /* YapDatabaseFilteredViewTypes.h */,
+				33F998CAAFC0BB728C266B47A2916E0B /* YapDatabaseFilteredViewTypes.m */,
+				1F86F5DE0E843156D360DBC142DB7EF6 /* Internal */,
 			);
-			path = Internal;
+			path = FilteredViews;
 			sourceTree = "<group>";
 		};
 		E973B0FBD48111F2CBE01BB9EAD1976C /* Pods */ = {
@@ -1031,55 +1047,157 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		EF76006DDAD410A8A689EA077A9F4530 /* FullTextSearch */ = {
+		F0881096A46CEE97E98F96052E28D4CC /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				36E21A8119699FDB374CB3262F227E97 /* YapDatabaseFullTextSearch.h */,
-				ABFA3A939380311EF51ED290F486CFCE /* YapDatabaseFullTextSearch.m */,
-				D4B04409C68A525FC76B724CD9CD4E14 /* YapDatabaseFullTextSearchConnection.h */,
-				CF3FD8815BE891C39C141EDA084A9AA4 /* YapDatabaseFullTextSearchConnection.m */,
-				00EA9E27554304E93282EF5BF2E2F20E /* YapDatabaseFullTextSearchHandler.h */,
-				31D41B028047C6A2120B960CDF3873EE /* YapDatabaseFullTextSearchHandler.m */,
-				A804F15716B4BE0A90BBB90D6F09EDC0 /* YapDatabaseFullTextSearchSnippetOptions.h */,
-				B2D7CCA9A8171410CE55B30EFB25B50A /* YapDatabaseFullTextSearchSnippetOptions.m */,
-				FC0169A057F34239D824035BF8BF70E2 /* YapDatabaseFullTextSearchTransaction.h */,
-				C493DA727F3B7F13334385C13B309485 /* YapDatabaseFullTextSearchTransaction.m */,
-				AA4D747A7920A87845710937362C7300 /* Internal */,
-			);
-			path = FullTextSearch;
-			sourceTree = "<group>";
-		};
-		F44A2DAF913000CA185E99BDAFA96D4A /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				2EE925426226F66EBE27083E21D2EF47 /* YapDatabaseRTreeIndexPrivate.h */,
+				C12FAF4C4AF7ADB9E520919F6934BC6B /* YapDatabaseCloudKitPrivate.h */,
+				2A91CCD9279E9FDC37A131C25F0B0079 /* YDBCKAttachRequest.h */,
+				B27DF70BDF04B97794AFC77BD6E45462 /* YDBCKAttachRequest.m */,
+				CB5287261CF2C001B5EDF9407BD09BEB /* YDBCKChangeQueue.h */,
+				785A6EBAB877052B9D64302D41BE1CE3 /* YDBCKChangeQueue.m */,
+				65991F1294DA96B7EA0C8A6EE6D1896C /* YDBCKChangeRecord.h */,
+				735271F6634176AD4065ACD204D9EC42 /* YDBCKChangeRecord.m */,
+				E1936902513F202C2C297FABFA27C4BF /* YDBCKMappingTableInfo.h */,
+				F62360F0833D4350ADDC3E77C7037A49 /* YDBCKMappingTableInfo.m */,
+				EBF43A8365E5A6D7C46B8B7D3D415E40 /* YDBCKRecordTableInfo.h */,
+				6219C4A647C73AB9631E933DAEA82790 /* YDBCKRecordTableInfo.m */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
 		};
-		F7C6962771B5D3E82810C89C73EB80D0 /* RTreeIndex */ = {
+		FD98B9BA6E8982EC508CB74497B7B826 /* FullTextSearch */ = {
 			isa = PBXGroup;
 			children = (
-				E52BBDC32C5F7CA597C16A47D6890F81 /* YapDatabaseRTreeIndex.h */,
-				9C764E8FAD35D9D4E07B8365D0718B30 /* YapDatabaseRTreeIndex.m */,
-				BD438CBD6985592ACBDCDA7FFB555002 /* YapDatabaseRTreeIndexConnection.h */,
-				936249C808FB3FF760973692617734C0 /* YapDatabaseRTreeIndexConnection.m */,
-				E9F551C4C330E91AA3C267195137C18F /* YapDatabaseRTreeIndexHandler.h */,
-				9940A1D73FF6AA9B60856DA512BD05CC /* YapDatabaseRTreeIndexHandler.m */,
-				D44C2C2892EF84F4B63827E49928FF93 /* YapDatabaseRTreeIndexOptions.h */,
-				C89497866A2668D8CFFA53D266232165 /* YapDatabaseRTreeIndexOptions.m */,
-				AA47DE97BA5921119D4DE805D025DF86 /* YapDatabaseRTreeIndexSetup.h */,
-				AE2449FBD13E40FBFDFAFFD82F62E0A4 /* YapDatabaseRTreeIndexSetup.m */,
-				1EDC89F3C717A2A72179C3F65DE5FC82 /* YapDatabaseRTreeIndexTransaction.h */,
-				47DE15CB269FE987356EB6B862B4B246 /* YapDatabaseRTreeIndexTransaction.m */,
-				F44A2DAF913000CA185E99BDAFA96D4A /* Internal */,
+				431FC0D824F9F536AB27E17B7B906BB6 /* YapDatabaseFullTextSearch.h */,
+				84418AA95E5334C72A4F3CA3FCB8EC74 /* YapDatabaseFullTextSearch.m */,
+				5F409BFD2D58D005C50238FF512DB514 /* YapDatabaseFullTextSearchConnection.h */,
+				8FDBD74F41BDA79D747FCB115C9B1372 /* YapDatabaseFullTextSearchConnection.m */,
+				60F01A4D165CA692868A25E9BBF6A669 /* YapDatabaseFullTextSearchHandler.h */,
+				223F025287AF6C7CF6F7EED41CAC94E4 /* YapDatabaseFullTextSearchHandler.m */,
+				3B903CD7650F49A9B8BF5F2FC63FD8F4 /* YapDatabaseFullTextSearchSnippetOptions.h */,
+				AE5494054F4C559747B1688783FB3DB2 /* YapDatabaseFullTextSearchSnippetOptions.m */,
+				7C42EFA4176B229F3F2A364D5C06F47D /* YapDatabaseFullTextSearchTransaction.h */,
+				3422204C401A303ED132EEC30520C8E4 /* YapDatabaseFullTextSearchTransaction.m */,
+				0E03360C75D497DDAD13C0057C8B0E22 /* Internal */,
 			);
-			path = RTreeIndex;
+			path = FullTextSearch;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		23B26290B888F0DDB0C96C20AB388442 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				36AE8EDEA06133D6699E71184AC1FF08 /* NSDictionary+YapDatabase.h in Headers */,
+				B9662429B2407F4A56E940F0B62D5F84 /* yap_vfs_shim.h in Headers */,
+				7701B3422BAB34836FC4ED7CE9BDEE19 /* YapCache.h in Headers */,
+				ACB88E893352436F8E883F50303E5440 /* YapCollectionKey.h in Headers */,
+				BB19440F4CBA4434DAAF5EF1776DFC40 /* YapDatabase.h in Headers */,
+				FF7BF12DFD112AB97971340DC7CAEB37 /* YapDatabaseCloudKit.h in Headers */,
+				C51F3082EA87568D0E3CE8B85461799A /* YapDatabaseCloudKitConnection.h in Headers */,
+				7CC3E234BE3FA403043ED3B3F3614648 /* YapDatabaseCloudKitOptions.h in Headers */,
+				A546508180EE8E63C9EAA635D43DC577 /* YapDatabaseCloudKitPrivate.h in Headers */,
+				FB3612DCC9116C86981F735394C8FDFF /* YapDatabaseCloudKitTransaction.h in Headers */,
+				F595E02D65FB67C6A256017C08E4CF66 /* YapDatabaseCloudKitTypes.h in Headers */,
+				88EB187ADA227A9146E50E1634E4D200 /* YapDatabaseConnection.h in Headers */,
+				6099651C37E0FD54943FB892B05165FF /* YapDatabaseConnectionDefaults.h in Headers */,
+				91235E939BA0885A6C4DDC8EB5BECA0D /* YapDatabaseConnectionState.h in Headers */,
+				129E51693FB1E76FBF5AB4BBF59BF271 /* YapDatabaseExtension.h in Headers */,
+				47E656896B03152A9F609EC7BC2AACBE /* YapDatabaseExtensionConnection.h in Headers */,
+				2921BAACCDB9725FCF4CDFADBA872EB7 /* YapDatabaseExtensionPrivate.h in Headers */,
+				A4B000966D30247FEE5FA2E8FF0D8EFA /* YapDatabaseExtensionTransaction.h in Headers */,
+				681216D48E0D951027AF0D64B478FC9D /* YapDatabaseExtensionTypes.h in Headers */,
+				9FFEBFC646F5C64BFB64DDC228B91667 /* YapDatabaseFilteredView.h in Headers */,
+				98DAF5AF4EDFBDC02AAD594CB8E4A6AF /* YapDatabaseFilteredViewConnection.h in Headers */,
+				3DCA4AAA2CE8B28DD67F302842693996 /* YapDatabaseFilteredViewPrivate.h in Headers */,
+				12100F28EC093016F1D6FB7786E35017 /* YapDatabaseFilteredViewTransaction.h in Headers */,
+				3E517D3F7B6202B0CF625E8EEB343534 /* YapDatabaseFilteredViewTypes.h in Headers */,
+				D3BE609B61572EDD6137C149F797986A /* YapDatabaseFullTextSearch.h in Headers */,
+				3170DC4AA112B020A679AD92F7B7B730 /* YapDatabaseFullTextSearchConnection.h in Headers */,
+				D22EB49E2F913CD595D63490F8CC1212 /* YapDatabaseFullTextSearchHandler.h in Headers */,
+				99E57BE53DB0338F3B7F38B6B40CA2F0 /* YapDatabaseFullTextSearchPrivate.h in Headers */,
+				B02BEBD8C7200FB86A8952F24FC10AAD /* YapDatabaseFullTextSearchSnippetOptions.h in Headers */,
+				ECCE55284A1707A2AFD4BE58C41E1618 /* YapDatabaseFullTextSearchTransaction.h in Headers */,
+				CE6C36423E960AFFAC6E1F43B29980C1 /* YapDatabaseHooks.h in Headers */,
+				20AE57D9B772254D5CB2036C53406582 /* YapDatabaseHooksConnection.h in Headers */,
+				B097CBD3A09320E92F178EFFCBEFF0BC /* YapDatabaseHooksPrivate.h in Headers */,
+				2A4756672A66CAC9A686C259B11B2353 /* YapDatabaseHooksTransaction.h in Headers */,
+				96FD2FA6845B08E3D7DA67149055EBD5 /* YapDatabaseLogging.h in Headers */,
+				8BCCB470D23D4392D1D0F5A6F97B434F /* YapDatabaseManager.h in Headers */,
+				B8233C383C320F41B9DB01276481511D /* YapDatabaseOptions.h in Headers */,
+				2E4404ECA2C4BF7092AB092FBCF7152C /* YapDatabasePrivate.h in Headers */,
+				1E48363AE5545ABC54E858306E2201C9 /* YapDatabaseQuery.h in Headers */,
+				56C0D06DD64369F973D98BDF8DEC96B7 /* YapDatabaseRelationship.h in Headers */,
+				30784992AF8216AA1EC2C384A7AC9424 /* YapDatabaseRelationshipConnection.h in Headers */,
+				8C4BB1398C0EBE211DC2C412D82F3668 /* YapDatabaseRelationshipEdge.h in Headers */,
+				3FAF8A623D5020FA9F64333D929D2E7B /* YapDatabaseRelationshipEdgePrivate.h in Headers */,
+				972E110DA1ADD98E17F3185246C6BFC1 /* YapDatabaseRelationshipNode.h in Headers */,
+				ECE111F94DEE964104CCB11D824749F4 /* YapDatabaseRelationshipOptions.h in Headers */,
+				20CEF7CAF6459542143ECBCDE18D00F8 /* YapDatabaseRelationshipPrivate.h in Headers */,
+				A74E67F6D42E1B7E1B76EDE9B7D808EB /* YapDatabaseRelationshipTransaction.h in Headers */,
+				FA062F8ECE31623E5C2E3B077491AA59 /* YapDatabaseRTreeIndex.h in Headers */,
+				EF9F25714176EC39EBE501175098CA44 /* YapDatabaseRTreeIndexConnection.h in Headers */,
+				49EC96D778816168DD8C41AFEB7EF183 /* YapDatabaseRTreeIndexHandler.h in Headers */,
+				BE1F2D1A77DFD0A2CBFE2ABA214FEFD1 /* YapDatabaseRTreeIndexOptions.h in Headers */,
+				9C0C7110D5513C6573A5E27B87505E1B /* YapDatabaseRTreeIndexPrivate.h in Headers */,
+				475F6E57FF82CB210B3FC57DE77AA6CB /* YapDatabaseRTreeIndexSetup.h in Headers */,
+				6DE61BD14333FD73AC9B1C043076581E /* YapDatabaseRTreeIndexTransaction.h in Headers */,
+				1EE3F7CD08754BC9ED960FE2305F0EF2 /* YapDatabaseSearchQueue.h in Headers */,
+				DD5F5689D9AFFC255F4B8DF61299E2C4 /* YapDatabaseSearchQueuePrivate.h in Headers */,
+				40B263C91588190B54BD46ACF89DE75C /* YapDatabaseSearchResultsView.h in Headers */,
+				42B6C6B0829E4745B9AA5275FD93C47C /* YapDatabaseSearchResultsViewConnection.h in Headers */,
+				39B68FC8B90E67AB9432EA7C175929CC /* YapDatabaseSearchResultsViewOptions.h in Headers */,
+				BEA81CB20CC828E5C73536449BEEBF02 /* YapDatabaseSearchResultsViewPrivate.h in Headers */,
+				90231ACED987DADED8EE7CAF744B0E6D /* YapDatabaseSearchResultsViewTransaction.h in Headers */,
+				D91DCD2494C573A63946AD00A639F31C /* YapDatabaseSecondaryIndex.h in Headers */,
+				229826EFFDFB458B8A0692505C207B75 /* YapDatabaseSecondaryIndexConnection.h in Headers */,
+				C5DC6B0136247022F78EF957649F60FF /* YapDatabaseSecondaryIndexHandler.h in Headers */,
+				36F53B78CEFDCF89AD1C209422B7225F /* YapDatabaseSecondaryIndexOptions.h in Headers */,
+				FFD47FAC7D522D27CF95128AC9C306E3 /* YapDatabaseSecondaryIndexPrivate.h in Headers */,
+				612298C907D09DA643C123EC8DAD5BE4 /* YapDatabaseSecondaryIndexSetup.h in Headers */,
+				8195AAF714875E38C9472D7DF4190094 /* YapDatabaseSecondaryIndexTransaction.h in Headers */,
+				FC72CDDEA4A05B3413FF02E0AD737A66 /* YapDatabaseStatement.h in Headers */,
+				4190103A3078F187417168F725CDF07B /* YapDatabaseString.h in Headers */,
+				0545835D13DC12F701EAE172A2826179 /* YapDatabaseTransaction.h in Headers */,
+				1B87E357A87E9E93B79A67178105C49C /* YapDatabaseView.h in Headers */,
+				C083C53A259A12DB1BDA44D2D79412D3 /* YapDatabaseViewChange.h in Headers */,
+				3DEE69A0C9658F7A5B6705D1A167137B /* YapDatabaseViewChangePrivate.h in Headers */,
+				6A4E1688E6E6742F56BB93F117070B9E /* YapDatabaseViewConnection.h in Headers */,
+				D804343D3D515A62C05989E1489E095B /* YapDatabaseViewMappings.h in Headers */,
+				573CA73E83E49AA210AF8897DDD91F51 /* YapDatabaseViewMappingsPrivate.h in Headers */,
+				0E84BFCDA024D21036CD240467062961 /* YapDatabaseViewOptions.h in Headers */,
+				F2797BF960D828722CCFBF263CA6E6F4 /* YapDatabaseViewPage.h in Headers */,
+				EB5D5C2E77B4108A13B76E7EC322B356 /* YapDatabaseViewPageMetadata.h in Headers */,
+				CCABA9A6467D27FBB3A70B132C83E7C4 /* YapDatabaseViewPrivate.h in Headers */,
+				044D69FB400BE58D50A7F15F7CC6EB39 /* YapDatabaseViewRangeOptions.h in Headers */,
+				D9B1018C11E5CADDADA1F273D52CDF3C /* YapDatabaseViewRangeOptionsPrivate.h in Headers */,
+				E083FAADCD30319104455635E651DA89 /* YapDatabaseViewState.h in Headers */,
+				92B7A2955E52A0924D8AA28014A0C577 /* YapDatabaseViewTransaction.h in Headers */,
+				F8DB2224EC35009A92BF819B0E36E089 /* YapDatabaseViewTypes.h in Headers */,
+				67F64FCFF346A66EA29FB077F065B0DF /* YapMemoryTable.h in Headers */,
+				0A0CF6EE221D537254577D6F651E3EA0 /* YapMurmurHash.h in Headers */,
+				5400FBACFD14F219AB0F5469C88E1287 /* YapMutationStack.h in Headers */,
+				7F1E9A8A765B55F409C39D5E1BA029FA /* YapNull.h in Headers */,
+				ED5D7AC47325195B903512E16965381A /* YapProxyObject.h in Headers */,
+				505CFCEB6129E67DE3A9BBBAE57EB9E9 /* YapProxyObjectPrivate.h in Headers */,
+				ED69B7F521A8F3E6AAD2A64C9ECDD61B /* YapRowidSet.h in Headers */,
+				16203529550648AF674A035E2167C32A /* YapSet.h in Headers */,
+				5DE9CC983A8DB391196EED018429ACEB /* YapTouch.h in Headers */,
+				E153E8CA07EBCA8F10740E6057AB07BD /* YapWhitelistBlacklist.h in Headers */,
+				F5FADDFCD90E501799869B3BAA83DA52 /* YDBCKAttachRequest.h in Headers */,
+				0966B10349DC4693FF2EDAA975AD79DE /* YDBCKChangeQueue.h in Headers */,
+				7CBF4AF3ACFF38F848B7A1683D881933 /* YDBCKChangeRecord.h in Headers */,
+				1A33A3DC9F70D6A7CF8AF05F58FD528C /* YDBCKChangeSet.h in Headers */,
+				EB5E6D02113BFD07D15304F5D873CA45 /* YDBCKMappingTableInfo.h in Headers */,
+				E9E7EFE6F8DD4D4BE38F58709FCD0365 /* YDBCKMergeInfo.h in Headers */,
+				961A588BA42A44315FCA655CA0A6C608 /* YDBCKRecord.h in Headers */,
+				8C73E1892D3A8EFA45DCD74DE8FFC9A0 /* YDBCKRecordInfo.h in Headers */,
+				0BD1E0F43ED3C603C6BEDBA9E91C7310 /* YDBCKRecordTableInfo.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3D1929340700AE302905262BB6EE9651 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1098,117 +1216,6 @@
 				3DDD0FB94D61AB71C8F5C727EC7A0BD9 /* DDLogMacros.h in Headers */,
 				6475050C8BA464772209BD6AF03F1EB1 /* DDMultiFormatter.h in Headers */,
 				5DCBA219BC81D9190F11EE56F93BB908 /* DDTTYLogger.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DBD91164274E6A50692DB751ACE1C443 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				08805ED592529C6775FBF1FE3A8524EE /* NSDictionary+YapDatabase.h in Headers */,
-				1A0BABF12635A41AB0427834C72B4F8C /* YapCache.h in Headers */,
-				9A2954DCA42B4779137A299D89B91A1C /* YapCollectionKey.h in Headers */,
-				3C1977C9C888DA930F2108E9E076B135 /* YapDatabase.h in Headers */,
-				29B09567B817A90369B697CF3760719D /* YapDatabaseCloudKit.h in Headers */,
-				66442206C1F4BCB3820C69F9A5626B37 /* YapDatabaseCloudKitConnection.h in Headers */,
-				A88EB9ED02FF0D26C14C32404E5D1DA1 /* YapDatabaseCloudKitOptions.h in Headers */,
-				E50CEAAD702118FA08956E479B2A96C9 /* YapDatabaseCloudKitPrivate.h in Headers */,
-				08CF982D111FFA79CAC3653E45EEB4AC /* YapDatabaseCloudKitTransaction.h in Headers */,
-				BA83C7A5E19CE27B47E453C8683D109F /* YapDatabaseCloudKitTypes.h in Headers */,
-				ADE18C4317B6BAF739D38914CAA82F98 /* YapDatabaseConnection.h in Headers */,
-				04E148442E97995074B8EE528BEA39C5 /* YapDatabaseConnectionDefaults.h in Headers */,
-				2D2DEF89718B29828550513EC7739EB8 /* YapDatabaseConnectionState.h in Headers */,
-				38E7B80958F40C94C5B8E29782E389B7 /* YapDatabaseExtension.h in Headers */,
-				8ECEE147A0DA1D7BF2C1D082F3096C5D /* YapDatabaseExtensionConnection.h in Headers */,
-				CA7FC90945F43ABF67B245B385DA5A4D /* YapDatabaseExtensionPrivate.h in Headers */,
-				5CF61E927832BA4277626D98AE498781 /* YapDatabaseExtensionTransaction.h in Headers */,
-				AA4E93F117D502A902AEA3263F81FFF3 /* YapDatabaseExtensionTypes.h in Headers */,
-				36584980D4A0420AC86B7F4162137AB1 /* YapDatabaseFilteredView.h in Headers */,
-				2CA4C5901FAB7F32BD38F211A4608D13 /* YapDatabaseFilteredViewConnection.h in Headers */,
-				B1CCC050C335E43DE8F72EEC82F6ACDD /* YapDatabaseFilteredViewPrivate.h in Headers */,
-				6AB51294C00240C00234432ED8E33139 /* YapDatabaseFilteredViewTransaction.h in Headers */,
-				94BDA2DA2D89A101E02A5E2732AF71A9 /* YapDatabaseFilteredViewTypes.h in Headers */,
-				E9EB5D3E166360A358E6BE999B0B2C02 /* YapDatabaseFullTextSearch.h in Headers */,
-				916AFC5EDE34B71E38AF67183EDE274B /* YapDatabaseFullTextSearchConnection.h in Headers */,
-				10E6A6CE536B13D9D49C7B1E7B36CE0D /* YapDatabaseFullTextSearchHandler.h in Headers */,
-				822FB2C21B16FF428C9BE4DCA1F8F30A /* YapDatabaseFullTextSearchPrivate.h in Headers */,
-				D9E1B34E9F3B29871237756EF77F3C77 /* YapDatabaseFullTextSearchSnippetOptions.h in Headers */,
-				E93EE1ED6B51197ABC1695A4C099C81C /* YapDatabaseFullTextSearchTransaction.h in Headers */,
-				E62E2A96500B41384CAE4C1FFF2E6FDC /* YapDatabaseHooks.h in Headers */,
-				6D1A7F16035BFCA931157E82C20901E3 /* YapDatabaseHooksConnection.h in Headers */,
-				F9B033B6CF260AF75B54D363279E72E3 /* YapDatabaseHooksPrivate.h in Headers */,
-				45E510115B573B98ECE60AF76A3F6476 /* YapDatabaseHooksTransaction.h in Headers */,
-				8FA2E6C90FF9C12F5FC3D87B7D9291DC /* YapDatabaseLogging.h in Headers */,
-				473E27EA39600681EA98037D087ACB10 /* YapDatabaseManager.h in Headers */,
-				0EE577EC5BB5B2F7CB719DF2D31CF06B /* YapDatabaseOptions.h in Headers */,
-				61756DB5882D00093B8DE46B69B84069 /* YapDatabasePrivate.h in Headers */,
-				B4E53E9E1C544456B8CC57CCA6633647 /* YapDatabaseQuery.h in Headers */,
-				C68FFF658A09735C143A9574B1FB6B20 /* YapDatabaseRelationship.h in Headers */,
-				278D9193EDC7D11367906BC6891B2897 /* YapDatabaseRelationshipConnection.h in Headers */,
-				9D68786F03B1271C44FCE4B930AB07FF /* YapDatabaseRelationshipEdge.h in Headers */,
-				E23084FC5F07D46C4F162CA3A58FF89F /* YapDatabaseRelationshipEdgePrivate.h in Headers */,
-				529DAE23DFBABD303CAA7634FABBA19C /* YapDatabaseRelationshipNode.h in Headers */,
-				8FFD82E51BF55093AC240EC831D9B145 /* YapDatabaseRelationshipOptions.h in Headers */,
-				2B19C2168FC950858A214291862C9F39 /* YapDatabaseRelationshipPrivate.h in Headers */,
-				E78466BE25AE02C87FABAE0A20B4C5C6 /* YapDatabaseRelationshipTransaction.h in Headers */,
-				7DBE369AA7CB574AEED84707CF04A9AE /* YapDatabaseRTreeIndex.h in Headers */,
-				F095A542DBD5D5B116135F8D4004B838 /* YapDatabaseRTreeIndexConnection.h in Headers */,
-				2B9979622557369F3ABACADF405BA203 /* YapDatabaseRTreeIndexHandler.h in Headers */,
-				3D202DEEA12C732F3B0E5849A0225568 /* YapDatabaseRTreeIndexOptions.h in Headers */,
-				C5948BB0F3CE15BC544BB69C24F4A55A /* YapDatabaseRTreeIndexPrivate.h in Headers */,
-				93837BA1C646A79E4CE9F2286B0BF76F /* YapDatabaseRTreeIndexSetup.h in Headers */,
-				AD9964D5A81E379C81BAA210844E9EF8 /* YapDatabaseRTreeIndexTransaction.h in Headers */,
-				FCA086EFC13567301D9E956E5E8959C5 /* YapDatabaseSearchQueue.h in Headers */,
-				8D868CC868962C3296E0BC7706B1A93A /* YapDatabaseSearchQueuePrivate.h in Headers */,
-				D9EC99F3DD12C8C2554BDAF1A30235F0 /* YapDatabaseSearchResultsView.h in Headers */,
-				A8FDA4D9DAA171B7BCAC0E015C65C5E9 /* YapDatabaseSearchResultsViewConnection.h in Headers */,
-				098EBE80DDFC9CB575870E519A5DE302 /* YapDatabaseSearchResultsViewOptions.h in Headers */,
-				963356FC04C94BC1C6DE473659C7A4C1 /* YapDatabaseSearchResultsViewPrivate.h in Headers */,
-				F238476CDDDFF709EBAD06DF4B20C551 /* YapDatabaseSearchResultsViewTransaction.h in Headers */,
-				2960383E5BF11CDF66733617000EC576 /* YapDatabaseSecondaryIndex.h in Headers */,
-				6681032A8F7C098BA72A29A0AA514E26 /* YapDatabaseSecondaryIndexConnection.h in Headers */,
-				6B8F1F3A4F73833DFB2E359C3317C328 /* YapDatabaseSecondaryIndexHandler.h in Headers */,
-				9CCCDB03543B8954B596255C477286B8 /* YapDatabaseSecondaryIndexOptions.h in Headers */,
-				36FCA08A0E91B77CA35497326F0B276D /* YapDatabaseSecondaryIndexPrivate.h in Headers */,
-				84B9A84D598A200CFDDC2A70A2564FF0 /* YapDatabaseSecondaryIndexSetup.h in Headers */,
-				AE6E3629187CA3A71ABAD2B52B0BE2D6 /* YapDatabaseSecondaryIndexTransaction.h in Headers */,
-				268D74969608D13368D93CD67BBB7F78 /* YapDatabaseStatement.h in Headers */,
-				70120DF2E98FC6DF30AC9E09094256ED /* YapDatabaseString.h in Headers */,
-				D21697F8AA4C395F3726222602988A3E /* YapDatabaseTransaction.h in Headers */,
-				99F4B885AB08B87A93B9BEB95D602A10 /* YapDatabaseView.h in Headers */,
-				792F8BE825637280329F3E67CBFE5175 /* YapDatabaseViewChange.h in Headers */,
-				AADFCF570B8FA7D7D6D275B64C701549 /* YapDatabaseViewChangePrivate.h in Headers */,
-				1CF32A72CF73C68E61E21BB899E5413B /* YapDatabaseViewConnection.h in Headers */,
-				31D120F1E08D8B5530E506594BAD4E13 /* YapDatabaseViewMappings.h in Headers */,
-				5C652BEBA7AB9B468E5170773BBB1073 /* YapDatabaseViewMappingsPrivate.h in Headers */,
-				D0378E9DFFDA42CFA7658A604E8B38E5 /* YapDatabaseViewOptions.h in Headers */,
-				0576ACF3B0E87D02956EBEFC2183B55E /* YapDatabaseViewPage.h in Headers */,
-				86CB06B4951DB700C9903A6BC975033E /* YapDatabaseViewPageMetadata.h in Headers */,
-				34B8AA30FD1919369781A8DDE0BDE467 /* YapDatabaseViewPrivate.h in Headers */,
-				83EC30059533930DE5914B4C2F9131A4 /* YapDatabaseViewRangeOptions.h in Headers */,
-				9D1AA07CFCA36F88E5FF28E157E9ED6C /* YapDatabaseViewRangeOptionsPrivate.h in Headers */,
-				0EBF1BA9149B0AD36479E5A44B08E264 /* YapDatabaseViewState.h in Headers */,
-				04CCD002FBFEEF1B1D12F5F5BD539845 /* YapDatabaseViewTransaction.h in Headers */,
-				60E662F4D58F4B3248413E3EB804D60D /* YapDatabaseViewTypes.h in Headers */,
-				0600CF953F3A3AB31492A85FD1C7834C /* YapMemoryTable.h in Headers */,
-				7DD4EFDD4A2C173C4D91D953C8D75D29 /* YapMurmurHash.h in Headers */,
-				5263C0992A007DB20CD5CE04F33F8852 /* YapMutationStack.h in Headers */,
-				C99A43D87150B060AF1F52D16FC5267A /* YapNull.h in Headers */,
-				8376DBAB103A6547C0CC9C7EAF44A45B /* YapProxyObject.h in Headers */,
-				CDC58BF93062D93A5397F6E416017CB6 /* YapProxyObjectPrivate.h in Headers */,
-				7C6205454FA86A4FDDAC53A870A1817F /* YapRowidSet.h in Headers */,
-				2E613F0ADCA711BF91650EB8D5644EA5 /* YapSet.h in Headers */,
-				D9D7FE5D7994204382EFC796141CF126 /* YapTouch.h in Headers */,
-				BC6F376743E870B8FEE653D85684B369 /* YapWhitelistBlacklist.h in Headers */,
-				6CE47D93F369F8EBC82309722B4D49B9 /* YDBCKAttachRequest.h in Headers */,
-				73DB6C2CEFE9748174FFE5200EE18E57 /* YDBCKChangeQueue.h in Headers */,
-				E9FAB73235EAFA1F8BACF17C837DECAA /* YDBCKChangeRecord.h in Headers */,
-				65E5BDEC5A8D9FD4DEEA8CC2287A8987 /* YDBCKChangeSet.h in Headers */,
-				F7ED854C5396CB2D97B28D8665A2A751 /* YDBCKMappingTableInfo.h in Headers */,
-				7E57F03FD6B64C487B60558052CD03A4 /* YDBCKMergeInfo.h in Headers */,
-				76AFC574495724006EF0583C41949F35 /* YDBCKRecord.h in Headers */,
-				D05DCEB15DBFEAD19F24E63335A70028 /* YDBCKRecordInfo.h in Headers */,
-				EB7BF161A0F9A5C3E10DBE428A891FA8 /* YDBCKRecordTableInfo.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1254,9 +1261,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F0D3EB88458C122C21A859F35CE9C8AD /* Build configuration list for PBXNativeTarget "YapDatabase" */;
 			buildPhases = (
-				FCAECB5772A3E8E458D63DB338001981 /* Sources */,
+				2355E4BE8F22632CDFC81939FD1FB5BB /* Sources */,
 				2BB378CDECA3079CBE47D12536D427D8 /* Frameworks */,
-				DBD91164274E6A50692DB751ACE1C443 /* Headers */,
+				23B26290B888F0DDB0C96C20AB388442 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1297,6 +1304,99 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2355E4BE8F22632CDFC81939FD1FB5BB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6BECCAA79A245EF625A7F418CD29342B /* NSDictionary+YapDatabase.m in Sources */,
+				23B20C8A1FEF14A62DFC247E6E20726E /* yap_vfs_shim.c in Sources */,
+				E56AC57FF6BF8B110C4F2183B3CF27C0 /* YapCache.m in Sources */,
+				BF5128F1A18B0CBAC309A63E40F35AD0 /* YapCollectionKey.m in Sources */,
+				297A4E8BAE90C43453D33AC36F7DB8BB /* YapDatabase-dummy.m in Sources */,
+				0AD3D149FC861A4DE6751E4B67EAD941 /* YapDatabase.m in Sources */,
+				209850E62E237C3A40F216EBAC597022 /* YapDatabaseCloudKit.m in Sources */,
+				E768D256E7AE3253A4FEE145EEE0A3FF /* YapDatabaseCloudKitConnection.m in Sources */,
+				145C85F0E4CEF0CD78E108CA575D2388 /* YapDatabaseCloudKitOptions.m in Sources */,
+				1E56678301E536B034CF41AABBB3329C /* YapDatabaseCloudKitTransaction.m in Sources */,
+				2350883BEF2B68075286E8B1E02F73DD /* YapDatabaseCloudKitTypes.m in Sources */,
+				46F22361A8B680CF9A0A114A9C664B2B /* YapDatabaseConnection.m in Sources */,
+				2D69BB1F4A5169784DBE2167512D6ED9 /* YapDatabaseConnectionDefaults.m in Sources */,
+				0763A9B62BFAE510BDA852D3208B61FC /* YapDatabaseConnectionState.m in Sources */,
+				E8DABF5F1CB54E483227AAF5EC26CED2 /* YapDatabaseExtension.m in Sources */,
+				28E8574965B95BDEA093AE2919E0F7B9 /* YapDatabaseExtensionConnection.m in Sources */,
+				951EA5F0DA4E7915F6F7599808D8EA63 /* YapDatabaseExtensionTransaction.m in Sources */,
+				1083BFADC5602922E36CA7365859DE40 /* YapDatabaseFilteredView.m in Sources */,
+				E488E755566BEE79E30962154BF4A3C6 /* YapDatabaseFilteredViewConnection.m in Sources */,
+				303B2662373CDA75ABB850492EC9FD11 /* YapDatabaseFilteredViewTransaction.m in Sources */,
+				747640D0405C1AC66F1BE0AC53D9A8AE /* YapDatabaseFilteredViewTypes.m in Sources */,
+				7B4DAAAC64771DCD622FE82D3DB6CFC2 /* YapDatabaseFullTextSearch.m in Sources */,
+				6E05447A4601FFC931678669D7655E1A /* YapDatabaseFullTextSearchConnection.m in Sources */,
+				17A339183796C623F42028A3B3D860B1 /* YapDatabaseFullTextSearchHandler.m in Sources */,
+				2E5212EF76388EB24CEB925018AFE6EC /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */,
+				09A9C0CE17B41B6BA998B4EA2AD06FE9 /* YapDatabaseFullTextSearchTransaction.m in Sources */,
+				5163EDDB6ED60E8162CA695DF958916E /* YapDatabaseHooks.m in Sources */,
+				AFA38CA3E13870ED1D6E778F9616A617 /* YapDatabaseHooksConnection.m in Sources */,
+				B8F17A1F539E61732460783CE27F8E73 /* YapDatabaseHooksTransaction.m in Sources */,
+				E564F94F334CB5991CC363D0C3088B16 /* YapDatabaseLogging.m in Sources */,
+				7466E6E7398833E7F255F72C177C50F6 /* YapDatabaseManager.m in Sources */,
+				0052DCA0BB2C599299DCF7959B8D19FD /* YapDatabaseOptions.m in Sources */,
+				5CD58EEFA00A6F5C08AE96A21D6A6E45 /* YapDatabaseQuery.m in Sources */,
+				53DEF7903C96D39291EA929B1390B706 /* YapDatabaseRelationship.m in Sources */,
+				343121F502390984B0EF2F11886AA07A /* YapDatabaseRelationshipConnection.m in Sources */,
+				915BA1AC82B8EEB5F6E7A9CA664136C9 /* YapDatabaseRelationshipEdge.m in Sources */,
+				96108A9DA8860B0A03F4A24797B2B808 /* YapDatabaseRelationshipOptions.m in Sources */,
+				182BA6BB112EB99274A01DFC259498FF /* YapDatabaseRelationshipTransaction.m in Sources */,
+				362A0D6C66530BA3D799AD48E8804303 /* YapDatabaseRTreeIndex.m in Sources */,
+				4570F46C00C5118D6E70AF8DA9909868 /* YapDatabaseRTreeIndexConnection.m in Sources */,
+				39CB1B02039EC51F8A14C33D6D455286 /* YapDatabaseRTreeIndexHandler.m in Sources */,
+				1837A7198FC4C673C70B17EB822DE48A /* YapDatabaseRTreeIndexOptions.m in Sources */,
+				6FDCAF622DCA72758CC9B87166935C14 /* YapDatabaseRTreeIndexSetup.m in Sources */,
+				F4B57C6AA4323BEDA4525F7862A71884 /* YapDatabaseRTreeIndexTransaction.m in Sources */,
+				E0474A8E92215052568E5431037D6D4A /* YapDatabaseSearchQueue.m in Sources */,
+				721B1B792804558616A28FCB3B823F23 /* YapDatabaseSearchResultsView.m in Sources */,
+				28A47BDB25A5D20E1FDFF20C317030ED /* YapDatabaseSearchResultsViewConnection.m in Sources */,
+				B715389142985DA5DD101253B5450108 /* YapDatabaseSearchResultsViewOptions.m in Sources */,
+				181BF7039492E946566B88D6F91FD529 /* YapDatabaseSearchResultsViewTransaction.m in Sources */,
+				F571370F530D6DF2F13D32944D140949 /* YapDatabaseSecondaryIndex.m in Sources */,
+				1D85DC7BCFCC62A960EE3A3C01D115DF /* YapDatabaseSecondaryIndexConnection.m in Sources */,
+				B9E666E0908611F66C0924F83FF8BEEC /* YapDatabaseSecondaryIndexHandler.m in Sources */,
+				0B5C76380BE18724F6AF8A0636C6AD01 /* YapDatabaseSecondaryIndexOptions.m in Sources */,
+				A6582D608B5B84712F642D67CC597DFE /* YapDatabaseSecondaryIndexSetup.m in Sources */,
+				F863178D9D99A5CD40890871533DD31D /* YapDatabaseSecondaryIndexTransaction.m in Sources */,
+				92FA43DB1B5D6C8EFD894D016565B87A /* YapDatabaseStatement.m in Sources */,
+				F27FCC444876B5E74C992529B329DDC1 /* YapDatabaseTransaction.m in Sources */,
+				0B906A7F0132144753DE229DE82B5A4A /* YapDatabaseView.m in Sources */,
+				733EFD60D6AD4A76F10B5A4CD726368D /* YapDatabaseViewChange.m in Sources */,
+				8FCA1B1B8A8FDE08089EA0959E835CB0 /* YapDatabaseViewConnection.m in Sources */,
+				91AA71697FAA691123941B503B17EA7B /* YapDatabaseViewMappings.m in Sources */,
+				E26FE555508A95DD7E9784CAF00FD88E /* YapDatabaseViewOptions.m in Sources */,
+				E1B5745E0C972329160CE8A1EAD77CFD /* YapDatabaseViewPage.mm in Sources */,
+				3A792E0EEE407D5067C9FA547311E129 /* YapDatabaseViewPageMetadata.m in Sources */,
+				B380A2293C966EA7600B741F8513A539 /* YapDatabaseViewRangeOptions.m in Sources */,
+				5B8D5AF8370A793712DBCB42D7C057E9 /* YapDatabaseViewState.m in Sources */,
+				D2832BD806E4514C46900E166A7B88A3 /* YapDatabaseViewTransaction.m in Sources */,
+				59C060923DD680FEC5F271F2521F6841 /* YapDatabaseViewTypes.m in Sources */,
+				F9540C1ED83692973709C68F8607EDA7 /* YapMemoryTable.m in Sources */,
+				1AD88C9AC3B7F07857888AC96032CBA7 /* YapMurmurHash.m in Sources */,
+				BC9B7BF941B175ACA70385ED3952C90F /* YapMutationStack.m in Sources */,
+				80C89E262A95622C8A8F80F50D478B8B /* YapNull.m in Sources */,
+				5D3CF682BB27D593B24DC3B95550988E /* YapProxyObject.m in Sources */,
+				EA5E8BC140E1DED4A02000E16BB973E0 /* YapRowidSet.mm in Sources */,
+				7D24A82D2C75C39192A3C59D3356676A /* YapSet.m in Sources */,
+				ACC474DCEFE86ABF4E58F8F88B9B7679 /* YapTouch.m in Sources */,
+				65560476067F435038CD79F6CB291806 /* YapWhitelistBlacklist.m in Sources */,
+				9B8C2A678D905351C1C663E842B8F241 /* YDBCKAttachRequest.m in Sources */,
+				FCE97D46E93F223B3656326BFA523321 /* YDBCKChangeQueue.m in Sources */,
+				CD58D1E311DC4D6B19E774D495011125 /* YDBCKChangeRecord.m in Sources */,
+				063D846DFF2139ACB0C80572A9D3EA58 /* YDBCKChangeSet.m in Sources */,
+				7F3EF298C2C1AC522EA6734A57A1B032 /* YDBCKMappingTableInfo.m in Sources */,
+				2687774CEC15BBC46D1DF8177090BDE0 /* YDBCKMergeInfo.m in Sources */,
+				4CEBEBE629F83E135AFF1302A73F3198 /* YDBCKRecord.m in Sources */,
+				8D5DC82D175786E2A1C8DE6D5F233502 /* YDBCKRecordInfo.m in Sources */,
+				1B96654C249E0E3440938EE0D6023632 /* YDBCKRecordTableInfo.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		896BFDD81CD617BCCE12E7FCD204E6D7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1319,98 +1419,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BF91CDA8B3E716D193A6F006EE6F869 /* Pods-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FCAECB5772A3E8E458D63DB338001981 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C0530AEE9E0A6DC5D5B6E712759F0B28 /* NSDictionary+YapDatabase.m in Sources */,
-				909D7B346E1F8E5E384C8B2E50F2F2FA /* YapCache.m in Sources */,
-				77DC7234B563ECB9F576462C08E4211E /* YapCollectionKey.m in Sources */,
-				F5C7281CA959AF788516BC641F95563A /* YapDatabase-dummy.m in Sources */,
-				233AA695F18F55952778907D13AFE439 /* YapDatabase.m in Sources */,
-				E04079EAF9A401CCA4B6E02BA5E3BBDF /* YapDatabaseCloudKit.m in Sources */,
-				478A215D217E915BBFED7CC9F21EA4CF /* YapDatabaseCloudKitConnection.m in Sources */,
-				2A12EF52CA1E149BD92EF7B74C763075 /* YapDatabaseCloudKitOptions.m in Sources */,
-				ABDCC1DBD6E59E04B7AA73CAF8EEF633 /* YapDatabaseCloudKitTransaction.m in Sources */,
-				73D371256220F117C4174D073AA75852 /* YapDatabaseCloudKitTypes.m in Sources */,
-				42A4B0F355B56C3E78E0D9CE7226FAE4 /* YapDatabaseConnection.m in Sources */,
-				927601B508E7270EE46E7530FDAC787F /* YapDatabaseConnectionDefaults.m in Sources */,
-				14F82CD3064EC08B81CADCFF9B37262B /* YapDatabaseConnectionState.m in Sources */,
-				E00C27B1724FA780C8F0238E11A35FD8 /* YapDatabaseExtension.m in Sources */,
-				2CD3AA866E767EA39F0E837CA2CE34E8 /* YapDatabaseExtensionConnection.m in Sources */,
-				DD66598AC4CBB61F1745584BC392387A /* YapDatabaseExtensionTransaction.m in Sources */,
-				D832DAE0712F4E653463AC17EDBB0A26 /* YapDatabaseFilteredView.m in Sources */,
-				FDC72DD6896206ED1AE63A8CB25C97F5 /* YapDatabaseFilteredViewConnection.m in Sources */,
-				F64AA423D0BE9D25FE17F5ACE38E84C9 /* YapDatabaseFilteredViewTransaction.m in Sources */,
-				7ACD4793935EE29894D683BD2596B7F9 /* YapDatabaseFilteredViewTypes.m in Sources */,
-				5E022A9DAB33A815D64F684F7FF4CD04 /* YapDatabaseFullTextSearch.m in Sources */,
-				54645C6CCCD947D1A3D247EA9796A6C4 /* YapDatabaseFullTextSearchConnection.m in Sources */,
-				EADC363BD2BE6F25A2ADE6C9DD10F617 /* YapDatabaseFullTextSearchHandler.m in Sources */,
-				7DF85D908A13F2157BF3261B2DAED389 /* YapDatabaseFullTextSearchSnippetOptions.m in Sources */,
-				D8D556F3B02D709BCB214A6A1E02DFF9 /* YapDatabaseFullTextSearchTransaction.m in Sources */,
-				C02F6ADDC6B73E43C54C303CB26FC248 /* YapDatabaseHooks.m in Sources */,
-				27FD0116639DFECB1E00CFE09D68056D /* YapDatabaseHooksConnection.m in Sources */,
-				EA6C2212F71700FFBC9428C6274E8EBD /* YapDatabaseHooksTransaction.m in Sources */,
-				750B324650BD93E465D19A01CA793F59 /* YapDatabaseLogging.m in Sources */,
-				23AEA0B3910030CACD1CBFFFF6551603 /* YapDatabaseManager.m in Sources */,
-				B0D252A8A4D2F75B9B8F9BAB51953FAB /* YapDatabaseOptions.m in Sources */,
-				7B0C69E4DC3F4B29C6A516500AC50FEB /* YapDatabaseQuery.m in Sources */,
-				478237571F3B81AE02688F2821A89757 /* YapDatabaseRelationship.m in Sources */,
-				156F4E1FF3061708E3593B5554286DED /* YapDatabaseRelationshipConnection.m in Sources */,
-				2D2D1B52B6D6E4E64E56A3864671074B /* YapDatabaseRelationshipEdge.m in Sources */,
-				C7FE492557ECB4AA3481BE984D14CEB6 /* YapDatabaseRelationshipOptions.m in Sources */,
-				74031B9DFEBBF10D05670147EA51EF21 /* YapDatabaseRelationshipTransaction.m in Sources */,
-				751FA935725ED627F86FFE6BE5CE5B48 /* YapDatabaseRTreeIndex.m in Sources */,
-				754CC2181CD3DD612EE98CA72D9DFD77 /* YapDatabaseRTreeIndexConnection.m in Sources */,
-				FCB6070AF48A3E65B4FCAC1A0F91DC6C /* YapDatabaseRTreeIndexHandler.m in Sources */,
-				78C0C14967F38CB0F4E79C73BEB77684 /* YapDatabaseRTreeIndexOptions.m in Sources */,
-				B7A2B22CD1C14FDD3C9074B2FAAA3DF2 /* YapDatabaseRTreeIndexSetup.m in Sources */,
-				2DEC65B0611E4EFEC6FE32579BFCC5AE /* YapDatabaseRTreeIndexTransaction.m in Sources */,
-				45D5F45F51499657036E5A3DB42C0C39 /* YapDatabaseSearchQueue.m in Sources */,
-				E368AF6624699AD6E5766B19ABCC5980 /* YapDatabaseSearchResultsView.m in Sources */,
-				2CB33F208E86CBDB5698CA3E62423DBE /* YapDatabaseSearchResultsViewConnection.m in Sources */,
-				379D2172E84279B55A06AF6B45918B7F /* YapDatabaseSearchResultsViewOptions.m in Sources */,
-				F4699653CD000EB5F093FF533C59C3FC /* YapDatabaseSearchResultsViewTransaction.m in Sources */,
-				D86EE9EEB088F63F1DDA9052248BDB68 /* YapDatabaseSecondaryIndex.m in Sources */,
-				867B53220326EE73D7D823A553E301B2 /* YapDatabaseSecondaryIndexConnection.m in Sources */,
-				16034079F04250DB23239218E29ABEF4 /* YapDatabaseSecondaryIndexHandler.m in Sources */,
-				86128B5FDEFB7F2B9119D146DCED6BE9 /* YapDatabaseSecondaryIndexOptions.m in Sources */,
-				184F145E3AD0C24D984ED5657212924F /* YapDatabaseSecondaryIndexSetup.m in Sources */,
-				6DDD8E305F637A9DD21F077EAC7928EA /* YapDatabaseSecondaryIndexTransaction.m in Sources */,
-				FDD5EF992EA748F75D4BACFA2C4175E6 /* YapDatabaseStatement.m in Sources */,
-				3BFCBBD87B2B4E0BACCB88097FE2F3E9 /* YapDatabaseTransaction.m in Sources */,
-				FA56C3CF85F9B1F9035E18EB28CD4CEA /* YapDatabaseView.m in Sources */,
-				EDE185716C3C61927A1B35F6F52B0039 /* YapDatabaseViewChange.m in Sources */,
-				D4AC47077A161D54C78E26B97CF61D71 /* YapDatabaseViewConnection.m in Sources */,
-				5908DFE23919F060F4ED3835CB328C95 /* YapDatabaseViewMappings.m in Sources */,
-				6BE77C1FF6C79CC249103CFB4BCFBC07 /* YapDatabaseViewOptions.m in Sources */,
-				E570326A40FAB23225371D1EA5E3BC93 /* YapDatabaseViewPage.mm in Sources */,
-				5106C4189A895D5D375CE2C56AB8ACC3 /* YapDatabaseViewPageMetadata.m in Sources */,
-				8F8D4F7F8230103287AA172E0AB815C7 /* YapDatabaseViewRangeOptions.m in Sources */,
-				0B99BF1B7B07BD8FA21BEF07E6C2E3A3 /* YapDatabaseViewState.m in Sources */,
-				12C40074260E39955F2ED650A0677B10 /* YapDatabaseViewTransaction.m in Sources */,
-				D3609484FD90551A513D6AFE3A3CFBA3 /* YapDatabaseViewTypes.m in Sources */,
-				2D46D1DCB450F421B5A5BC34CAAC0840 /* YapMemoryTable.m in Sources */,
-				266BCEFEF756664E548526710D2BEC5F /* YapMurmurHash.m in Sources */,
-				5B3CF6E4110B18035598EBDCA24EC8EB /* YapMutationStack.m in Sources */,
-				4F36A0A99C9DB33EED8D9C2A3817C576 /* YapNull.m in Sources */,
-				1F78BC1B4954B6B51BC79CFDFA3D3EC4 /* YapProxyObject.m in Sources */,
-				A0DB9BDA5DA4F348B3776F7564B0EC91 /* YapRowidSet.mm in Sources */,
-				68A4C5F5F69FAF87EBF5045690C06941 /* YapSet.m in Sources */,
-				3D308951FCFCEC91E4190CC0912E9890 /* YapTouch.m in Sources */,
-				6C501503B99B2CDB8995453450805D23 /* YapWhitelistBlacklist.m in Sources */,
-				B240E1C6FB234B2912BD552B04B9052F /* YDBCKAttachRequest.m in Sources */,
-				BC6A30C283CBAF85D7AE15EBF1B8F426 /* YDBCKChangeQueue.m in Sources */,
-				C9D2CFB82AB07EC6D4D33DAE3A7394EA /* YDBCKChangeRecord.m in Sources */,
-				B137EACFDC3221284A9A999F9E4C457A /* YDBCKChangeSet.m in Sources */,
-				C6500778F20C01AB6E15349BA0355105 /* YDBCKMappingTableInfo.m in Sources */,
-				6F0920326A8E406417272EE0D433376D /* YDBCKMergeInfo.m in Sources */,
-				C53C676181F4BEAE48621854DF0E2696 /* YDBCKRecord.m in Sources */,
-				7F68F0C4103A1B62FA489802019574C9 /* YDBCKRecordInfo.m in Sources */,
-				42687A4C9AD600844E744E3294E790D8 /* YDBCKRecordTableInfo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/SearchResultsExample/Pods/Pods.xcodeproj/xcshareddata/xcschemes/YapDatabase.xcscheme
+++ b/Examples/SearchResultsExample/Pods/Pods.xcodeproj/xcshareddata/xcschemes/YapDatabase.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '42DF34B1D6BBAD613529B235'
+               BlueprintIdentifier = '894022E66DA3A533DAACC9E7'
                BlueprintName = 'YapDatabase'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libYapDatabase.a'>


### PR DESCRIPTION
The SearchResultsExample project could not build due to `yap_vfs_shim` files being referenced from source but missing in the CocoaPods generated project.

The project was based on version 2.7.3. Running `pod update YapDatabase` updated to 2.7.7 and resolved the issue.