### PR TITLE
Fix queryString's expansion error for array parameter in the queryPar…

### DIFF
--- a/YapDatabase/Utilities/YapDatabaseQuery.m
+++ b/YapDatabase/Utilities/YapDatabaseQuery.m
@@ -285,11 +285,14 @@
 		// - outQueryString: @"col1 = ? AND col2 in (?,?)"
 		// - outQueryParmas: @[ @(0), @(1), @(2) ]
 		
-		__block NSUInteger unpackingOffset = 0;
-		
-		[paramIndexToArrayCountMap enumerateKeysAndObjectsUsingBlock:
-		    ^(NSNumber *paramIndexNum, NSNumber *arrayCountNum, BOOL *stop)
+		NSArray *sortedKeys = [paramIndexToArrayCountMap.allKeys sortedArrayUsingDescriptors:({
+			NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"integerValue" ascending:YES];
+			@[sortDescriptor];
+		})];
+		[sortedKeys enumerateObjectsUsingBlock:^(NSNumber * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop)
 		{
+			NSNumber *paramIndexNum = obj;
+			NSNumber *arrayCountNum = paramIndexToArrayCountMap[obj];
 			NSUInteger arrayCount = [arrayCountNum unsignedIntegerValue];
 			
 			NSMutableString *unpackedParamsStr = [NSMutableString stringWithCapacity:(arrayCount * 2)];
@@ -304,8 +307,7 @@
 			NSUInteger paramIndex = [paramIndexNum unsignedIntegerValue];
 			NSUInteger paramLocation = [paramLocations[paramIndex] unsignedIntegerValue];
 			
-			NSRange range = NSMakeRange(paramLocation + unpackingOffset, 1);
-			unpackingOffset += [unpackedParamsStr length] - 1;
+			NSRange range = NSMakeRange(paramLocation, 1);
 			
 			[queryString replaceCharactersInRange:range withString:unpackedParamsStr];
 			


### PR DESCRIPTION
…ameter list

`NSDictionary` is unordered, so it is when enumerated.

```objc
YapDatabaseQuery *query = [YapDatabaseQuery queryWithFormat:
@"WHERE CASE WHEN type1 = ? THEN status1 in (?) END and 
type2 = ? and 
status2 in (?) and 
time BETWEEN ? AND ?", 
@(1), statusArray1, @(4), statusArray2, @(time1), @(time2)];
```