### PR TITLE
Toggling on App Extension API Only

### DIFF
--- a/YapDatabase.xcodeproj/project.pbxproj
+++ b/YapDatabase.xcodeproj/project.pbxproj
@@ -2037,6 +2037,7 @@
 		DCF7C2B71BCC8E610087ED39 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2061,6 +2062,7 @@
 		DCF7C2B81BCC8E610087ED39 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2085,6 +2087,7 @@
 		DCF7C2C41BCC8E870087ED39 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2110,6 +2113,7 @@
 		DCF7C2C51BCC8E870087ED39 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
This setting needs to be enabled to silence warnings when using this Framework in an app extension.

Details are on this apple doc: https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html under "Using an Embedded Framework to Share Code"

Toggling this on basically stops us from using any APIs that are not allowed in app extensions such as UIApplication.sharedApplication() - which we're not.