### PR TITLE
Make -initWithReachabilityRef: retain the ref argument, fixing a Clang analyzer warning.

### DIFF
--- a/YapDatabase/Extensions/ActionManager/Utilities/YapReachability.m
+++ b/YapDatabase/Extensions/ActionManager/Utilities/YapReachability.m
@@ -116,6 +116,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     if (ref) 
     {
         id reachability = [[self alloc] initWithReachabilityRef:ref];
+        CFRelease(ref);
 
         return reachability;
     }
@@ -129,6 +130,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     if (ref) 
     {
         id reachability = [[self alloc] initWithReachabilityRef:ref];
+        CFRelease(ref);
         
         return reachability;
     }
@@ -167,7 +169,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     if (self != nil) 
     {
         self.reachableOnWWAN = YES;
-        self.reachabilityRef = ref;
+        self.reachabilityRef = CFRetain(ref);
 
         // We need to create a serial queue.
         // We allocate this once for the lifetime of the notifier.


### PR DESCRIPTION
Without this Clang shows an analyzer warning that after calling -initWithReachabilityRef: the ref should be released. Because -initWithReachabilityRef: doesn’t retain the argument, this would result in a dangling pointer.

Warning: This change fixes the issue in YapDatabase internally, but it introduces a memory leak for consumers that are currently using -initWithReachabilityRef without releasing the ref.

<img width="1835" alt="analyzer" src="https://user-images.githubusercontent.com/143137/28033902-f597e994-65af-11e7-96aa-59fc4a1e054b.png">