### PR TITLE
Read transaction in YapDatabaseSecondaryIndexHandler

### DIFF
--- a/Testing/UnitTesting/TestYapDatabaseSecondaryIndex.m
+++ b/Testing/UnitTesting/TestYapDatabaseSecondaryIndex.m
@@ -54,7 +54,7 @@
 	[setup addColumn:@"someInt" withType:YapDatabaseSecondaryIndexTypeInteger];
 	
 	YapDatabaseSecondaryIndexHandler *handler = [YapDatabaseSecondaryIndexHandler withObjectBlock:
-	    ^(NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
+	    ^(YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
 		
 		// If we're storing other types of objects in our database,
 		// then we should check the object before presuming we can cast it.
@@ -290,7 +290,7 @@
 	[setup addColumn:@"str" withType:YapDatabaseSecondaryIndexTypeText];
 	
 	YapDatabaseSecondaryIndexHandler *handler = [YapDatabaseSecondaryIndexHandler withObjectBlock:
-	    ^(NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
+	    ^(YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
 		
 		// If we're storing other types of objects in our database,
 		// then we should check the object before presuming we can cast it.
@@ -374,7 +374,7 @@
 	[setup addColumn:@"salary" withType:YapDatabaseSecondaryIndexTypeReal];
 	
 	YapDatabaseSecondaryIndexHandler *handler = [YapDatabaseSecondaryIndexHandler withObjectBlock:
-	    ^(NSMutableDictionary *dict, NSString *collection, NSString *key, id object)
+	    ^(YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object)
 	{
 		// If we're storing other types of objects in our database,
 		// then we should check the object before presuming we can cast it.

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexHandler.h
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexHandler.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import "YapDatabaseExtensionTypes.h"
 
+@class YapDatabaseReadTransaction;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -23,16 +25,16 @@ NS_ASSUME_NONNULL_BEGIN
 typedef id YapDatabaseSecondaryIndexBlock; // One of the YapDatabaseSecondaryIndexWith_X_Block types below.
 
 typedef void (^YapDatabaseSecondaryIndexWithKeyBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key);
 
 typedef void (^YapDatabaseSecondaryIndexWithObjectBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key, id object);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object);
 
 typedef void (^YapDatabaseSecondaryIndexWithMetadataBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key, __nullable id metadata);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, __nullable id metadata);
 
 typedef void (^YapDatabaseSecondaryIndexWithRowBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key, id object, __nullable id metadata);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object, __nullable id metadata);
 
 + (instancetype)withKeyBlock:(YapDatabaseSecondaryIndexWithKeyBlock)block;
 + (instancetype)withObjectBlock:(YapDatabaseSecondaryIndexWithObjectBlock)block;

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
@@ -299,7 +299,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop);
 		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, BOOL __unused *stop) {
 			
-			secondaryIndexBlock(parentConnection->blockDict, collection, key);
+			secondaryIndexBlock(databaseTransaction, parentConnection->blockDict, collection, key);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -331,7 +331,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop);
 		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL __unused *stop) {
 			
-			secondaryIndexBlock(parentConnection->blockDict, collection, key, object);
+			secondaryIndexBlock(databaseTransaction, parentConnection->blockDict, collection, key, object);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -364,7 +364,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop);
 		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL __unused *stop) {
 			
-			secondaryIndexBlock(parentConnection->blockDict, collection, key, metadata);
+			secondaryIndexBlock(databaseTransaction, parentConnection->blockDict, collection, key, metadata);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -397,7 +397,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 		void (^enumBlock)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop);
 		enumBlock = ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL __unused *stop) {
 			
-			secondaryIndexBlock(parentConnection->blockDict, collection, key, object, metadata);
+			secondaryIndexBlock(databaseTransaction, parentConnection->blockDict, collection, key, object, metadata);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -772,28 +772,28 @@ static NSString *const ext_key_version_deprecated = @"version";
 		__unsafe_unretained YapDatabaseSecondaryIndexWithKeyBlock block =
 		    (YapDatabaseSecondaryIndexWithKeyBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key);
+		block(databaseTransaction, parentConnection->blockDict, collection, key);
 	}
 	else if (blockType == YapDatabaseBlockTypeWithObject)
 	{
 		__unsafe_unretained YapDatabaseSecondaryIndexWithObjectBlock block =
 		    (YapDatabaseSecondaryIndexWithObjectBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key, object);
+		block(databaseTransaction, parentConnection->blockDict, collection, key, object);
 	}
 	else if (blockType == YapDatabaseBlockTypeWithMetadata)
 	{
 		__unsafe_unretained YapDatabaseSecondaryIndexWithMetadataBlock block =
 		    (YapDatabaseSecondaryIndexWithMetadataBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key, metadata);
+		block(databaseTransaction, parentConnection->blockDict, collection, key, metadata);
 	}
 	else
 	{
 		__unsafe_unretained YapDatabaseSecondaryIndexWithRowBlock block =
 		    (YapDatabaseSecondaryIndexWithRowBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key, object, metadata);
+		block(databaseTransaction, parentConnection->blockDict, collection, key, object, metadata);
 	}
 	
 	if ([parentConnection->blockDict count] == 0)


### PR DESCRIPTION
Read transaction can be used to create index of object properties depending on related objects.