### PR TITLE
Fixed FTS extension repeatedly reindexing

### DIFF
--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
@@ -108,6 +108,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 			if (![self populate]) return NO;
 			
 			[self setStringValue:versionTag forExtensionKey:ext_key__versionTag persistent:YES];
+			[self setStringValue:ftsVersion forExtensionKey:ext_key__ftsVersion persistent:YES];
 			
 			if (hasOldVersion_deprecated)
 				[self removeValueForExtensionKey:ext_key__version_deprecated persistent:YES];


### PR DESCRIPTION
The changes introduced in e8371ad93dba8de9aca3a1c88f51f69ffc5a40ce were causing existing databases to reindex the entire database with FTS every time the database was loaded.

Setting ftsVersion when upgrading the extension version ensures that the reindex only occurs once.