### PR TITLE
Add some explicit casts when implicitly converting types.

### DIFF
--- a/YapDatabase/Extensions/ActionManager/YapDatabaseActionManager.m
+++ b/YapDatabase/Extensions/ActionManager/YapDatabaseActionManager.m
@@ -873,10 +873,10 @@
 		if (startOffset < 0.0)
 			startOffset = 0.0;
 		
-		dispatch_time_t start = dispatch_time(DISPATCH_TIME_NOW, (startOffset * NSEC_PER_SEC));
+		dispatch_time_t start = dispatch_time(DISPATCH_TIME_NOW, (uint64_t)(startOffset * NSEC_PER_SEC));
 		
 		uint64_t interval = DISPATCH_TIME_FOREVER;
-		uint64_t leeway = (0.1 * NSEC_PER_SEC);
+		uint64_t leeway = (uint64_t)(0.1 * NSEC_PER_SEC);
 		
 		dispatch_source_set_timer(timer, start, interval, leeway);
 		

--- a/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitTransaction.m
+++ b/YapDatabase/Extensions/CloudKit/YapDatabaseCloudKitTransaction.m
@@ -1027,7 +1027,7 @@ static BOOL ClassVersionsAreCompatible(int oldClassVersion, int newClassVersion)
 	uint8_t bufferStack[maxStackSize];
 	void *buffer = NULL;
 	
-	if (maxLen <= maxStackSize)
+	if (maxLen <= (NSUInteger)maxStackSize)
 		buffer = bufferStack;
 	else
 		buffer = malloc((size_t)maxLen);
@@ -1086,7 +1086,7 @@ static BOOL ClassVersionsAreCompatible(int oldClassVersion, int newClassVersion)
 	NSData *hashData = [NSData dataWithBytesNoCopy:(void *)hashBytes length:CC_SHA1_DIGEST_LENGTH freeWhenDone:NO];
 	NSString *hashStr = [hashData base64EncodedStringWithOptions:0];
 	
-	if (maxLen > maxStackSize) {
+	if (maxLen > (NSUInteger)maxStackSize) {
 		free(buffer);
 	}
 	return hashStr;

--- a/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotification.m
+++ b/YapDatabase/Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotification.m
@@ -84,7 +84,7 @@ static pid_t currentPid() {
         
         uint64_t fromPid;
         notify_get_state(token, &fromPid);
-        BOOL isExternal = fromPid != currentPid();
+        BOOL isExternal = fromPid != (uint64_t)currentPid();
         if (isExternal)
         {
             NSLog(@"received external modification from %llu", fromPid);


### PR DESCRIPTION
We are compiling some files of YapDatabase directly in our app which has implicit conversion warnings enabled.

I'm aware this is a very minor and only cosmetic change so feel free to close this pull request.