### PR TITLE
Fixed data race in YapTouch

### DIFF
--- a/YapDatabase/Internal/YapTouch.h
+++ b/YapDatabase/Internal/YapTouch.h
@@ -10,6 +10,6 @@
 **/
 @interface YapTouch : NSObject
 
-+ (id)touch;
++ (instancetype)touch;
 
 @end

--- a/YapDatabase/Internal/YapTouch.m
+++ b/YapDatabase/Internal/YapTouch.m
@@ -5,22 +5,17 @@
 
 static YapTouch *singleton;
 
-+ (void)initialize
++ (instancetype)touch
 {
-	static BOOL initialized = NO;
-	if (!initialized)
-	{
-		initialized = YES;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
 		singleton = [[YapTouch alloc] init];
-	}
-}
-
-+ (id)touch
-{
+	});
+	
 	return singleton;
 }
 
-- (id)init
+- (instancetype)init
 {
 	NSAssert(singleton == nil, @"Must use singleton via [YapTouch touch]");
 	


### PR DESCRIPTION
Use dispatch_once to prevent a data race if two threads try to use YapTouch at the same time.

This is probably more theoretical than real, but using dispatch_once over +initialize is safer.

Found by TSan.