### PR TITLE
Limitation for number of changes per one change request in CloudKit extension

### DIFF
--- a/YapDatabase/Extensions/CloudKit/Internal/YDBCKChangeQueue.h
+++ b/YapDatabase/Extensions/CloudKit/Internal/YDBCKChangeQueue.h
@@ -131,6 +131,11 @@
 @property (atomic, readonly) NSUInteger numberOfPendingChangeSets;
 
 /**
+ * Number of changes (saved and deleted objects) in current commit.
+ **/
+- (NSUInteger)numberOfChangesInCurrentCommit;
+
+/**
  * Atomic access to all counts at once.
 **/
 - (void)getNumberOfInFlightChangeSets:(NSUInteger *)numInFlightChangeSetsPtr

--- a/YapDatabase/Extensions/CloudKit/Internal/YDBCKChangeQueue.m
+++ b/YapDatabase/Extensions/CloudKit/Internal/YDBCKChangeQueue.m
@@ -373,6 +373,23 @@
 }
 
 /**
+ * Number of changes (saved and deleted objects) in current commit.
+ **/
+- (NSUInteger)numberOfChangesInCurrentCommit
+{
+	NSAssert(self.isPendingQueue, @"Method can only be invoked on pendingQueue");
+	
+	NSUInteger count = 0;
+	
+	for (YDBCKChangeSet *newChangeSet in [newChangeSetsDict objectEnumerator])
+	{
+		count += (newChangeSet.recordIDsToDeleteCount + newChangeSet.recordsToSaveCount);
+	}
+	
+	return count;
+}
+
+/**
  * Atomic access to all counts at once.
 **/
 - (void)getNumberOfInFlightChangeSets:(NSUInteger *)numInFlightChangeSetsPtr

--- a/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitOptions.h
+++ b/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitOptions.h
@@ -27,6 +27,14 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 @property (nonatomic, strong, readwrite, nullable) YapWhitelistBlacklist *allowedCollections;
 
+/**
+ * CloudKit has a limitation for number of changes in one change request.
+ * Currenly CloudKit can't handle more than 400 changes at once.
+ *
+ * You can use this property to set limit for number of changes per one request.
+ * Default value is 0 (No limitation).
+ **/
+@property (nonatomic, assign, readwrite) NSUInteger maxChangesPerChangeRequest;
 
 // Todo: Need ability to set default options for CKModifyRecordsOperation
 

--- a/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitOptions.m
+++ b/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitOptions.m
@@ -3,11 +3,13 @@
 @implementation YapDatabaseCloudKitOptions
 
 @synthesize allowedCollections = allowedCollections;
+@synthesize maxChangesPerChangeRequest = maxChangesPerChangeRequest;
 
 - (id)copyWithZone:(NSZone *)zone
 {
 	YapDatabaseCloudKitOptions *copy = [[[self class] alloc] init]; // [self class] required to support subclassing
 	copy->allowedCollections = allowedCollections;
+	copy->maxChangesPerChangeRequest = maxChangesPerChangeRequest;
 	
 	return copy;
 }

--- a/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitTransaction.m
+++ b/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitTransaction.m
@@ -2985,19 +2985,56 @@ static BOOL ClassVersionsAreCompatible(int oldClassVersion, int newClassVersion)
 		}
 	}];
 	
+	// Step 4 of 6:
+	//
+	// Use YDBCKChangeQueue tools to generate a list of updates for the queue table.
+	
+	void (^mergeQueueBlock)(YDBCKChangeQueue *, YDBCKChangeQueue *) = ^(YDBCKChangeQueue *masterQueue, YDBCKChangeQueue *pendingQueue) {
+		
+		// Step 5 of 6:
+		//
+		// Update queue table.
+		// This is the list of changes the pendingQueue gives us.
+		
+		for (YDBCKChangeSet *oldChangeSet in pendingQueue.changeSetsFromPreviousCommits)
+		{
+			if (oldChangeSet.hasChangesToDeletedRecordIDs || oldChangeSet.hasChangesToModifiedRecords)
+			{
+				[self updateQueueTableRowWithChangeSet:oldChangeSet];
+			}
+		}
+		
+		for (YDBCKChangeSet *newChangeSet in pendingQueue.changeSetsFromCurrentCommit)
+		{
+			[self insertQueueTableRowWithChangeSet:newChangeSet];
+		}
+		
+		// Step 6 of 6:
+		//
+		// Update the masterQueue,
+		// and unlock it so the next operation can be dispatched.
+		
+		[masterQueue mergePendingQueue:pendingQueue];
+	};
+	
 	// Step 3 of 6:
 	//
 	// Create a pendingQueue,
 	// and lock the masterQueue so we can make changes to it.
 	
-	YDBCKChangeQueue *masterQueue = parentConnection->parent->masterQueue;
-	YDBCKChangeQueue *pendingQueue = [masterQueue newPendingQueue];
+	__block YDBCKChangeQueue *masterQueue = parentConnection->parent->masterQueue;
+	__block YDBCKChangeQueue *pendingQueue = nil;
 	
-	// Step 4 of 6:
-	//
-	// Use YDBCKChangeQueue tools to generate a list of updates for the queue table.
+	YapDatabaseCloudKitOptions *options = parentConnection->parent->options;
+	NSUInteger maxChangesPerChangeRequest = (options) ? (options.maxChangesPerChangeRequest) : (0);
 	
 	[parentConnection->dirtyRecordTableInfoDict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		
+		// Create pending queue if not exist.
+		if (pendingQueue == nil)
+		{
+			pendingQueue = [masterQueue newPendingQueue];
+		}
 		
 	//	__unsafe_unretained NSString *hash = (NSString *)key;
 		__unsafe_unretained YDBCKDirtyRecordTableInfo *dirtyRecordTableInfo = (YDBCKDirtyRecordTableInfo *)obj;
@@ -3087,32 +3124,21 @@ static BOOL ClassVersionsAreCompatible(int oldClassVersion, int newClassVersion)
 				}
 			}
 		}
+
+		// Merge pending queue in master queue if number of changes is reached the limit.
+		if (maxChangesPerChangeRequest > 0 && maxChangesPerChangeRequest <= pendingQueue.numberOfChangesInCurrentCommit)
+		{
+			mergeQueueBlock(masterQueue, pendingQueue);
+			pendingQueue = nil;
+		}
 	}];
 	
-	// Step 5 of 6:
-	//
-	// Update queue table.
-	// This is the list of changes the pendingQueue gives us.
-	
-	for (YDBCKChangeSet *oldChangeSet in pendingQueue.changeSetsFromPreviousCommits)
+	// Merge the rest.
+	if (pendingQueue != nil)
 	{
-		if (oldChangeSet.hasChangesToDeletedRecordIDs || oldChangeSet.hasChangesToModifiedRecords)
-		{
-			[self updateQueueTableRowWithChangeSet:oldChangeSet];
-		}
+		mergeQueueBlock(masterQueue, pendingQueue);
+		pendingQueue = nil;
 	}
-	
-	for (YDBCKChangeSet *newChangeSet in pendingQueue.changeSetsFromCurrentCommit)
-	{
-		[self insertQueueTableRowWithChangeSet:newChangeSet];
-	}
-	
-	// Step 6 of 6:
-	//
-	// Update the masterQueue,
-	// and unlock it so the next operation can be dispatched.
-	
-	[masterQueue mergePendingQueue:pendingQueue];
 }
 
 /**


### PR DESCRIPTION
Ability to set the limit for number of changes per one change request in YapDatabaseCloudKitOptions. This can be used to fix "Invalid Arguments" (12/1020); "Your request contains more than the maximum number of items in a single request (400)" error. Discussion in #212.