### PR TITLE
Fix a nullable parameter

### DIFF
--- a/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitTransaction.h
+++ b/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitTransaction.h
@@ -159,7 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   That is, if we deleted the item locally, and the delete operation is pending upload to the cloudKit server.
  *   If this value is YES, then you may not want to create a new database item for the record.
 **/
-- (void)getRecordChangeTag:(NSString * _Nonnull * _Nullable)outRecordChangeTag
+- (void)getRecordChangeTag:(NSString * _Nullable * _Nullable)outRecordChangeTag
    hasPendingModifications:(nullable BOOL *)outPendingModifications
           hasPendingDelete:(nullable BOOL *)outPendingDelete
                forRecordID:(CKRecordID *)recordID


### PR DESCRIPTION
When I tried to use this method in Swift, i noticed outRecordChangeTag can be nil (https://github.com/yapstudios/YapDatabase/blob/master/Examples/CloudKitTodo/CloudKitTodo/CloudKitManager.m#L624), it should really typed ``(NSString * _Nullable * _Nullable)``