### PR TITLE
Add prefix for NSDate category methods.

### DIFF
--- a/YapDatabase/Extensions/ActionManager/YapActionItem.m
+++ b/YapDatabase/Extensions/ActionManager/YapActionItem.m
@@ -88,7 +88,7 @@
 	// if (date <= atDate) -> date is in past   -> ready
 	// if (date  > atDate) -> date is in future -> not ready
 	//
-	return [date isBeforeOrEqual:atDate];
+	return [date ydb_isBeforeOrEqual:atDate];
 }
 
 /**
@@ -116,7 +116,7 @@
 		// if (nextRetry <= atDate) -> nextRetry is in past   -> ready
 		// if (nextRetry  > atDate) -> nextRetry is in future -> not ready
 		//
-		return [nextRetry isBeforeOrEqual:atDate];
+		return [nextRetry ydb_isBeforeOrEqual:atDate];
 	}
 }
 

--- a/YapDatabase/Internal/NSDate+YapDatabase.h
+++ b/YapDatabase/Internal/NSDate+YapDatabase.h
@@ -3,10 +3,10 @@
 
 @interface NSDate (YapDatabase)
 
-- (BOOL)isBefore:(NSDate *)date;
-- (BOOL)isAfter:(NSDate *)date;
+- (BOOL)ydb_isBefore:(NSDate *)date;
+- (BOOL)ydb_isAfter:(NSDate *)date;
 
-- (BOOL)isBeforeOrEqual:(NSDate *)date;
-- (BOOL)isAfterOrEqual:(NSDate *)date;
+- (BOOL)ydb_isBeforeOrEqual:(NSDate *)date;
+- (BOOL)ydb_isAfterOrEqual:(NSDate *)date;
 
 @end

--- a/YapDatabase/Internal/NSDate+YapDatabase.m
+++ b/YapDatabase/Internal/NSDate+YapDatabase.m
@@ -3,17 +3,17 @@
 
 @implementation NSDate (YapDatabase)
 
-- (BOOL)isBefore:(NSDate *)date
+- (BOOL)ydb_isBefore:(NSDate *)date
 {
 	return ([self compare:date] == NSOrderedAscending);
 }
 
-- (BOOL)isAfter:(NSDate *)date
+- (BOOL)ydb_isAfter:(NSDate *)date
 {
 	return ([self compare:date] == NSOrderedDescending);
 }
 
-- (BOOL)isBeforeOrEqual:(NSDate *)date
+- (BOOL)ydb_isBeforeOrEqual:(NSDate *)date
 {
 	// [dateA compare:dateB]
 	//
@@ -26,7 +26,7 @@
 	        result == NSOrderedSame);
 }
 
-- (BOOL)isAfterOrEqual:(NSDate *)date
+- (BOOL)ydb_isAfterOrEqual:(NSDate *)date
 {
 	// [dateA compare:dateB]
 	//


### PR DESCRIPTION
The NSDictionary category does this already. Without prefixing the method names might clash with consumer code.