### PR TITLE
Fix [YapcollectionKey isEqual:] nullability

### DIFF
--- a/YapDatabase/Utilities/YapCollectionKey.h
+++ b/YapDatabase/Utilities/YapCollectionKey.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToCollectionKey:(YapCollectionKey *)collectionKey;
 
 // These methods are overriden and optimized:
-- (BOOL)isEqual:(id)anObject;
+- (BOOL)isEqual:(nullable id)anObject;
 - (NSUInteger)hash;
 
 // C versions for low-level optimizations:


### PR DESCRIPTION
this remove a compiler warning on Xcode 8