### PR TITLE
Fix test for metadata post sanitizer before calling it.

### DIFF
--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -4613,7 +4613,7 @@
 	{
 		connection->database->objectPostSanitizer(collection, key, object);
 	}
-	if (metadata && connection->database->metadataPreSanitizer)
+	if (metadata && connection->database->metadataPostSanitizer)
 	{
 		connection->database->metadataPostSanitizer(collection, key, metadata);
 	}


### PR DESCRIPTION
Currently if you have a pre sanitizer but no post sanitizer, the metadata post sanitizer block is still called, resulting in a crash. (I'm guessing this is just a typo.)

There's an easy workaround, in case anybody needs it: set the post sanitizer to a block that does nothing.