### PR TITLE
Cross Process notifications delivery fixed

### DIFF
--- a/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotification.m
+++ b/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotification.m
@@ -62,6 +62,7 @@ static pid_t currentPid() {
     self = [super init];
     if (self) {
         self.identifier = identifier;
+        notifyToken = NOTIFY_TOKEN_INVALID;
     }
     return self;
 }
@@ -80,6 +81,7 @@ static pid_t currentPid() {
     __weak YapDatabaseCrossProcessNotification* wSelf = self;
     
     notify_register_dispatch(name, &notifyToken, dispatch_get_main_queue(), ^(int token) {
+        
         uint64_t fromPid;
         notify_get_state(token, &fromPid);
         BOOL isExternal = fromPid != currentPid();
@@ -96,7 +98,7 @@ static pid_t currentPid() {
     if (notify_is_valid_token(notifyToken))
     {
         notify_cancel(notifyToken);
-        notifyToken = 0;
+        notifyToken = NOTIFY_TOKEN_INVALID;
     }
 }
 
@@ -110,10 +112,24 @@ static pid_t currentPid() {
  *   This method is invoked within the writeQueue.
  *   So either don't do anything expensive/time-consuming in this method, or dispatch_async to do it in another queue.
 **/
-- (void)didRegisterWithDatabase:(YapDatabase __unused *)database
+- (void)didRegisterExtension {
+    // only start dispatching notifications once the extension is registered to a database
+    [self start];
+}
+
+- (void)noteCommittedChangeset:(NSDictionary *)changeset registeredName:(NSString *)extName
 {
-	// only start dispatching notifications once the extension is registered to a database
-	[self start];
+    NSDictionary *ext_changeset = [[changeset objectForKey:YapDatabaseExtensionsKey] objectForKey:extName];
+    if (ext_changeset)
+    {
+        [self processChangeset:ext_changeset];
+    }
+    
+    NSNotification *notification = changeset[YapDatabaseNotificationKey];
+    if ([notification.name isEqualToString:YapDatabaseModifiedNotification])
+    {
+        [self notifyChanged];
+    }
 }
 
 - (YapDatabaseExtensionConnection *)newConnection:(YapDatabaseConnection *)databaseConnection
@@ -122,6 +138,9 @@ static pid_t currentPid() {
 }
 
 - (void)notifyChanged {
+    if (!notify_is_valid_token(notifyToken)) {
+        [self start];
+    }
     
     const char* name = [[self channel] cStringUsingEncoding:NSUTF8StringEncoding];
     

--- a/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotificationTransaction.m
+++ b/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotificationTransaction.m
@@ -26,7 +26,6 @@
 
 @property (nonatomic, strong) YapDatabaseCrossProcessNotificationConnection* parentConnection;
 @property (nonatomic, strong) YapDatabaseReadTransaction* databaseTransaction;
-@property (nonatomic, assign) BOOL anyChange;
 
 @end
 
@@ -37,7 +36,6 @@
 {
 	if ((self = [super init]))
 	{
-        self.anyChange = NO;
 		self.parentConnection = inParentConnection;
         self.databaseTransaction = inDatabaseTransaction;
 	}
@@ -104,14 +102,6 @@
 **/
 - (void)didCommitTransaction
 {
-	if (self.anyChange)
-	{
-		YapDatabaseCrossProcessNotification *ext =
-		  (YapDatabaseCrossProcessNotification *)self.parentConnection.extension;
-		
-		[ext notifyChanged];
-	}
-    
 	// An extensionTransaction is only valid within the scope of its encompassing databaseTransaction.
 	// I imagine this may occasionally be misunderstood, and developers may attempt to store the extension in an ivar,
 	// and then use it outside the context of the database transaction block.
@@ -126,7 +116,6 @@
 **/
 - (void)didRollbackTransaction
 {
-    self.anyChange = NO;
 	// An extensionTransaction is only valid within the scope of its encompassing databaseTransaction.
 	// I imagine this may occasionally be misunderstood, and developers may attempt to store the extension in an ivar,
 	// and then use it outside the context of the database transaction block.
@@ -149,7 +138,7 @@
               withMetadata:(id)metadata
                      rowid:(int64_t)rowid
 {
-	self.anyChange = YES;
+
 }
 
 /**
@@ -161,7 +150,7 @@
               withMetadata:(id)metadata
                      rowid:(int64_t)rowid
 {
-    self.anyChange = YES;
+
 }
 
 /**
@@ -170,7 +159,7 @@
 **/
 - (void)handleReplaceObject:(id)object forCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
 {
-    self.anyChange = YES;
+
 }
 
 /**
@@ -179,7 +168,7 @@
 **/
 - (void)handleReplaceMetadata:(id)metadata forCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
 {
-    self.anyChange = YES;
+
 }
 
 /**
@@ -188,7 +177,7 @@
 **/
 - (void)handleTouchObjectForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
-    self.anyChange = YES;
+
 }
 
 /**
@@ -197,7 +186,7 @@
 **/
 - (void)handleTouchMetadataForCollectionKey:(YapCollectionKey __unused *)collectionKey withRowid:(int64_t __unused)rowid
 {
-    self.anyChange = YES;
+
 }
 
 /**
@@ -206,7 +195,7 @@
 **/
 - (void)handleTouchRowForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
 {
-    self.anyChange = YES;
+
 }
 
 /**
@@ -215,7 +204,7 @@
 **/
 - (void)handleRemoveObjectForCollectionKey:(YapCollectionKey *)collectionKey withRowid:(int64_t)rowid
 {
-	self.anyChange = YES;
+
 }
 
 /**
@@ -224,7 +213,7 @@
 **/
 - (void)handleRemoveObjectsForKeys:(NSArray __unused *)keys inCollection:(NSString *)collection withRowids:(NSArray *)rowids
 {
-	self.anyChange = YES;
+
 }
 
 /**
@@ -233,7 +222,7 @@
 **/
 - (void)handleRemoveAllObjectsInAllCollections
 {
-	self.anyChange = YES;
+
 }
 
 @end


### PR DESCRIPTION
Fixed: 
- Registration for notifications
- Cancelation of previously registered notifications

Observing database changes through noteCommittedChangeset to notify other processes about every snapshot