### PR TITLE
Relax CocoaLumberjack version to ease 2->3 transition

### DIFF
--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     ss.subspec 'Core' do |ssc|
       ssc.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DYAP_STANDARD_SQLITE' }
       ssc.library = 'sqlite3'
-      ssc.dependency 'CocoaLumberjack', '~> 2'
+      ssc.dependency 'CocoaLumberjack'
       ssc.source_files = 'YapDatabase/*.{h,m,mm,c}', 'YapDatabase/{Internal,Utilities}/*.{h,m,mm,c}', 'YapDatabase/Extensions/Protocol/**/*.{h,m,mm,c}'
       ssc.private_header_files = 'YapDatabase/Internal/*.h', 'YapDatabase/Extensions/Protocol/Internal/*.h'
     end
@@ -120,7 +120,7 @@ Pod::Spec.new do |s|
     ss.subspec 'Core' do |ssc|
       ssc.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC' }
       ssc.dependency 'SQLCipher', '>= 3.4.0'
-      ssc.dependency 'CocoaLumberjack', '~> 2'
+      ssc.dependency 'CocoaLumberjack'
       ssc.source_files = 'YapDatabase/*.{h,m,mm,c}', 'YapDatabase/{Internal,Utilities}/*.{h,m,mm,c}', 'YapDatabase/Extensions/Protocol/**/*.{h,m,mm,c}'
       ssc.private_header_files = 'YapDatabase/Internal/*.h', 'YapDatabase/Extensions/Protocol/Internal/*.h'
     end


### PR DESCRIPTION
CocoaLumberjack 3 contains breaking changes that only affect Swift 2->3. Although people should update to Swift 3 ASAP, it puts library authors in a weird place to simultaneously support non-pinned versions.

edit: Fixes #386