### PR TITLE
Fixed shadowing of local variables by renaming them.

### DIFF
--- a/YapDatabase/Extensions/ActionManager/YapDatabaseActionManager.m
+++ b/YapDatabase/Extensions/ActionManager/YapDatabaseActionManager.m
@@ -719,9 +719,9 @@
 	__block NSMutableArray *collectionKeysToRemove = nil;
 	__block NSDate *nextTimerFireDate = nil;
 	
-	[actionItemsDict enumerateKeysAndObjectsUsingBlock:^(YapCollectionKey *ck, NSArray *actionItems, BOOL *stop) {
+	[actionItemsDict enumerateKeysAndObjectsUsingBlock:^(YapCollectionKey *ck, NSArray *actionItems, BOOL *dictStop) {
 		
-		[actionItems enumerateObjectsUsingBlock:^(YapActionItem *actionItem, NSUInteger idx, BOOL *stop) {
+		[actionItems enumerateObjectsUsingBlock:^(YapActionItem *actionItem, NSUInteger idx, BOOL *itemsStop) {
 			
 			BOOL needsRun = NO;
 			NSDate *actionDate = nil;

--- a/YapDatabase/Extensions/FilteredView/YapDatabaseFilteredViewTransaction.m
+++ b/YapDatabase/Extensions/FilteredView/YapDatabaseFilteredViewTransaction.m
@@ -693,10 +693,10 @@
 			int64_t prevRowid = 0;
 			[parentViewTransaction getRowid:&prevRowid atIndex:prevIndex inGroup:group];
 			
-			YapDatabaseViewLocator *locator = [self locatorForRowid:prevRowid];
-			if (locator)
+			YapDatabaseViewLocator *prevLocator = [self locatorForRowid:prevRowid];
+			if (prevLocator)
 			{
-				index = locator.index + 1;
+				index = prevLocator.index + 1;
 				break;
 			}
 		}
@@ -708,10 +708,10 @@
 			int64_t nextRowid = 0;
 			[parentViewTransaction getRowid:&nextRowid atIndex:nextIndex inGroup:group];
 			
-			YapDatabaseViewLocator *locator = [self locatorForRowid:nextRowid];
-			if (locator)
+			YapDatabaseViewLocator *nextLocator = [self locatorForRowid:nextRowid];
+			if (nextLocator)
 			{
-				index = locator.index;
+				index = nextLocator.index;
 				break;
 			}
 		}

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -2074,7 +2074,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 **/
 - (int64_t)edgeCountWithDestinationFileURL:(NSURL *)dstFileURL
                                       name:(NSString *)name
-                           excludingSource:(int64_t)srcRowid
+                           excludingSource:(int64_t)exclSrcRowid
 {
 	NSAssert(dstFileURL != nil, @"Internal logic error");
 	NSAssert(name != nil, @"Internal logic error");
@@ -2099,7 +2099,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 	int const bind_idx_src = SQLITE_BIND_START + 0;
 	int const bind_idx_name = SQLITE_BIND_START + 1;
 	
-	sqlite3_bind_int64(statement, bind_idx_src, srcRowid);
+	sqlite3_bind_int64(statement, bind_idx_src, exclSrcRowid);
 	
 	YapDatabaseString _name; MakeYapDatabaseString(&_name, name);
 	sqlite3_bind_text(statement, bind_idx_name, _name.str, _name.length, SQLITE_STATIC);

--- a/YapDatabase/Extensions/SearchResultsView/YapDatabaseSearchResultsViewTransaction.m
+++ b/YapDatabase/Extensions/SearchResultsView/YapDatabaseSearchResultsViewTransaction.m
@@ -660,10 +660,10 @@ static NSString *const ext_key_query           = @"query";
 			int64_t prevRowid = 0;
 			[parentViewTransaction getRowid:&prevRowid atIndex:prevIndex inGroup:group];
 			
-			YapDatabaseViewLocator *locator = [self locatorForRowid:prevRowid];
-			if (locator)
+			YapDatabaseViewLocator *prevLocator = [self locatorForRowid:prevRowid];
+			if (prevLocator)
 			{
-				index = locator.index + 1;
+				index = prevLocator.index + 1;
 				break;
 			}
 		}
@@ -675,10 +675,10 @@ static NSString *const ext_key_query           = @"query";
 			int64_t nextRowid = 0;
 			[parentViewTransaction getRowid:&nextRowid atIndex:nextIndex inGroup:group];
 			
-			YapDatabaseViewLocator *locator = [self locatorForRowid:nextRowid];
-			if (locator)
+			YapDatabaseViewLocator *nextLocator = [self locatorForRowid:nextRowid];
+			if (nextLocator)
 			{
-				index = locator.index;
+				index = nextLocator.index;
 				break;
 			}
 		}


### PR DESCRIPTION
While the „Hidden Local Variables“ setting is turned off by default it’s better to give the variables slightly more descriptive names.

We are compiling some files of YapDatabase directly in our app and we have the warning enabled. This commit doesn't change anything other than renaming the variables.