### PR TITLE
Use sqlite3_blob_read instead of prepared statements

### DIFF
--- a/YapDatabase/Internal/YapDatabasePrivate.h
+++ b/YapDatabase/Internal/YapDatabasePrivate.h
@@ -251,7 +251,6 @@ static NSString *const ext_key_class = @"class";
 - (sqlite3_stmt *)getCountForRowidStatement;
 - (sqlite3_stmt *)getRowidForKeyStatement;
 - (sqlite3_stmt *)getKeyForRowidStatement;
-- (sqlite3_stmt *)getMetadataForRowidStatement;
 - (sqlite3_stmt *)getAllForRowidStatement;
 - (sqlite3_stmt *)getDataForKeyStatement;
 - (sqlite3_stmt *)getMetadataForKeyStatement;
@@ -276,6 +275,7 @@ static NSString *const ext_key_class = @"class";
 - (sqlite3_stmt *)enumerateRowsInAllCollectionsStatement:(BOOL *)needsFinalizePtr;
 
 - (sqlite3_blob *)getDataForRowidBlob:(int64_t)rowid;
+- (sqlite3_blob *)getMetadataForRowidBlob:(int64_t)rowid;
 
 - (void)prepare;
 

--- a/YapDatabase/Internal/YapDatabasePrivate.h
+++ b/YapDatabase/Internal/YapDatabasePrivate.h
@@ -251,7 +251,6 @@ static NSString *const ext_key_class = @"class";
 - (sqlite3_stmt *)getCountForRowidStatement;
 - (sqlite3_stmt *)getRowidForKeyStatement;
 - (sqlite3_stmt *)getKeyForRowidStatement;
-- (sqlite3_stmt *)getDataForRowidStatement;
 - (sqlite3_stmt *)getMetadataForRowidStatement;
 - (sqlite3_stmt *)getAllForRowidStatement;
 - (sqlite3_stmt *)getDataForKeyStatement;
@@ -275,6 +274,8 @@ static NSString *const ext_key_class = @"class";
 - (sqlite3_stmt *)enumerateKeysAndObjectsInAllCollectionsStatement:(BOOL *)needsFinalizePtr;
 - (sqlite3_stmt *)enumerateRowsInCollectionStatement:(BOOL *)needsFinalizePtr;
 - (sqlite3_stmt *)enumerateRowsInAllCollectionsStatement:(BOOL *)needsFinalizePtr;
+
+- (sqlite3_blob *)getDataForRowidBlob:(int64_t)rowid;
 
 - (void)prepare;
 

--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -629,46 +629,52 @@
 		else
 			return metadata;
 	}
-	
-	sqlite3_stmt *statement = [connection getMetadataForRowidStatement];
-	if (statement == NULL) return nil;
-	
-	// SELECT "metadata" FROM "database2" WHERE "rowid" = ?;
-	
-	int const column_idx_metadata = SQLITE_COLUMN_START;
-	int const bind_idx_rowid      = SQLITE_BIND_START;
-	
-	sqlite3_bind_int64(statement, bind_idx_rowid, rowid);
-	
-	int status = sqlite3_step(statement);
-	if (status == SQLITE_ROW)
-	{
-		const void *blob = sqlite3_column_blob(statement, column_idx_metadata);
-		int blobSize = sqlite3_column_bytes(statement, column_idx_metadata);
-		
-		if (blobSize > 0)
-		{
-			// Performance tuning:
-			// Use dataWithBytesNoCopy to avoid an extra allocation and memcpy.
-			
-			NSData *data = [NSData dataWithBytesNoCopy:(void *)blob length:blobSize freeWhenDone:NO];
-			metadata = connection->database->metadataDeserializer(cacheKey.collection, cacheKey.key, data);
-		}
-		
-		if (metadata)
-			[connection->metadataCache setObject:metadata forKey:cacheKey];
-		else
-			[connection->metadataCache setObject:[YapNull null] forKey:cacheKey];
-	}
-	else if (status == SQLITE_ERROR)
-	{
-		YDBLogError(@"Error executing 'getMetadataForRowidStatement': %d %s", status, sqlite3_errmsg(connection->db));
-	}
-	
-	sqlite3_clear_bindings(statement);
-	sqlite3_reset(statement);
-	
-	return metadata;
+
+    sqlite3_blob *blob = [connection getMetadataForRowidBlob:rowid];
+
+    if (blob == NULL)
+    {
+        return nil;
+    }
+
+    int status = sqlite3_blob_reopen(blob, rowid);
+
+    if (status != SQLITE_OK)
+    {
+        YDBLogError(@"Error calling 'sqlite3_blob_reopen': %d %s", status, sqlite3_errmsg(connection->db));
+    }
+
+    int size = sqlite3_blob_bytes(blob);
+
+    if (size == 0) {
+        [connection->metadataCache setObject:[YapNull null] forKey:cacheKey];
+    } else {
+        void *bytes = malloc(size);
+
+        status = sqlite3_blob_read(blob, bytes, size, 0);
+
+        if (status == SQLITE_OK)
+        {
+            // Performance tuning:
+            // Use dataWithBytesNoCopy to avoid an extra allocation and memcpy.
+
+            NSData *data = [NSData dataWithBytesNoCopy:(void *)bytes length:size freeWhenDone:NO];
+            metadata = connection->database->metadataDeserializer(cacheKey.collection, cacheKey.key, data);
+
+            if (metadata)
+                [connection->metadataCache setObject:metadata forKey:cacheKey];
+            else
+                [connection->metadataCache setObject:[YapNull null] forKey:cacheKey];
+        }
+        else
+        {
+            YDBLogError(@"Error executing 'sqlite3_blob_read': %d %s", status, sqlite3_errmsg(connection->db));
+
+            free(bytes);
+        }
+    }
+
+    return metadata;
 }
 
 - (BOOL)getObject:(id *)objectPtr
@@ -930,46 +936,49 @@
 	if (cachedRowid)
 	{
 		int64_t rowid = [cachedRowid longLongValue];
-		
-		sqlite3_stmt *statement = [connection getMetadataForRowidStatement];
-		if (statement == NULL) return nil;
-		
-		// SELECT "metadata" FROM "database2" WHERE "rowid" = ?;
-		
-		int const column_idx_metadata = SQLITE_COLUMN_START;
-		int const bind_idx_rowid      = SQLITE_BIND_START;
-		
-		sqlite3_bind_int64(statement, bind_idx_rowid, rowid);
-		
-		int status = sqlite3_step(statement);
-		if (status == SQLITE_ROW)
-		{
-			const void *blob = sqlite3_column_blob(statement, column_idx_metadata);
-			int blobSize = sqlite3_column_bytes(statement, column_idx_metadata);
-			
-			if (blobSize > 0)
-			{
-				// Performance tuning:
-				// Use dataWithBytesNoCopy to avoid an extra allocation and memcpy.
-				
-				NSData *data = [NSData dataWithBytesNoCopy:(void *)blob length:blobSize freeWhenDone:NO];
-				metadata = connection->database->metadataDeserializer(cacheKey.collection, cacheKey.key, data);
-			}
-			
-			// Update cache
-			
-			if (metadata)
-				[connection->metadataCache setObject:metadata forKey:cacheKey];
-			else
-				[connection->metadataCache setObject:[YapNull null] forKey:cacheKey];
-		}
-		else if (status == SQLITE_ERROR)
-		{
-			YDBLogError(@"Error executing 'getMetadataForRowidStatement': %d %s", status, sqlite3_errmsg(connection->db));
-		}
-		
-		sqlite3_clear_bindings(statement);
-		sqlite3_reset(statement);
+        sqlite3_blob *blob = [connection getMetadataForRowidBlob:rowid];
+
+        if (blob == NULL)
+        {
+            return nil;
+        }
+
+        int status = sqlite3_blob_reopen(blob, rowid);
+
+        if (status != SQLITE_OK)
+        {
+            YDBLogError(@"Error calling 'sqlite3_blob_reopen': %d %s", status, sqlite3_errmsg(connection->db));
+        }
+
+        int size = sqlite3_blob_bytes(blob);
+
+        if (size == 0) {
+            [connection->metadataCache setObject:[YapNull null] forKey:cacheKey];
+        } else {
+            void *bytes = malloc(size);
+
+            status = sqlite3_blob_read(blob, bytes, size, 0);
+
+            if (status == SQLITE_OK)
+            {
+                // Performance tuning:
+                // Use dataWithBytesNoCopy to avoid an extra allocation and memcpy.
+
+                NSData *data = [NSData dataWithBytesNoCopy:(void *)bytes length:size freeWhenDone:NO];
+                metadata = connection->database->metadataDeserializer(cacheKey.collection, cacheKey.key, data);
+
+                if (metadata)
+                    [connection->metadataCache setObject:metadata forKey:cacheKey];
+                else
+                    [connection->metadataCache setObject:[YapNull null] forKey:cacheKey];
+            }
+            else
+            {
+                YDBLogError(@"Error executing 'sqlite3_blob_read': %d %s", status, sqlite3_errmsg(connection->db));
+
+                free(bytes);
+            }
+        }
 	}
 	else
 	{
@@ -1336,32 +1345,30 @@
 	if (cachedRowid)
 	{
 		int64_t rowid = [cachedRowid longLongValue];
-		
-		sqlite3_stmt *statement = [connection getMetadataForRowidStatement];
-		if (statement == NULL) return nil;
-		
-		// SELECT "metadata" FROM "database2" WHERE "rowid" = ?;
-		
-		int const column_idx_metadata = SQLITE_COLUMN_START;
-		int const bind_idx_rowid      = SQLITE_BIND_START;
-		
-		sqlite3_bind_int64(statement, bind_idx_rowid, rowid);
-		
-		int status = sqlite3_step(statement);
-		if (status == SQLITE_ROW)
-		{
-			const void *blob = sqlite3_column_blob(statement, column_idx_metadata);
-			int blobSize = sqlite3_column_bytes(statement, column_idx_metadata);
-			
-			result = [[NSData alloc] initWithBytes:blob length:blobSize];
-		}
-		else if (status == SQLITE_ERROR)
-		{
-			YDBLogError(@"Error executing 'getMetadataForRowidStatement': %d %s", status, sqlite3_errmsg(connection->db));
-		}
-		
-		sqlite3_clear_bindings(statement);
-		sqlite3_reset(statement);
+        sqlite3_blob *blob = [connection getMetadataForRowidBlob:rowid];
+
+        if (blob == NULL) {
+            return nil;
+        }
+
+        int status = sqlite3_blob_reopen(blob, rowid);
+
+        if (status != SQLITE_OK) {
+            YDBLogError(@"Error calling 'sqlite3_blob_reopen': %d %s", status, sqlite3_errmsg(connection->db));
+        }
+
+        int size = sqlite3_blob_bytes(blob);
+        void *bytes = malloc(size);
+
+        status = sqlite3_blob_read(blob, bytes, size, 0);
+
+        if (status == SQLITE_OK) {
+            result = [NSData dataWithBytesNoCopy:bytes length:size freeWhenDone:YES];
+        } else {
+            YDBLogError(@"Error executing 'sqlite3_blob_read': %d %s", status, sqlite3_errmsg(connection->db));
+
+            free(bytes);
+        }
 	}
 	else
 	{

--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -603,9 +603,9 @@
     else
     {
         YDBLogError(@"Error executing 'sqlite3_blob_read': %d %s", status, sqlite3_errmsg(connection->db));
-
-        free(bytes);
     }
+
+    free(bytes);
 	
 	return object;
 }
@@ -669,9 +669,9 @@
         else
         {
             YDBLogError(@"Error executing 'sqlite3_blob_read': %d %s", status, sqlite3_errmsg(connection->db));
-
-            free(bytes);
         }
+
+        free(bytes);
     }
 
     return metadata;
@@ -857,9 +857,9 @@
         else
         {
             YDBLogError(@"Error executing 'sqlite3_blob_read': %d %s", status, sqlite3_errmsg(connection->db));
-
-            free(bytes);
         }
+
+        free(bytes);
 	}
 	else
 	{
@@ -975,9 +975,9 @@
             else
             {
                 YDBLogError(@"Error executing 'sqlite3_blob_read': %d %s", status, sqlite3_errmsg(connection->db));
-
-                free(bytes);
             }
+
+            free(bytes);
         }
 	}
 	else


### PR DESCRIPTION
This replaces the usage of `getDataForRowidstatement` and `getMetadataForRowidStatement` with `sqlite3_blob_open`/`sqlite3_blob_read`.

This provides a small speedup if the object's key is already in the cache but the object itself isn't. This probably doesn't happen very often, but it is slightly faster :)

One caveat: Metadata fetches will now log an error if there's no metadata for the given key (`sqlite3_blob_read` returns an error if the column is null). The YDBLogError calls could be removed from metadata fetches to silence those.

Here's the changes in timings I found (average of 4 runs each). I was running `[transaction objectForKey:@"key" inCollection:@"example"]` and `[transaction serializedObjectForKey:@"key" inCollection:@"example"]` in a for loop.

### Fetching an object named "World":

*objectForKey:inCollection:*

Old: 196,335 objects per second
New:  235,095 objects per second

*serializedObjectForKey:inCollection:*

Old: 671,447 objects per second
New: 835,267 objects per second

### Fetching 400 KB empty NSData:

*serializedObjectsForKey:inCollection:*

Old: 2,250 objects per second
New: 3,245 objects per second