### PR TITLE
Added nullability specifier to the return value of rangeOptionsForGroup

### DIFF
--- a/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.h
+++ b/YapDatabase/Extensions/Views/Utilities/YapDatabaseViewMappings.h
@@ -342,7 +342,7 @@ typedef NSComparisonResult (^YapDatabaseViewMappingGroupSort)(NSString *group1, 
 **/
 
 - (void)setRangeOptions:(nullable YapDatabaseViewRangeOptions *)rangeOpts forGroup:(NSString *)group;
-- (YapDatabaseViewRangeOptions *)rangeOptionsForGroup:(NSString *)group;
+- (nullable YapDatabaseViewRangeOptions *)rangeOptionsForGroup:(NSString *)group;
 
 - (void)removeRangeOptionsForGroup:(NSString *)group;
 


### PR DESCRIPTION
This reflects what happens when the group has no range options and makes it possible to test for a nil return from swift.