### PR TITLE
Improving the connection logging

### DIFF
--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -393,6 +393,18 @@ static int connectionBusyHandler(void *ptr, int count)
 	extensionsReady = ([registeredExtensions count] == 0);
 }
 
+- (NSString *)description
+{
+    // If the user has a name then lets use it for printing
+    // Will look something like this <YapDatabaseConnection: 0x7f85e0e62300> - ConnectionName
+    
+    if (_name.length > 0) {
+        return [NSString stringWithFormat:@"%@ - %@", [super description], _name];
+    } else {
+        return [super description];
+    }
+}
+
 - (void)dealloc
 {
 	YDBLogVerbose(@"Dealloc <YapDatabaseConnection %p: databaseName=%@>",


### PR DESCRIPTION
In `YapDatabaseConnection.h` for `name` it has a comment that says `It is only used internally for log statements.` but when I turn on logging I don't see the name. I overwrote the description to also include the name.

An example of how this might look in logs:
`YapDatabaseConnection: Processing changeset 2517 for connection <YapDatabaseConnection: 0x7f85e0e62300> - Sync engine, database <YapDatabase: 0x7f85e0e58bb0>`
