### PR TITLE
Flushing beginImmediateTransactionStatement

### DIFF
--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -459,6 +459,7 @@ static int connectionBusyHandler(void *ptr, int count)
 - (void)_flushStatements
 {
 	sqlite_finalize_null(&beginTransactionStatement);
+	sqlite_finalize_null(&beginImmediateTransactionStatement);
 	sqlite_finalize_null(&commitTransactionStatement);
 	sqlite_finalize_null(&rollbackTransactionStatement);
 	


### PR DESCRIPTION
YapDatabase was not able correctly close sqlite connection in the multiprocess mode because of unfinished statement in the YapDatabaseConnection