### PR TITLE
Fix cross-process notifications

### DIFF
--- a/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotification.m
+++ b/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotification.m
@@ -110,7 +110,7 @@ static pid_t currentPid() {
  *   This method is invoked within the writeQueue.
  *   So either don't do anything expensive/time-consuming in this method, or dispatch_async to do it in another queue.
 **/
-- (void)didRegisterWithDatabase:(YapDatabase __unused *)database
+- (void)didRegisterExtension
 {
 	// only start dispatching notifications once the extension is registered to a database
 	[self start];


### PR DESCRIPTION
In the `YapDatabaseCrossProcessNotification` extension, `didRegisterWithDatabase:` is never called - it seems it was replaced with `didRegisterExtension`. After this change, the cross-process notification extension is properly set up and notifications are posted.