### PR TITLE
Fix several YapDatabaseRelationship extension bugs

### DIFF
--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "YapDatabase"
-  s.version      = "2.9.3"
+  s.version      = "2.9.4"
   s.summary      = "A key/value store built atop sqlite for iOS & Mac."
   s.homepage     = "https://github.com/yapstudios/YapDatabase"
   s.license      = 'MIT'

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -1175,7 +1175,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 		{
 			if ((edge->state & YDB_EdgeState_HasSourceRowid) && srcRowid)
 			{
-				if (edge->sourceRowid != srcRowid.unsignedLongLongValue)
+				if (edge->sourceRowid != srcRowid.longLongValue)
 				{
 					continue;
 				}
@@ -1228,7 +1228,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 				// Shortcut:
 				// We already know the sourceRowid. It was given to us as a parameter.
 				
-				edge->sourceRowid = srcRowid.unsignedLongLongValue;
+				edge->sourceRowid = srcRowid.longLongValue;
 				edge->flags |= YDB_EdgeState_HasSourceRowid;
 			}
 			else
@@ -1286,7 +1286,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 			}
 			else if ((edge->state & YDB_EdgeState_HasDestinationRowid) && dstRowid)
 			{
-				if (edge->destinationRowid != dstRowid.unsignedLongLongValue)
+				if (edge->destinationRowid != dstRowid.longLongValue)
 				{
 					continue;
 				}
@@ -1319,7 +1319,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 			}
 			else if ((edge->state & YDB_EdgeState_HasDestinationRowid) && dstRowid)
 			{
-				if (edge->destinationRowid != dstRowid.unsignedLongLongValue)
+				if (edge->destinationRowid != dstRowid.longLongValue)
 				{
 					continue;
 				}
@@ -1376,7 +1376,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 				// Shortcut:
 				// We already know the sourceRowid. It was given to us as a parameter.
 				
-				edge->destinationRowid = dstRowid.unsignedLongLongValue;
+				edge->destinationRowid = dstRowid.longLongValue;
 				edge->state |= YDB_EdgeState_HasDestinationRowid;
 			}
 			else
@@ -1534,7 +1534,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 		}
 		else if ((edge->state & YDB_EdgeState_HasDestinationRowid) && dstRowid)
 		{
-			if (edge->destinationRowid != dstRowid.unsignedLongLongValue)
+			if (edge->destinationRowid != dstRowid.longLongValue)
 			{
 				continue;
 			}
@@ -1562,7 +1562,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 		{
 			if ((edge->state & YDB_EdgeState_HasSourceRowid) && srcRowid)
 			{
-				if (edge->sourceRowid != srcRowid.unsignedLongLongValue)
+				if (edge->sourceRowid != srcRowid.longLongValue)
 				{
 					continue;
 				}
@@ -1582,7 +1582,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 			}
 			else if ((edge->state & YDB_EdgeState_HasDestinationRowid) && dstRowid)
 			{
-				if (edge->destinationRowid != dstRowid.unsignedLongLongValue)
+				if (edge->destinationRowid != dstRowid.longLongValue)
 				{
 					continue;
 				}
@@ -1634,7 +1634,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 				// Shortcut:
 				// We already know the sourceRowid. It was given to us as a parameter.
 				
-				edge->sourceRowid = srcRowid.unsignedLongLongValue;
+				edge->sourceRowid = srcRowid.longLongValue;
 				edge->state |= YDB_EdgeState_HasSourceRowid;
 			}
 			else
@@ -1650,7 +1650,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 				// Shortcut:
 				// We already know the destinationRowid. It was given to us as a parameter.
 				
-				edge->destinationRowid = dstRowid.unsignedLongLongValue;
+				edge->destinationRowid = dstRowid.longLongValue;
 				edge->state |= YDB_EdgeState_HasDestinationRowid;
 			}
 			else
@@ -1722,7 +1722,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 		{
 			if ((edge->state & YDB_EdgeState_HasSourceRowid) && srcRowid)
 			{
-				if (edge->sourceRowid != srcRowid.unsignedLongLongValue)
+				if (edge->sourceRowid != srcRowid.longLongValue)
 				{
 					continue;
 				}
@@ -1779,7 +1779,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 				// Shortcut:
 				// We already know the sourceRowid. It was given to us as a parameter.
 				
-				edge->sourceRowid = srcRowid.unsignedLongLongValue;
+				edge->sourceRowid = srcRowid.longLongValue;
 				edge->state |= YDB_EdgeState_HasSourceRowid;
 			}
 			else

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -5515,6 +5515,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 				
 				int64_t edgeRowid = sqlite3_column_int64(statement, column_idx_rowid);
 				
+                edge = [parentConnection->edgeCache objectForKey:@(edgeRowid)];
 				if (edge)
 				{
 					edge->sourceRowid = srcRowid;

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -2091,10 +2091,10 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 	// AKA: typeof(dst) IS BLOB
 	
 	int const column_idx_rowid  = SQLITE_COLUMN_START + 0;
-	int const column_idx_src    = SQLITE_COLUMN_START + 2;
-	int const column_idx_dst    = SQLITE_COLUMN_START + 3;
-	int const column_idx_rules  = SQLITE_COLUMN_START + 4;
-	int const column_idx_manual = SQLITE_COLUMN_START + 5;
+	int const column_idx_src    = SQLITE_COLUMN_START + 1;
+	int const column_idx_dst    = SQLITE_COLUMN_START + 2;
+	int const column_idx_rules  = SQLITE_COLUMN_START + 3;
+	int const column_idx_manual = SQLITE_COLUMN_START + 4;
 	
 	int const bind_idx_src = SQLITE_BIND_START + 0;
 	int const bind_idx_name = SQLITE_BIND_START + 1;


### PR DESCRIPTION
The `edgeCache` was getting corrupted by some incorrect SQLite column offsets, which was resulting in edges being returned with invalid destination and delete rules.

Also, when deleting edges that were just added, the NotInDatabase flag wasn't being set in all cases leading to an assertion in `-deleteEdge:` failing. Note that this commit only addresses this issue for manual edges - I'm not using protocol edges and didn't feel comfortable modifying the code in the preprocessProtocolEdges method yet.

This includes a commit from the 3.0 branch that fixes a minor bug