### PR TITLE
3.0 nullable

### DIFF
--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     ss.subspec 'Core' do |ssc|
       ssc.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DYAP_STANDARD_SQLITE' }
       ssc.library = 'sqlite3'
-      ssc.dependency 'CocoaLumberjack', '~> 2'
+      ssc.dependency 'CocoaLumberjack', '~> 3'
       ssc.source_files = 'YapDatabase/*.{h,m,mm,c}', 'YapDatabase/{Internal,Utilities}/*.{h,m,mm,c}', 'YapDatabase/Extensions/Protocol/**/*.{h,m,mm,c}'
       ssc.private_header_files = 'YapDatabase/Internal/*.h', 'YapDatabase/Extensions/Protocol/Internal/*.h'
     end
@@ -132,7 +132,7 @@ Pod::Spec.new do |s|
     ss.subspec 'Core' do |ssc|
       ssc.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC' }
       ssc.dependency 'SQLCipher', '>= 3.4.0'
-      ssc.dependency 'CocoaLumberjack', '~> 2'
+      ssc.dependency 'CocoaLumberjack', '~> 3'
       ssc.source_files = 'YapDatabase/*.{h,m,mm,c}', 'YapDatabase/{Internal,Utilities}/*.{h,m,mm,c}', 'YapDatabase/Extensions/Protocol/**/*.{h,m,mm,c}'
       ssc.private_header_files = 'YapDatabase/Internal/*.h', 'YapDatabase/Extensions/Protocol/Internal/*.h'
     end

--- a/YapDatabase/Extensions/View/Utilities/YapDatabaseViewChange.h
+++ b/YapDatabase/Extensions/View/Utilities/YapDatabaseViewChange.h
@@ -250,8 +250,8 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseViewChangesBitMask) {
  *
  * [self.tableView endUpdates];
 **/
-@property (nonatomic, readonly) NSIndexPath *indexPath;
-@property (nonatomic, readonly) NSIndexPath *newIndexPath;
+@property (nonatomic, readonly, nullable) NSIndexPath *indexPath;
+@property (nonatomic, readonly, nullable) NSIndexPath *newIndexPath;
 
 /**
  * The "original" values represent the location of the changed item


### PR DESCRIPTION
Fixed a couple of Swift 3 issues:

- CocoaLumberjack needs to be v3
- Row changes need to be nullable. Swift 3 doesn't seem to import them as implicitly-unwrapped (which is what it is meant to), causing a crash. 