### PR TITLE
watchOS2 support

### DIFF
--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.8'
   s.ios.deployment_target = '6.0'
   s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
   
   s.module_map = "Framework/module.modulemap"
   s.libraries  = 'c++'

--- a/YapDatabase/Extensions/CloudKit/Utilities/YDBCKRecord.m
+++ b/YapDatabase/Extensions/CloudKit/Utilities/YDBCKRecord.m
@@ -26,7 +26,7 @@
 **/
 - (id)safeCopy
 {
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IOS
 	
 	// iOS only
 	//

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipOptions.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipOptions.m
@@ -272,7 +272,7 @@ static NSString *const kPlistKey_PathComponents = @"pathComponents";
 		
 		if (filePath)
 		{
-		#if TARGET_OS_IPHONE
+		#if TARGET_OS_IOS
 			
 			NSArray *pathComponents = [filePath pathComponents];
 			

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewChange.m
@@ -3,7 +3,7 @@
 #import "YapDatabaseViewMappingsPrivate.h"
 #import "YapDatabaseLogging.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
 #endif
 
@@ -178,7 +178,7 @@
 	}
 	else
 	{
-	  #if TARGET_OS_IPHONE
+	  #if TARGET_OS_IOS
 		return [NSIndexPath indexPathForRow:originalIndex inSection:originalSection];
 	  #else
 		NSUInteger indexes[] = {originalSection, originalIndex};
@@ -193,7 +193,7 @@
 		return nil; // <-- You should be using indexPath
 	}
 	else {
-	#if TARGET_OS_IPHONE
+	#if TARGET_OS_IOS
 		return [NSIndexPath indexPathForRow:finalIndex inSection:finalSection];
 	#else
 		NSUInteger indexes[] = {finalSection, finalIndex};

--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.m
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.m
@@ -4,7 +4,7 @@
 #import "YapDatabasePrivate.h"
 #import "YapDatabaseLogging.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
 #endif
 
@@ -804,7 +804,7 @@
 		return NO;
 	}
 	
-  #if TARGET_OS_IPHONE
+  #if TARGET_OS_IOS
 	NSUInteger section = indexPath.section;
 	NSUInteger row = indexPath.row;
   #else
@@ -1139,7 +1139,7 @@
 	
 	if ([self getRow:&row section:&section forIndex:index inGroup:group])
 	{
-	  #if TARGET_OS_IPHONE
+	  #if TARGET_OS_IOS
 		return [NSIndexPath indexPathForRow:row inSection:section];
 	  #else
 		NSUInteger indexes[] = {section, row};
@@ -1596,7 +1596,7 @@
 				_section = 0;
 			}
 			
-		  #if TARGET_OS_IPHONE
+		  #if TARGET_OS_IOS
 			return [NSIndexPath indexPathForRow:_row inSection:_section];
 		  #else
 			NSUInteger indexes[] = {_section, _row};
@@ -1630,7 +1630,7 @@
 					_section = 0;
 				}
 				
-			  #if TARGET_OS_IPHONE
+			  #if TARGET_OS_IOS
 				return [NSIndexPath indexPathForRow:_row inSection:_section];
 			  #else
 				NSUInteger indexes[] = {_section, _row};
@@ -1663,7 +1663,7 @@
 					_section = 0;
 				}
 				
-			  #if TARGET_OS_IPHONE
+			  #if TARGET_OS_IOS
 				return [NSIndexPath indexPathForRow:_row inSection:_section];
 			  #else
 				NSUInteger indexes[] = {_section, _row};

--- a/YapDatabase/Extensions/Views/YapDatabaseViewTransaction.m
+++ b/YapDatabase/Extensions/Views/YapDatabaseViewTransaction.m
@@ -11,7 +11,7 @@
 #import "YapDatabaseString.h"
 #import "YapDatabaseLogging.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
 #endif
 
@@ -5394,7 +5394,7 @@
 		return NO;
 	}
 	
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 	NSUInteger section = indexPath.section;
 	NSUInteger row = indexPath.row;
 #else
@@ -5499,7 +5499,7 @@
 		return nil;
 	}
 	
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 	NSUInteger section = indexPath.section;
 	NSUInteger row = indexPath.row;
 #else
@@ -5566,7 +5566,7 @@
 		return nil;
 	}
 	
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 	NSUInteger section = indexPath.section;
 	NSUInteger row = indexPath.row;
 #else

--- a/YapDatabase/Internal/YapDatabaseConnectionDefaults.h
+++ b/YapDatabase/Internal/YapDatabaseConnectionDefaults.h
@@ -30,7 +30,7 @@
 @property (nonatomic, assign, readwrite) YapDatabasePolicy objectPolicy;
 @property (nonatomic, assign, readwrite) YapDatabasePolicy metadataPolicy;
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 @property (nonatomic, assign, readwrite) YapDatabaseConnectionFlushMemoryFlags autoFlushMemoryFlags;
 #endif
 

--- a/YapDatabase/Internal/YapDatabaseConnectionDefaults.m
+++ b/YapDatabase/Internal/YapDatabaseConnectionDefaults.m
@@ -15,7 +15,7 @@ static NSUInteger const DEFAULT_METADATA_CACHE_LIMIT = 250;
 @synthesize objectPolicy = objectPolicy;
 @synthesize metadataPolicy = metadataPolicy;
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 @synthesize autoFlushMemoryFlags = autoFlushMemoryFlags;
 #endif
 
@@ -32,7 +32,7 @@ static NSUInteger const DEFAULT_METADATA_CACHE_LIMIT = 250;
 		objectPolicy = YapDatabasePolicyContainment;
 		metadataPolicy = YapDatabasePolicyContainment;
 		
-		#if TARGET_OS_IPHONE
+		#if TARGET_OS_IOS
 		autoFlushMemoryFlags = YapDatabaseConnectionFlushMemoryFlags_All;
 		#endif
 	}
@@ -52,7 +52,7 @@ static NSUInteger const DEFAULT_METADATA_CACHE_LIMIT = 250;
 	copy->objectPolicy = objectPolicy;
 	copy->metadataPolicy = metadataPolicy;
 	
-	#if TARGET_OS_IPHONE
+	#if TARGET_OS_IOS
 	copy->autoFlushMemoryFlags = autoFlushMemoryFlags;
 	#endif
 	

--- a/YapDatabase/YapDatabase.h
+++ b/YapDatabase/YapDatabase.h
@@ -473,7 +473,7 @@ extern NSString *const YapDatabaseModifiedExternallyKey;
 @property (atomic, assign, readwrite) YapDatabasePolicy defaultObjectPolicy;
 @property (atomic, assign, readwrite) YapDatabasePolicy defaultMetadataPolicy;
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 /**
  * Allows you to set the default autoFlushMemoryFlags for all new connections.
  *

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -1664,7 +1664,7 @@ static int connectionBusyHandler(void *ptr, int count) {
 	});
 }
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 
 - (YapDatabaseConnectionFlushMemoryFlags)defaultAutoFlushMemoryFlags
 {

--- a/YapDatabase/YapDatabaseConnection.h
+++ b/YapDatabase/YapDatabaseConnection.h
@@ -606,7 +606,7 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
 **/
 - (void)flushMemoryWithFlags:(YapDatabaseConnectionFlushMemoryFlags)flags;
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 /**
  * When a UIApplicationDidReceiveMemoryWarningNotification is received,
  * the code automatically invokes flushMemoryWithFlags and passes the set flags.

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -15,7 +15,7 @@
 #import <mach/mach_time.h>
 #import <libkern/OSAtomic.h>
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
 #endif
 
@@ -249,7 +249,7 @@ static int connectionBusyHandler(void *ptr, int count)
 		self.permittedTransactions = YDB_AnyTransaction;
 		#endif
 		
-		#if TARGET_OS_IPHONE
+		#if TARGET_OS_IOS
 		self.autoFlushMemoryFlags = defaults.autoFlushMemoryFlags;
 		#endif
 		
@@ -365,7 +365,7 @@ static int connectionBusyHandler(void *ptr, int count)
 			}
 		}
 		
-		#if TARGET_OS_IPHONE
+		#if TARGET_OS_IOS
 		[[NSNotificationCenter defaultCenter] addObserver:self
 		                                         selector:@selector(didReceiveMemoryWarning:)
 		                                             name:UIApplicationDidReceiveMemoryWarningNotification
@@ -555,7 +555,7 @@ static int connectionBusyHandler(void *ptr, int count)
 		dispatch_async(connectionQueue, block);
 }
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 - (void)didReceiveMemoryWarning:(NSNotification __unused *)notification
 {
 	[self flushMemoryWithFlags:[self autoFlushMemoryFlags]];
@@ -573,7 +573,7 @@ static int connectionBusyHandler(void *ptr, int count)
 @synthesize permittedTransactions = _mustUseAtomicProperty_permittedTransactions;
 #endif
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 @synthesize autoFlushMemoryFlags;
 #endif
 

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -141,7 +141,7 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
  * 
  * > #ifdef __APPLE__
  * > # include <TargetConditionals.h>
- * > # if TARGET_OS_IPHONE
+ * > # if TARGET_OS_IOS
  * > #   undef SQLITE_MAX_MMAP_SIZE
  * > #   define SQLITE_MAX_MMAP_SIZE 0
  * > # endif


### PR DESCRIPTION
These are some basic changes to make the library build and work on watchOS2 when installing with CocoaPods.

You must specify YapDatabase Core instead of the whole thing, and then select only the extensions you require:

```ruby
target 'WatchKit Extension' do
    pod 'YapDatabase/Standard/Core'
    pod 'YapDatabase/Standard/Extensions/Views'
end
```

This is because some extensions that are included when you use the full pod aren't available on watchOS, for example `YapDatabaseCloudKit`.

I call this "basic" since I assume the correct way to implement watchOS-support would be to add a framework for watchOS, just like there currently are for iOS and OSX. However, I'm not comfortable enough with the YapDatabase build-chain to set this up without spending a lot of time, and these fixes have worked well for me.

Related to #323 