### PR TITLE
FTS5 with bm25 ranking queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
 script:
   - cd ./Testing/Xcode-desktop
   - pod update
-  - xctool -workspace YapDatabaseTesting.xcworkspace -scheme YapDatabaseTesting -sdk macosx -arch x86_64 test
+  - xctool -workspace YapDatabaseTesting.xcworkspace -scheme YapDatabaseTesting -sdk macosx -arch x86_64 run-tests

--- a/YapDatabase/Extensions/FullTextSearch/Internal/YapDatabaseFullTextSearchPrivate.h
+++ b/YapDatabase/Extensions/FullTextSearch/Internal/YapDatabaseFullTextSearchPrivate.h
@@ -43,6 +43,7 @@
 	
 	NSOrderedSet *columnNames;
 	NSDictionary *options;
+	NSString *ftsVersion;
 	NSString *versionTag;
 	
 	id columnNamesSharedKeySet;
@@ -77,6 +78,8 @@
 - (sqlite3_stmt *)removeRowidStatement;
 - (sqlite3_stmt *)removeAllStatement;
 - (sqlite3_stmt *)queryStatement;
+- (sqlite3_stmt *)bm25QueryStatement;
+- (sqlite3_stmt *)bm25QueryStatementWithWeights:(NSArray<NSNumber *> *)weights;
 - (sqlite3_stmt *)querySnippetStatement;
 - (sqlite3_stmt *)rowidQueryStatement;
 - (sqlite3_stmt *)rowidQuerySnippetStatement;

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.h
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.h
@@ -18,6 +18,13 @@ NS_ASSUME_NONNULL_BEGIN
  * YapDatabaseFullTextSearch is an extension for performing text based search.
  * Internally it uses sqlite's FTS module which was contributed by Google.
 **/
+
+
+extern NSString *const YapDatabaseFullTextSearchFTS5Version;
+extern NSString *const YapDatabaseFullTextSearchFTS4Version;
+extern NSString *const YapDatabaseFullTextSearchFTS3Version;
+
+
 @interface YapDatabaseFullTextSearch : YapDatabaseExtension
 
 - (id)initWithColumnNames:(NSArray<NSString *> *)columnNames
@@ -30,6 +37,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)initWithColumnNames:(NSArray<NSString *> *)columnNames
                   options:(nullable NSDictionary *)options
                   handler:(YapDatabaseFullTextSearchHandler *)handler
+               versionTag:(nullable NSString *)versionTag;
+
+- (id)initWithColumnNames:(NSArray<NSString *> *)columnNames
+                  options:(nullable NSDictionary *)options
+                  handler:(YapDatabaseFullTextSearchHandler *)handler
+               ftsVersion:(nullable NSString *)ftsVersion
                versionTag:(nullable NSString *)versionTag;
 
 
@@ -49,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  * and the FTS extension will automatically update itself.
 **/
 @property (nonatomic, copy, readonly, nullable) NSString *versionTag;
+@property (nonatomic, copy, readonly, nullable) NSString *ftsVersion;
 
 @end
 

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearch.m
@@ -22,6 +22,11 @@ static const int ydbLogLevel = YDB_LOG_LEVEL_WARN;
 #pragma unused(ydbLogLevel)
 
 
+NSString *const YapDatabaseFullTextSearchFTS5Version = @"fts5";
+NSString *const YapDatabaseFullTextSearchFTS4Version = @"fts4";
+NSString *const YapDatabaseFullTextSearchFTS3Version = @"fts3";
+
+
 @implementation YapDatabaseFullTextSearch
 
 + (void)dropTablesForRegisteredName:(NSString *)registeredName
@@ -59,6 +64,7 @@ static const int ydbLogLevel = YDB_LOG_LEVEL_WARN;
 
 @synthesize handler = handler;
 @synthesize versionTag = versionTag;
+@synthesize ftsVersion = ftsVersion;
 
 - (id)initWithColumnNames:(NSArray *)inColumnNames
                   handler:(YapDatabaseFullTextSearchHandler *)inHandler
@@ -81,42 +87,55 @@ static const int ydbLogLevel = YDB_LOG_LEVEL_WARN;
                   handler:(YapDatabaseFullTextSearchHandler *)inHandler
                versionTag:(NSString *)inVersionTag
 {
-	if ([inColumnNames count] == 0)
-	{
-		NSAssert(NO, @"Empty columnNames array");
-		return nil;
-	}
-	
-	for (id columnName in inColumnNames)
-	{
-		if (![columnName isKindOfClass:[NSString class]])
-		{
-			NSAssert(NO, @"Invalid column name. Not a string: %@", columnName);
-			return nil;
-		}
-		
-		NSRange range = [(NSString *)columnName rangeOfString:@"\""];
-		if (range.location != NSNotFound)
-		{
-			NSAssert(NO, @"Invalid column name. Cannot contain quotes: %@", columnName);
-			return nil;
-		}
-	}
-	
-	NSAssert(inHandler != NULL, @"Null handler");
-	
-	if ((self = [super init]))
-	{
-		columnNames = [NSOrderedSet orderedSetWithArray:inColumnNames];
-		columnNamesSharedKeySet = [NSDictionary sharedKeySetForKeys:[columnNames array]];
-		
-		options = [inOptions copy];
-		
-		handler = inHandler;
-		
-		versionTag = inVersionTag ? [inVersionTag copy] : @"";
-	}
-	return self;
+    return [self initWithColumnNames:inColumnNames
+                             options:inOptions
+                             handler:inHandler
+                          ftsVersion:nil
+                          versionTag:inVersionTag];
+}
+
+- (id)initWithColumnNames:(NSArray *)inColumnNames
+                  options:(NSDictionary *)inOptions
+                  handler:(YapDatabaseFullTextSearchHandler *)inHandler
+               ftsVersion:(NSString *)inFtsVersion
+               versionTag:(NSString *)inVersionTag {
+    if ([inColumnNames count] == 0)
+    {
+        NSAssert(NO, @"Empty columnNames array");
+        return nil;
+    }
+    
+    for (id columnName in inColumnNames)
+    {
+        if (![columnName isKindOfClass:[NSString class]])
+        {
+            NSAssert(NO, @"Invalid column name. Not a string: %@", columnName);
+            return nil;
+        }
+        
+        NSRange range = [(NSString *)columnName rangeOfString:@"\""];
+        if (range.location != NSNotFound)
+        {
+            NSAssert(NO, @"Invalid column name. Cannot contain quotes: %@", columnName);
+            return nil;
+        }
+    }
+    
+    NSAssert(inHandler != NULL, @"Null handler");
+    
+    if ((self = [super init]))
+    {
+        columnNames = [NSOrderedSet orderedSetWithArray:inColumnNames];
+        columnNamesSharedKeySet = [NSDictionary sharedKeySetForKeys:[columnNames array]];
+        
+        options = [inOptions copy];
+        
+        handler = inHandler;
+        
+        versionTag = inVersionTag ? [inVersionTag copy] : @"";
+        ftsVersion = inFtsVersion ? [inFtsVersion copy] : YapDatabaseFullTextSearchFTS4Version;
+    }
+    return self;
 }
 
 - (YapDatabaseExtensionConnection *)newConnection:(YapDatabaseConnection *)databaseConnection

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.h
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.h
@@ -44,6 +44,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enumerateRowsMatching:(NSString *)query
                    usingBlock:(void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
 
+// FTS5 bm25 ordering
+
+- (void)enumerateBm25OrderedKeysMatching:(NSString *)query
+                             withWeights:(nullable NSArray<NSNumber *> *)weights
+                              usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block;
+
+- (void)enumerateBm25OrderedKeysAndMetadataMatching:(NSString *)query
+                                        withWeights:(nullable NSArray<NSNumber *> *)weights
+                                         usingBlock:(void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+
+- (void)enumerateBm25OrderedKeysAndObjectsMatching:(NSString *)query
+                                       withWeights:(nullable NSArray<NSNumber *> *)weights
+                                        usingBlock:(void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
+
+- (void)enumerateBm25OrderedRowsMatching:(NSString *)query
+                             withWeights:(nullable NSArray<NSNumber *> *)weights
+                              usingBlock:(void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+
 // Query matching + Snippets
 
 - (void)enumerateKeysMatching:(NSString *)query


### PR DESCRIPTION
FullTextSearch extension may be created with different FTS versions. FTS4 is default and api is backward compatible.

For FTS5 indexes added methods to enumerate result ordered with bm25 ranking function