### PR TITLE
Charlesmchen/unencrypted headers

### DIFF
--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
@@ -4,6 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#ifdef SQLITE_HAS_CODEC
+
 extern const NSUInteger kSqliteHeaderLength;
 extern const NSUInteger kSQLCipherSaltLength;
 extern const NSUInteger kSQLCipherDerivedKeyLength;
@@ -12,24 +14,136 @@ extern const NSUInteger kSQLCipherKeySpecLength;
 typedef void (^YapDatabaseSaltBlock)(NSData *saltData);
 typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 
-// Used to convert YapDatabase/SQLCipher databases whose header is encrypted
-// to databases whose first 32 bytes are unencrypted so that iOS can determine
-// that this is a SQLite database using WAL and therefore not terminate the app
-// when it is suspended.
+// This class contains utility methods for use with SQLCipher encrypted
+// databases, specifically to address an issue around database files that
+// reside in the "shared data container" used to share files between
+// iOS main apps and their app extensions.
 //
-// See comments in YapDatabaseOptions for more details.
+//
+// The Issue
+//
+// iOS will terminate suspended apps which hold a file lock on files in the shared
+// container.  An exception is made for certain kinds of Sqlite files, so that iOS apps
+// can share databases with their app extensions.  Unfortunately, this exception does
+// not apply for SQLCipher databases which have encrypted the Sqlite file header,
+// which is the default behavior of SQLCipher. Therefore apps which try to share an
+// SQLCipher database with their app extensions and use WAL (write-ahead logging) will
+// be terminated whenever they are sent to the background (0x10deadcc terminations).
+//
+// * YapDatabase always uses WAL.
+// * This issue seems to affect all versions of iOS and all device models.
+// * iOS only terminates apps for this reason when app transition from the `background`
+//   to `suspended` states.  iOS main apps can delay being suspended by creating a
+//   "background task", but this only defers the issue briefly as there are strict
+//   limits on the duration of "background tasks".
+// * `0xdead10cc` terminations don't occur in the simulator and won't occur on devices
+//   if the debugger is attached.
+// * These `0xdead10cc` terminations usually don't yield crash logs on the device, but
+//   always show up in the device console logs.
+//
+// See:
+//
+// * https://developer.apple.com/library/content/technotes/tn2408/_index.html
+// * References to 0x10deadcc in https://developer.apple.com/library/content/technotes/tn2151/_index.html
+//
+//
+// Solution
+//
+// The solution is to have SQLCipher encrypt everything _except_ the first 32 bytes of
+// the Sqlite file, which corresponds to the first part of the Sqlite header.  This is
+// accomplished using the cipher_plaintext_header_size PRAGMA.
+//
+// The header does not contain any user data.  See:
+// https://www.sqlite.org/fileformat.html#the_database_header
+//
+// However, Sqlite normally uses the first 16 bytes of the Sqlite header to store
+// a salt value.  Therefore when using unencrypted headers, it is also necessary
+// to explicitly specify a salt value.
+//
+// It is possible to convert SQLCipher databases with encrypted headers to use
+// unencrypted headers.  However, during this conversion, the salt must be extracted
+// and preserved by reading the first 16 bytes of the unconverted file.
+//
+//
+// Implementation
+//
+// To open (a new or existing) YapDatabase using unencrypted headers, you have two
+// options:
+//
+// Option A:
+//
+// * Use cipherKeyBlock as usual to specify the database password.
+// * Use cipherSaltBlock to specify the database salt. It should be kSQLCipherSaltLength long.
+// * Use cipherUnencryptedHeaderLength to specify how many bytes to leave unencrypted.
+//   This should be kSqliteHeaderLength.
+// * Do not use a cipherKeySpecBlock.
+//
+// Option B:
+//
+// * Use cipherKeySpecBlock to specify the database key spec. It should be kSQLCipherKeySpecLength long.
+// * Use cipherUnencryptedHeaderLength to specify how many bytes to leave unencrypted.
+//   This should be kSqliteHeaderLength.
+// * The "key spec" includes the key derived from the database password and the salt,
+//   so do not use a cipherKeyBlock or cipherSaltBlock.
+//
+// Option B is more performant than Option A and is therefore recommended.
+//
+//
+// Upgrading legacy databases to use unencrypted headers:
+//
+// * Call the convertDatabaseIfNecessary method of this class _before_
+//   trying to open any YapDatabase that may need to be converted.
+// * This method will have no effect if the YapDatabase has already been converted.
+// * This method should always be pretty fast, and should be safe to
+//   call from within [UIApplicationDelegate application: didFinishLaunchingWithOptions:].
+// * If convertDatabaseIfNecessary converts the database, it will use its
+//   saltBlock and keySpecBlock parameters to inform you of the salt
+//   and keyspec for this database.  These values will be needed when
+//   opening the database, so they should presumably stored in the
+//   keychain (like the database password).
+//
+//
+// Creating new databases with unencrypted headers:
+//
+// * Randomly generate a database password and salt, presumably using SecRandomCopyBytes().
+// * Derive a keyspec using databaseKeySpecForPassword:.
+// * You probably should store these values in the keychain.
+//
+//
+// Note and Disclaimer
+//
+// There is no authoritative documentation from Apple about iOS' usage of the Sqlite
+// file header to make an exception for suspended apps with a file lock on database
+// files in the shared container.  Our usage of the first 32 bytes as being sufficient
+// is only empirical.
 @interface YapDatabaseCryptoUtils : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 
+// Returns YES IFF the database appears to have encrypted headers.
 + (BOOL)doesDatabaseNeedToBeConverted:(NSString *)databaseFilePath;
 
+// * Call the convertDatabaseIfNecessary method of this class _before_
+//   trying to open any YapDatabase that may need to be converted.
+// * This method will have no effect if the YapDatabase has already been converted.
+// * This method should always be pretty fast, and should be safe to
+//   call from within [UIApplicationDelegate application: didFinishLaunchingWithOptions:].
+// * If convertDatabaseIfNecessary converts the database, it will use its
+//   saltBlock and keySpecBlock parameters to inform you of the salt
+//   and keyspec for this database.  These values will be needed when
+//   opening the database, so they should presumably stored in the
+//   keychain (like the database password).
 + (nullable NSError *)convertDatabaseIfNecessary:(NSString *)databaseFilePath
                                 databasePassword:(NSData *)databasePassword
                                        saltBlock:(YapDatabaseSaltBlock)saltBlock
                                     keySpecBlock:(YapDatabaseKeySpecBlock)keySpecBlock;
 
-+ (nullable NSData *)deriveDatabaseKeyForPassword:(NSData *)passwordData saltData:(NSData *)saltData;
+// This method can be used to derive a SQLCipher "key spec" from a
+// database password and salt.  Key spec derivation is somewhat costly.
+// The key spec is needed every time the database file is opened
+// (including every time YapDatabse makes a new database connection),
+// So it benefits performance to pass a pre-derived key spec to
+// YapDatabase.
 + (nullable NSData *)databaseKeySpecForPassword:(NSData *)passwordData saltData:(NSData *)saltData;
 
 #pragma mark - Utils
@@ -37,5 +151,7 @@ typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 + (NSString *)hexadecimalStringForData:(NSData *)data;
 
 @end
+
+#endif
 
 NS_ASSUME_NONNULL_END

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
@@ -1,0 +1,41 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern const NSUInteger kSqliteHeaderLength;
+extern const NSUInteger kSQLCipherSaltLength;
+extern const NSUInteger kSQLCipherDerivedKeyLength;
+extern const NSUInteger kSQLCipherKeySpecLength;
+
+typedef void (^YapDatabaseSaltBlock)(NSData *saltData);
+typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
+
+// Used to convert YapDatabase/SQLCipher databases whose header is encrypted
+// to databases whose first 32 bytes are unencrypted so that iOS can determine
+// that this is a SQLite database using WAL and therefore not terminate the app
+// when it is suspended.
+//
+// See comments in YapDatabaseOptions for more details.
+@interface YapDatabaseCryptoUtils : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (BOOL)doesDatabaseNeedToBeConverted:(NSString *)databaseFilePath;
+
++ (nullable NSError *)convertDatabaseIfNecessary:(NSString *)databaseFilePath
+                                databasePassword:(NSData *)databasePassword
+                                       saltBlock:(YapDatabaseSaltBlock)saltBlock
+                                    keySpecBlock:(YapDatabaseKeySpecBlock)keySpecBlock;
+
++ (nullable NSData *)deriveDatabaseKeyForPassword:(NSData *)passwordData saltData:(NSData *)saltData;
++ (nullable NSData *)databaseKeySpecForPassword:(NSData *)passwordData saltData:(NSData *)saltData;
+
+#pragma mark - Utils
+
++ (NSString *)hexadecimalStringForData:(NSData *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#ifdef SQLITE_HAS_CODEC
+
 #if DEBUG
 static const int ydbLogLevel = YDB_LOG_LEVEL_INFO;
 #else
@@ -488,5 +490,7 @@ NSError *YDBErrorWithDescription(NSString *description)
 }
 
 @end
+
+#endif
 
 NS_ASSUME_NONNULL_END

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
@@ -1,0 +1,492 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+#import "YapDatabaseCryptoUtils.h"
+#import "YapDatabase.h"
+#import "YapDatabaseLogging.h"
+#import "sqlite3.h"
+#import <CommonCrypto/CommonCrypto.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if DEBUG
+static const int ydbLogLevel = YDB_LOG_LEVEL_INFO;
+#else
+static const int ydbLogLevel = YDB_LOG_LEVEL_WARN;
+#endif
+#pragma unused(ydbLogLevel)
+
+#ifdef DEBUG
+
+#define USE_ASSERTS
+
+#define YAP_CONVERT_TO_STRING(X) #X
+#define YAP_CONVERT_EXPR_TO_STRING(X) YAP_CONVERT_TO_STRING(X)
+
+// YapAssert() and YapFail() should be used in Obj-C methods.
+// YapCAssert() and YapCFail() should be used in free functions.
+
+#define YapAssert(X)                                                                                                   \
+if (!(X)) {                                                                                                        \
+YDBLogError(@"%s Assertion failed: %s", __PRETTY_FUNCTION__, YAP_CONVERT_EXPR_TO_STRING(X));                        \
+[DDLog flushLog];                                                                                              \
+NSAssert(0, @"Assertion failed: %s", YAP_CONVERT_EXPR_TO_STRING(X));                                               \
+}
+
+#define YapCAssert(X)                                                                                                  \
+if (!(X)) {                                                                                                        \
+YDBLogError(@"%s Assertion failed: %s", __PRETTY_FUNCTION__, YAP_CONVERT_EXPR_TO_STRING(X));                        \
+[DDLog flushLog];                                                                                              \
+NSCAssert(0, @"Assertion failed: %s", YAP_CONVERT_EXPR_TO_STRING(X));                                              \
+}
+
+#define YapFail(message, ...)                                                                                          \
+{                                                                                                                  \
+NSString *formattedMessage = [NSString stringWithFormat:message, ##__VA_ARGS__];                               \
+YDBLogError(@"%s %@", __PRETTY_FUNCTION__, formattedMessage);                                                   \
+[DDLog flushLog];                                                                                              \
+NSAssert(0, formattedMessage);                                                                                 \
+}
+
+#define YapCFail(message, ...)                                                                                         \
+{                                                                                                                  \
+NSString *formattedMessage = [NSString stringWithFormat:message, ##__VA_ARGS__];                               \
+YDBLogError(@"%s %@", __PRETTY_FUNCTION__, formattedMessage);                                                   \
+[DDLog flushLog];                                                                                              \
+NSCAssert(0, formattedMessage);                                                                                \
+}
+
+#define YapFailNoFormat(message)                                                                                       \
+{                                                                                                                  \
+YDBLogError(@"%s %@", __PRETTY_FUNCTION__, message);                                                            \
+[DDLog flushLog];                                                                                              \
+NSAssert(0, message);                                                                                          \
+}
+
+#define YapCFailNoFormat(message)                                                                                      \
+{                                                                                                                  \
+YDBLogError(@"%s %@", __PRETTY_FUNCTION__, message);                                                            \
+[DDLog flushLog];                                                                                              \
+NSCAssert(0, message);                                                                                         \
+}
+
+#else
+
+#define YapAssert(X)
+#define YapCAssert(X)
+#define YapFail(message, ...)
+#define YapCFail(message, ...)
+#define YapFailNoFormat(X)
+#define YapCFailNoFormat(X)
+
+#endif
+
+const NSUInteger kSqliteHeaderLength = 32;
+const NSUInteger kSQLCipherSaltLength = 16;
+const NSUInteger kSQLCipherDerivedKeyLength = 32;
+const NSUInteger kSQLCipherKeySpecLength = 48;
+
+NSString *const YapDatabaseErrorDomain = @"YapDatabaseErrorDomain";
+
+NSError *YDBErrorWithDescription(NSString *description)
+{
+    return [NSError errorWithDomain:YapDatabaseErrorDomain
+                               code:0
+                           userInfo:@{ NSLocalizedDescriptionKey: description }];
+}
+
+//@interface YapStorage (YapDatabaseCryptoUtils)
+//
+//+ (YapDatabaseDeserializer)logOnFailureDeserializer;
+//
+//@end
+
+#pragma mark -
+
+@implementation YapDatabaseCryptoUtils
+
++ (NSData *)readFirstNBytesOfDatabaseFile:(NSString *)filePath byteCount:(NSUInteger)byteCount
+{
+    YapAssert(filePath.length > 0);
+
+    @autoreleasepool {
+        NSError *error;
+        // We use NSDataReadingMappedAlways instead of NSDataReadingMappedIfSafe because
+        // we know the database will always exist for the duration of this instance of NSData.
+        NSData *_Nullable data = [NSData dataWithContentsOfURL:[NSURL fileURLWithPath:filePath]
+                                                       options:NSDataReadingMappedAlways
+                                                         error:&error];
+        if (!data || error) {
+            YDBLogError(@"%@ Couldn't read database file header.", self.logTag);
+            // TODO: Make a convenience method (on a category of NSException?) that
+            // flushes YDBLog before raising a terminal exception.
+            [NSException raise:@"Couldn't read database file header" format:@""];
+        }
+        // Pull this constant out so that we can use it in our YapDatabase fork.
+        NSData *_Nullable headerData = [data subdataWithRange:NSMakeRange(0, byteCount)];
+        if (!headerData || headerData.length != byteCount) {
+            [NSException raise:@"Database file header has unexpected length"
+                        format:@"Database file header has unexpected length: %zd", headerData.length];
+        }
+        return [headerData copy];
+    }
+}
+
++ (BOOL)doesDatabaseNeedToBeConverted:(NSString *)databaseFilePath
+{
+    YapAssert(databaseFilePath.length > 0);
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:databaseFilePath]) {
+        YDBLogVerbose(@"%@ database file not found.", self.logTag);
+        return nil;
+    }
+
+    NSData *headerData = [self readFirstNBytesOfDatabaseFile:databaseFilePath byteCount:kSqliteHeaderLength];
+    YapAssert(headerData);
+
+    NSString *kUnencryptedHeader = @"SQLite format 3\0";
+    NSData *unencryptedHeaderData = [kUnencryptedHeader dataUsingEncoding:NSUTF8StringEncoding];
+    BOOL isUnencrypted = [unencryptedHeaderData
+        isEqualToData:[headerData subdataWithRange:NSMakeRange(0, unencryptedHeaderData.length)]];
+    if (isUnencrypted) {
+        YDBLogVerbose(@"%@ doesDatabaseNeedToBeConverted; legacy database header already decrypted.", self.logTag);
+        return NO;
+    }
+
+    return YES;
+}
+
+// TODO upon failure show user error UI
+// TODO upon failure anything we need to do "back out" partial migration
++ (nullable NSError *)convertDatabaseIfNecessary:(NSString *)databaseFilePath
+                                databasePassword:(NSData *)databasePassword
+                                       saltBlock:(YapDatabaseSaltBlock)saltBlock
+                                    keySpecBlock:(YapDatabaseKeySpecBlock)keySpecBlock
+{
+    if (![self doesDatabaseNeedToBeConverted:databaseFilePath]) {
+        return nil;
+    }
+
+    return [self convertDatabase:databaseFilePath
+                databasePassword:databasePassword
+                       saltBlock:saltBlock
+                    keySpecBlock:keySpecBlock];
+}
+
++ (nullable NSError *)convertDatabase:(NSString *)databaseFilePath
+                     databasePassword:(NSData *)databasePassword
+                            saltBlock:(YapDatabaseSaltBlock)saltBlock
+                         keySpecBlock:(YapDatabaseKeySpecBlock)keySpecBlock
+{
+    YapAssert(databaseFilePath.length > 0);
+    YapAssert(databasePassword.length > 0);
+    YapAssert(saltBlock);
+    YapAssert(keySpecBlock);
+
+    NSData *saltData;
+    {
+        NSData *headerData = [self readFirstNBytesOfDatabaseFile:databaseFilePath byteCount:kSqliteHeaderLength];
+        YapAssert(headerData);
+
+        YapAssert(headerData.length >= kSQLCipherSaltLength);
+        saltData = [headerData subdataWithRange:NSMakeRange(0, kSQLCipherSaltLength)];
+
+        // Make sure we successfully persist the salt (persumably in the keychain) before
+        // proceeding with the database conversion or we could leave the app in an
+        // unrecoverable state.
+        saltBlock(saltData);
+    }
+
+    {
+        NSData *_Nullable keySpecData = [self databaseKeySpecForPassword:databasePassword saltData:saltData];
+        if (!keySpecData || keySpecData.length != kSQLCipherKeySpecLength) {
+            YDBLogError(@"Error deriving key spec");
+            return YDBErrorWithDescription(@"Invalid key spec");
+        }
+
+        YapAssert(keySpecData.length == kSQLCipherKeySpecLength);
+
+        // Make sure we successfully persist the key spec (persumably in the keychain) before
+        // proceeding with the database conversion or we could leave the app in an
+        // unrecoverable state.
+        keySpecBlock(keySpecData);
+    }
+
+    // -----------------------------------------------------------
+    //
+    // This block was derived from [Yapdatabase openDatabase].
+    sqlite3 *db;
+    int status;
+    {
+        int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_PRIVATECACHE;
+        status = sqlite3_open_v2([databaseFilePath UTF8String], &db, flags, NULL);
+        if (status != SQLITE_OK) {
+            // There are a few reasons why the database might not open.
+            // One possibility is if the database file has become corrupt.
+
+            // Sometimes the open function returns a db to allow us to query it for the error message.
+            // The openConfigCreate block will close it for us.
+            if (db) {
+                YDBLogError(@"Error opening database: %d %s", status, sqlite3_errmsg(db));
+            } else {
+                YDBLogError(@"Error opening database: %d", status);
+            }
+
+            return YDBErrorWithDescription(@"Failed to open database");
+        }
+    }
+
+    // -----------------------------------------------------------
+    //
+    // This block was derived from [Yapdatabase configureEncryptionForDatabase].
+    {
+        NSData *keyData = databasePassword;
+
+        status = sqlite3_key(db, [keyData bytes], (int)[keyData length]);
+        if (status != SQLITE_OK) {
+            YDBLogError(@"Error setting SQLCipher key: %d %s", status, sqlite3_errmsg(db));
+            return YDBErrorWithDescription(@"Failed to set SQLCipher key");
+        }
+    }
+
+    // -----------------------------------------------------------
+    //
+    // This block was derived from [Yapdatabase configureDatabase].
+    {
+        NSError *_Nullable error = [self executeSql:@"PRAGMA journal_mode = WAL;"
+                                                 db:db
+                                              label:@"PRAGMA journal_mode = WAL"];
+        if (error) {
+            return error;
+        }
+
+        // TODO verify we need to do this.
+        // Set synchronous to normal for THIS sqlite instance.
+        //
+        // This does NOT affect normal connections.
+        // That is, this does NOT affect YapDatabaseConnection instances.
+        // The sqlite connections of normal YapDatabaseConnection instances will follow the set pragmaSynchronous value.
+        //
+        // The reason we hardcode normal for this sqlite instance is because
+        // it's only used to write the initial snapshot value.
+        // And this doesn't need to be durable, as it is initialized to zero everytime.
+        //
+        // (This sqlite db is also used to perform checkpoints.
+        //  But a normal value won't affect these operations,
+        //  as they will perform sync operations whether the connection is normal or full.)
+        
+        error = [self executeSql:@"PRAGMA synchronous = NORMAL;"
+                              db:db
+                           label:@"PRAGMA synchronous = NORMAL"];
+        // Any error isn't critical, so we can continue.
+
+        // Set journal_size_imit.
+        //
+        // We only need to do set this pragma for THIS connection,
+        // because it is the only connection that performs checkpoints.
+
+        NSInteger defaultPragmaJournalSizeLimit = 0;
+        NSString *pragma_journal_size_limit =
+            [NSString stringWithFormat:@"PRAGMA journal_size_limit = %ld;", (long)defaultPragmaJournalSizeLimit];
+        error = [self executeSql:pragma_journal_size_limit
+                                                 db:db
+                                              label:@"PRAGMA journal_size_limit"];
+        // Any error isn't critical, so we can continue.
+
+        // Disable autocheckpointing.
+        //
+        // YapDatabase has its own optimized checkpointing algorithm built-in.
+        // It knYap the state of every active connection for the database,
+        // so it can invoke the checkpoint methods at the precise time in which a checkpoint can be most effective.
+        sqlite3_wal_autocheckpoint(db, 0);
+
+        // END DB setup copied from YapDatabase
+        // BEGIN SQLCipher migration
+    }
+
+#ifdef DEBUG
+    // We can obtain the database salt in two ways: by reading the first 16 bytes of the encrypted
+    // header OR by using "PRAGMA cipher_salt".  In DEBUG builds, we verify that these two values
+    // match.
+    {
+        NSString *_Nullable saltString =
+            [self executeSingleStringQuery:@"PRAGMA cipher_salt;" db:db label:@"extracting database salt"];
+
+        YapAssert([[self hexadecimalStringForData:saltData] isEqualToString:saltString]);
+    }
+#endif
+
+    // -----------------------------------------------------------
+    //
+    // SQLCipher migration
+    {
+        NSString *setPlainTextHeaderPragma =
+        [NSString stringWithFormat:@"PRAGMA cipher_plaintext_header_size = %zd;", kSqliteHeaderLength];
+        NSError *_Nullable error = [self executeSql:setPlainTextHeaderPragma
+                                                 db:db
+                                              label:setPlainTextHeaderPragma];
+        if (error) {
+            return error;
+        }
+
+        // Modify the first page, so that SQLCipher will overwrite, respecting our new cipher_plaintext_header_size
+        NSString *tableName = [NSString stringWithFormat:@"signal-migration-%@", [NSUUID new].UUIDString];
+        NSString *modificationSQL =
+        [NSString stringWithFormat:@"CREATE TABLE \"%@\"(a integer); INSERT INTO \"%@\"(a) VALUES (1);",
+         tableName,
+         tableName];
+        error = [self executeSql:modificationSQL
+                              db:db
+                           label:modificationSQL];
+        if (error) {
+            return error;
+        }
+
+        // Force a checkpoint so that the plaintext is written to the actual DB file, not just living in the WAL.
+        int log, ckpt;
+        status = sqlite3_wal_checkpoint_v2(db, NULL, SQLITE_CHECKPOINT_FULL, &log, &ckpt);
+        if (status != SQLITE_OK) {
+            YDBLogError(@"%@ Error forcing checkpoint. status: %d, log: %d, ckpt: %d, error: %s", self.logTag, status, log, ckpt, sqlite3_errmsg(db));
+            return YDBErrorWithDescription(@"Error forcing checkpoint.");
+        }
+
+        sqlite3_close(db);
+    }
+
+    return nil;
+}
+
++ (nullable NSError *)executeSql:(NSString *)sql
+                              db:(sqlite3 *)db
+                           label:(NSString *)label
+{
+    YapAssert(db);
+    YapAssert(sql.length > 0);
+    
+    int status = sqlite3_exec(db, [sql UTF8String], NULL, NULL, NULL);
+    if (status != SQLITE_OK) {
+        YDBLogError(@"Error %@: status: %d, error: %s",
+                   label,
+                   status,
+                   sqlite3_errmsg(db));
+        return YDBErrorWithDescription([NSString stringWithFormat:@"Failed to set %@", label]);
+    }
+    return nil;
+}
+
++ (nullable NSString *)executeSingleStringQuery:(NSString *)sql db:(sqlite3 *)db label:(NSString *)label
+{
+    sqlite3_stmt *statement;
+
+    int status = sqlite3_prepare_v2(db, sql.UTF8String, -1, &statement, NULL);
+    if (status != SQLITE_OK) {
+        YDBLogError(@"%@ Error %@: %d, error: %s", self.logTag, label, status, sqlite3_errmsg(db));
+        return nil;
+    }
+
+    status = sqlite3_step(statement);
+    if (status != SQLITE_ROW) {
+        YDBLogError(@"%@ Missing %@: %d, error: %s", self.logTag, label, status, sqlite3_errmsg(db));
+        return nil;
+    }
+
+    const unsigned char *valueBytes = sqlite3_column_text(statement, 0);
+    int valueLength = sqlite3_column_bytes(statement, 0);
+    YapAssert(valueLength == kSqliteHeaderLength);
+    YapAssert(valueBytes != NULL);
+
+    NSString *result =
+        [[NSString alloc] initWithBytes:valueBytes length:(NSUInteger)valueLength encoding:NSUTF8StringEncoding];
+
+    sqlite3_finalize(statement);
+    statement = NULL;
+
+    return result;
+}
+
++ (nullable NSData *)deriveDatabaseKeyForPassword:(NSData *)passwordData saltData:(NSData *)saltData
+{
+    YapAssert(passwordData.length > 0);
+    YapAssert(saltData.length == kSQLCipherSaltLength);
+
+    unsigned char *derivedKeyBytes = malloc((size_t)kSQLCipherDerivedKeyLength);
+    YapAssert(derivedKeyBytes);
+    // See: PBKDF2_ITER.
+    const unsigned int workfactor = 64000;
+
+    int result = CCKeyDerivationPBKDF(kCCPBKDF2,
+        passwordData.bytes,
+        (size_t)passwordData.length,
+        saltData.bytes,
+        (size_t)saltData.length,
+        kCCPRFHmacAlgSHA1,
+        workfactor,
+        derivedKeyBytes,
+        kSQLCipherDerivedKeyLength);
+    if (result != kCCSuccess) {
+        YDBLogError(@"Error deriving key: %d", result);
+        return nil;
+    }
+
+    NSData *_Nullable derivedKeyData = [NSData dataWithBytes:derivedKeyBytes length:kSQLCipherDerivedKeyLength];
+    if (!derivedKeyData || derivedKeyData.length != kSQLCipherDerivedKeyLength) {
+        YDBLogError(@"Invalid derived key: %d", result);
+        return nil;
+    }
+
+    return derivedKeyData;
+}
+
++ (nullable NSData *)databaseKeySpecForPassword:(NSData *)passwordData saltData:(NSData *)saltData
+{
+    YapAssert(passwordData.length > 0);
+    YapAssert(saltData.length == kSQLCipherSaltLength);
+
+    NSData *_Nullable derivedKeyData = [self deriveDatabaseKeyForPassword:passwordData saltData:saltData];
+    if (!derivedKeyData || derivedKeyData.length != kSQLCipherDerivedKeyLength) {
+        YDBLogError(@"Error deriving key");
+        return nil;
+    }
+    NSMutableData *keySpecData = [NSMutableData new];
+    [keySpecData appendData:derivedKeyData];
+    [keySpecData appendData:saltData];
+
+    YapAssert(keySpecData.length == kSQLCipherKeySpecLength);
+
+    return keySpecData;
+}
+
+#pragma mark - Utils
+
++ (NSString *)hexadecimalStringForData:(NSData *)data {
+    /* Returns hexadecimal string of NSData. Empty string if data is empty. */
+    const unsigned char *dataBuffer = (const unsigned char *)[data bytes];
+    if (!dataBuffer) {
+        return @"";
+    }
+    
+    NSUInteger dataLength = [data length];
+    NSMutableString *hexString = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    
+    for (NSUInteger i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", dataBuffer[i]];
+    }
+    return [hexString copy];
+}
+
+#pragma mark - Logging
+
++ (NSString *)logTag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)logTag
+{
+    return self.class.logTag;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
@@ -114,6 +114,8 @@ NSError *YDBErrorWithDescription(NSString *description)
 
     @autoreleasepool {
         NSError *error;
+        // Use memory-mapped NSData to avoid reading the entire file into memory.
+        //
         // We use NSDataReadingMappedAlways instead of NSDataReadingMappedIfSafe because
         // we know the database will always exist for the duration of this instance of NSData.
         NSData *_Nullable data = [NSData dataWithContentsOfURL:[NSURL fileURLWithPath:filePath]

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -3243,4 +3243,24 @@ static int connectionBusyHandler(void *ptr, int count) {
 	}
 }
 
+#ifdef DEBUG
+
+// This method is only used by tests.
+- (void)flushInternalQueue
+{
+    dispatch_sync(internalQueue,
+                  ^{
+                  });
+}
+
+// This method is only used by tests.
+- (void)flushCheckpointQueue
+{
+    dispatch_sync(checkpointQueue,
+                  ^{
+                  });
+}
+
+#endif
+
 @end

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -830,37 +830,6 @@ static int connectionBusyHandler(void *ptr, int count) {
 			return NO;
 		}
         
-//        BOOL hasUnencryptedHeader = NO;
-//        if (!options.cipherSaltBlock &&
-//            options.cipherUnencryptedHeaderLength == 0) {
-//            // Custom salt + unencrypted header not activated.
-//        } else if (options.cipherSaltBlock &&
-//                   options.cipherUnencryptedHeaderLength > 0) {
-//            NSData *_Nullable saltData = options.cipherSaltBlock();
-//
-//            if (saltData == nil)
-//            {
-//                NSAssert(NO, @"YapDatabaseOptions.cipherSaltBlock cannot return nil!");
-//                return NO;
-//            }
-//
-//            char *errorMsg;
-//            // Example: PRAGMA cipher_salt = "x'01010101010101010101010101010101';";
-//            NSString *cipherSaltPragma = [NSString stringWithFormat:@"PRAGMA cipher_salt = \"%@\";", [self hexadecimalStringForData:saltData]];
-//            // TODO: Remove.
-//            YDBLogError(@"cipherSaltPragma: %@", cipherSaltPragma);
-//            if (sqlite3_exec(sqlite, [cipherSaltPragma UTF8String], NULL, NULL, &errorMsg) != SQLITE_OK)
-//            {
-//                YDBLogError(@"failed to set database cipher_default_kdf_iter: %s", errorMsg);
-//                return NO;
-//            }
-//
-//            hasUnencryptedHeader = YES;
-//        } else {
-//            NSAssert(NO, @"Either both YapDatabaseOptions.cipherSaltBlock and YapDatabaseOptions.cipherUnencryptedHeaderLength should be set or neither should be set!");
-//            return NO;
-//        }
-
         //Setting the PBKDF2 default iteration number (this will have effect next time database is opened)
         if (options.cipherDefaultkdfIterNumber > 0) {
             char *errorMsg;
@@ -901,7 +870,6 @@ static int connectionBusyHandler(void *ptr, int count) {
 			return NO;
 		}
         
-        BOOL hasUnencryptedHeader = NO;
         if (!options.cipherSaltBlock &&
             options.cipherUnencryptedHeaderLength == 0) {
             // Custom salt + unencrypted header not activated.
@@ -915,37 +883,47 @@ static int connectionBusyHandler(void *ptr, int count) {
                 return NO;
             }
             
-            char *errorMsg;
-            // Example: PRAGMA cipher_salt = "x'01010101010101010101010101010101';";
-            NSString *cipherSaltPragma = [NSString stringWithFormat:@"PRAGMA cipher_salt = \"%@\";", [self hexadecimalStringForData:saltData]];
-            // TODO: Remove.
-            YDBLogError(@"cipherSaltPragma: %@", cipherSaltPragma);
-            if (sqlite3_exec(sqlite, [cipherSaltPragma UTF8String], NULL, NULL, &errorMsg) != SQLITE_OK)
             {
-                YDBLogError(@"failed to set database cipher_default_kdf_iter: %s", errorMsg);
-                return NO;
+                char *errorMsg;
+                // Example: PRAGMA cipher_salt = "x'01010101010101010101010101010101';";
+                NSString *pragmaSql = [NSString stringWithFormat:@"PRAGMA cipher_salt = \"x'%@'\";", [self hexadecimalStringForData:saltData]];
+                if (sqlite3_exec(sqlite, [pragmaSql UTF8String], NULL, NULL, &errorMsg) != SQLITE_OK)
+                {
+                    YDBLogError(@"failed to set database cipher_default_kdf_iter: %s", errorMsg);
+                    return NO;
+                }
             }
             
-            hasUnencryptedHeader = YES;
+            {
+                
+                NSString *pragmaSql =
+                [NSString stringWithFormat:@"PRAGMA cipher_plaintext_header_size = %zd;", options.cipherUnencryptedHeaderLength];
+                int status = sqlite3_exec(db, [pragmaSql UTF8String], NULL, NULL, NULL);
+                if (status != SQLITE_OK) {
+                    YDBLogError(@"Error setting PRAGMA cipher_plaintext_header_size = %zd: status: %d, error: %s",
+                                options.cipherUnencryptedHeaderLength,
+                                status,
+                                sqlite3_errmsg(db));
+                    return NO;
+                }
+            }
+
+            {
+                
+                NSString *pragmaSql =
+                [NSString stringWithFormat:@"PRAGMA cipher_default_plaintext_header_size = %zd;", options.cipherUnencryptedHeaderLength];
+                int status = sqlite3_exec(db, [pragmaSql UTF8String], NULL, NULL, NULL);
+                if (status != SQLITE_OK) {
+                    YDBLogError(@"Error setting PRAGMA cipher_default_plaintext_header_size = %zd: status: %d, error: %s",
+                                options.cipherUnencryptedHeaderLength,
+                                status,
+                                sqlite3_errmsg(db));
+                    return NO;
+                }
+            }
         } else {
             NSAssert(NO, @"Either both YapDatabaseOptions.cipherSaltBlock and YapDatabaseOptions.cipherUnencryptedHeaderLength should be set or neither should be set!");
             return NO;
-        }
-        
-        if (hasUnencryptedHeader) {
-            
-            NSString *setPlainTextHeaderPragma =
-            [NSString stringWithFormat:@"PRAGMA cipher_plaintext_header_size = %zd;", options.cipherUnencryptedHeaderLength];
-            // TODO: Remove.
-            YDBLogError(@"setPlainTextHeaderPragma: %@", setPlainTextHeaderPragma);
-            int status = sqlite3_exec(db, [setPlainTextHeaderPragma UTF8String], NULL, NULL, NULL);
-            if (status != SQLITE_OK) {
-                YDBLogError(@"Error setting PRAGMA cipher_plaintext_header_size = %zd: status: %d, error: %s",
-                            options.cipherUnencryptedHeaderLength,
-                            status,
-                            sqlite3_errmsg(db));
-                return NO;
-            }
         }
 	}
 	

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -902,9 +902,9 @@ static int connectionBusyHandler(void *ptr, int count) {
              options.cipherSaltBlock)) {
              
             if (options.cipherKeySpecBlock) {
-                YDBLogInfo(@"YapDatabase using cipher key spec and unencrypted header.");
+                // YapDatabase using cipher key spec and unencrypted header.
             } else {
-                YDBLogInfo(@"YapDatabase using cipher salt and unencrypted header.");
+                // YapDatabase using cipher salt and unencrypted header.
                 
                 NSData *_Nullable saltData = options.cipherSaltBlock();
                 

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -875,6 +875,9 @@ static int connectionBusyHandler(void *ptr, int count) {
             // Custom salt + unencrypted header not activated.
         } else if (options.cipherSaltBlock &&
                    options.cipherUnencryptedHeaderLength > 0) {
+            
+            YDBLogInfo(@"YapDatabase using cipher salt and unencrypted header.");
+            
             NSData *_Nullable saltData = options.cipherSaltBlock();
             
             if (saltData == nil)
@@ -895,29 +898,16 @@ static int connectionBusyHandler(void *ptr, int count) {
             }
             
             {
-                
+                // We use cipher_plaintext_header_size NOT cipher_default_plaintext_header_size,
+                // since the _default_ pragma affects a static variable.
                 NSString *pragmaSql =
                 [NSString stringWithFormat:@"PRAGMA cipher_plaintext_header_size = %zd;", options.cipherUnencryptedHeaderLength];
-                int status = sqlite3_exec(db, [pragmaSql UTF8String], NULL, NULL, NULL);
+                int status = sqlite3_exec(sqlite, [pragmaSql UTF8String], NULL, NULL, NULL);
                 if (status != SQLITE_OK) {
                     YDBLogError(@"Error setting PRAGMA cipher_plaintext_header_size = %zd: status: %d, error: %s",
                                 options.cipherUnencryptedHeaderLength,
                                 status,
-                                sqlite3_errmsg(db));
-                    return NO;
-                }
-            }
-
-            {
-                
-                NSString *pragmaSql =
-                [NSString stringWithFormat:@"PRAGMA cipher_default_plaintext_header_size = %zd;", options.cipherUnencryptedHeaderLength];
-                int status = sqlite3_exec(db, [pragmaSql UTF8String], NULL, NULL, NULL);
-                if (status != SQLITE_OK) {
-                    YDBLogError(@"Error setting PRAGMA cipher_default_plaintext_header_size = %zd: status: %d, error: %s",
-                                options.cipherUnencryptedHeaderLength,
-                                status,
-                                sqlite3_errmsg(db));
+                                sqlite3_errmsg(sqlite));
                     return NO;
                 }
             }

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -923,16 +923,17 @@ static int connectionBusyHandler(void *ptr, int count) {
 - (NSString *)hexadecimalStringForData:(NSData *)data {
     /* Returns hexadecimal string of NSData. Empty string if data is empty. */
     const unsigned char *dataBuffer = (const unsigned char *)[data bytes];
-    if (!dataBuffer)
-        return [NSString string];
-    
+    if (!dataBuffer) {
+        return @"";
+    }
+        
     NSUInteger dataLength = [data length];
     NSMutableString *hexString = [NSMutableString stringWithCapacity:(dataLength * 2)];
     
     for (NSUInteger i = 0; i < dataLength; ++i) {
         [hexString appendFormat:@"%02x", dataBuffer[i]];
     }
-    return [NSString stringWithString:hexString];
+    return [hexString copy];
 }
 
 #endif

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -243,10 +243,28 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
 @property (nonatomic, copy, readwrite) YapDatabaseCipherKeyBlock cipherSaltBlock;
 
 /**
+ * Set a block here that returns the key spec (not the key) for the SQLCipher database.
+ *
+ * This key spec incorporates the "derived key" and the "salt".
+ *
+ * This block allows you to fetch the key spec from the keychain (or elsewhere)
+ * only when you need it, instead of persisting it in memory.
+ *
+ * You must use the 'YapDatabase/SQLCipher' subspec
+ * in your Podfile for this option to take effect.
+ *
+ * cipherKeySpecBlock will be ignored if you don't also set cipherUnencryptedHeaderLength.
+ *
+ * See comments on cipherUnencryptedHeaderLength.  These two properties are
+ * intended to be used in conjunction.
+ **/
+@property (nonatomic, copy, readwrite) YapDatabaseCipherKeyBlock cipherKeySpecBlock;
+
+/**
  * If set, this many bytes at the start of the first page of the database will _NOT_
  * be encrypted.
  *
- * This salt that will be passed to SQLCipher via `PRAGMA cipher_plaintext_header_size`.
+ * This value will be passed to SQLCipher via `PRAGMA cipher_plaintext_header_size`.
  *
  * iOS will terminate suspended apps which hold a file lock on files in the shared
  * container.  An exception is made for certain kinds of Sqlite files, so that iOS apps
@@ -273,9 +291,11 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
  * You must use the 'YapDatabase/SQLCipher' subspec
  * in your Podfile for this option to take effect.
  *
- * cipherUnencryptedHeaderLength will be ignored if you don't also set cipherKeyBlock and cipherSaltBlock.
+ * cipherUnencryptedHeaderLength will be ignored if you don't also set
+ * ((cipherKeyBlock AND cipherSaltBlock) OR cipherKeySpecBlock).
  *
- * See comments on cipherSaltBlock.  These two properties are intended to be used in conjunction.
+ * See comments on cipherSaltBlock and cipherKeySpecBlock.  These properties are
+ * intended to be used in conjunction.
  **/
 @property (nonatomic, assign, readwrite) NSUInteger cipherUnencryptedHeaderLength;
 

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -237,8 +237,7 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
  *
  * cipherSaltBlock will be ignored if you don't also set cipherKeyBlock and cipherUnencryptedHeaderLength.
  *
- * See comments on cipherUnencryptedHeaderLength.  These two properties are
- * intended to be used in conjunction.
+ * For more information, see comments in YapDatabaseCryptoUtils.h.
  **/
 @property (nonatomic, copy, readwrite) YapDatabaseCipherKeyBlock cipherSaltBlock;
 
@@ -255,8 +254,7 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
  *
  * cipherKeySpecBlock will be ignored if you don't also set cipherUnencryptedHeaderLength.
  *
- * See comments on cipherUnencryptedHeaderLength.  These two properties are
- * intended to be used in conjunction.
+ * For more information, see comments in YapDatabaseCryptoUtils.h.
  **/
 @property (nonatomic, copy, readwrite) YapDatabaseCipherKeyBlock cipherKeySpecBlock;
 
@@ -266,36 +264,13 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
  *
  * This value will be passed to SQLCipher via `PRAGMA cipher_plaintext_header_size`.
  *
- * iOS will terminate suspended apps which hold a file lock on files in the shared
- * container.  An exception is made for certain kinds of Sqlite files, so that iOS apps
- * can share databases with their app extensions.  Unfortunately, this exception does
- * not apply for SQLCipher databases which have encrypted the Sqlite file header,
- * which is the default behavior. Therefore apps which try to share an SQLCipher
- * database with their app extensions and use WAL (write-ahead logging) will be
- * terminated whenever they are sent to the background (0x10deadcc terminations).
- *
- * The solution is to have SQLCipher encrypt everything _except_ the first 32 bytes
- * of the Sqlite file.  This is accomplished using the cipher_plaintext_header_size
- * PRAGMA.  The header does not contain any user data.
- *
- * However, Sqlite normally uses the first 16 bytes of the Sqlite header to store
- * a salt value.  Therefore when using unencrypted headers, it is also necessary
- * to explicitly specify a salt value.
- *
- * NOTE: When converting SQLCipher databases from using encrypted headers to using
- * unencrypted headers, the salt can extracted and preserved by reading the first
- * 16 bytes of the file.
- *
- * See: https://developer.apple.com/library/content/technotes/tn2151/_index.html
- *
  * You must use the 'YapDatabase/SQLCipher' subspec
  * in your Podfile for this option to take effect.
  *
  * cipherUnencryptedHeaderLength will be ignored if you don't also set
  * ((cipherKeyBlock AND cipherSaltBlock) OR cipherKeySpecBlock).
  *
- * See comments on cipherSaltBlock and cipherKeySpecBlock.  These properties are
- * intended to be used in conjunction.
+ * For more information, see comments in YapDatabaseCryptoUtils.h.
  **/
 @property (nonatomic, assign, readwrite) NSUInteger cipherUnencryptedHeaderLength;
 

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -223,6 +223,39 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
  * to customize the page size of your encrypted database.
  **/
 @property (nonatomic, assign, readwrite) NSUInteger cipherPageSize;
+
+/**
+ * Set a block here that returns the salt (not the key) for the SQLCipher database.
+ *
+ * This salt that will be passed to SQLCipher via `PRAGMA cipher_salt`.
+ *
+ * This block allows you to fetch the salt from the keychain (or elsewhere)
+ * only when you need it, instead of persisting it in memory.
+ *
+ * You must use the 'YapDatabase/SQLCipher' subspec
+ * in your Podfile for this option to take effect.
+ *
+ * cipherSaltBlock will be ignored if you don't also set cipherKeyBlock.
+ *
+ * Important: If you set a cipherSaltBlock you should also set cipherUnencryptedHeaderLength.
+ **/
+@property (nonatomic, copy, readwrite) YapDatabaseCipherKeyBlock cipherSaltBlock;
+
+/**
+ * If set, this many bytes at the start of the first page of the database will _NOT_
+ * be encrypted.
+ *
+ * This salt that will be passed to SQLCipher via `PRAGMA cipher_plaintext_header_size`.
+ *
+ * You must use the 'YapDatabase/SQLCipher' subspec
+ * in your Podfile for this option to take effect.
+ *
+ * cipherUnencryptedHeaderLength will be ignored if you don't also set cipherKeyBlock and cipherSaltBlock.
+ *
+ * Important: If you set a cipherUnencryptedHeaderLength you should also set cipherSaltBlock.
+ **/
+@property (nonatomic, assign, readwrite) NSUInteger cipherUnencryptedHeaderLength;
+
 #endif
 
 /**

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -25,6 +25,7 @@
 @synthesize cipherDefaultkdfIterNumber = cipherDefaultkdfIterNumber;
 @synthesize cipherPageSize = cipherPageSize;
 @synthesize cipherSaltBlock = cipherSaltBlock;
+@synthesize cipherKeySpecBlock = cipherKeySpecBlock;
 @synthesize cipherUnencryptedHeaderLength = cipherUnencryptedHeaderLength;
 
 #endif
@@ -60,6 +61,7 @@
     copy->cipherDefaultkdfIterNumber = cipherDefaultkdfIterNumber;
     copy->cipherPageSize = cipherPageSize;
     copy->cipherSaltBlock = cipherSaltBlock;
+    copy->cipherKeySpecBlock = cipherKeySpecBlock;
     copy->cipherUnencryptedHeaderLength = cipherUnencryptedHeaderLength;
 #endif
 	copy->aggressiveWALTruncationSize = aggressiveWALTruncationSize;

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -24,6 +24,9 @@
 @synthesize kdfIterNumber = kdfIterNumber;
 @synthesize cipherDefaultkdfIterNumber = cipherDefaultkdfIterNumber;
 @synthesize cipherPageSize = cipherPageSize;
+@synthesize cipherSaltBlock = cipherSaltBlock;
+@synthesize cipherUnencryptedHeaderLength = cipherUnencryptedHeaderLength;
+
 #endif
 @synthesize aggressiveWALTruncationSize = aggressiveWALTruncationSize;
 @synthesize enableMultiProcessSupport = enableMultiProcessSupport;
@@ -56,6 +59,8 @@
     copy->kdfIterNumber = kdfIterNumber;
     copy->cipherDefaultkdfIterNumber = cipherDefaultkdfIterNumber;
     copy->cipherPageSize = cipherPageSize;
+    copy->cipherSaltBlock = cipherSaltBlock;
+    copy->cipherUnencryptedHeaderLength = cipherUnencryptedHeaderLength;
 #endif
 	copy->aggressiveWALTruncationSize = aggressiveWALTruncationSize;
     copy->enableMultiProcessSupport = enableMultiProcessSupport;


### PR DESCRIPTION
PTAL @michaelkirk

NOTE: The current approach supplies the database password and key separately.  We could supply a database "key spec" instead, but I'm not sure this is a perf hotspot.
