### PR TITLE
Fts add transaction to handler blocks

### DIFF
--- a/Testing/UnitTesting/TestYapDatabaseFullTextSearch.m
+++ b/Testing/UnitTesting/TestYapDatabaseFullTextSearch.m
@@ -50,7 +50,7 @@
 	YapDatabaseConnection *connection = [database newConnection];
 	
 	YapDatabaseFullTextSearchHandler *handler = [YapDatabaseFullTextSearchHandler withObjectBlock:
-	    ^(NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
+	    ^(YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
 		
 		[dict setObject:object forKey:@"content"];
 	}];
@@ -169,7 +169,7 @@
 	YapDatabaseConnection *connection = [database newConnection];
 	
 	YapDatabaseFullTextSearchHandler *handler = [YapDatabaseFullTextSearchHandler withObjectBlock:
-	    ^(NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
+	    ^(YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
 		
 		[dict setObject:object forKey:@"content"];
 	}];

--- a/Testing/UnitTesting/TestYapDatabaseSearchResultsView.m
+++ b/Testing/UnitTesting/TestYapDatabaseSearchResultsView.m
@@ -169,7 +169,7 @@
 	// Setup FTS
 	
 	YapDatabaseFullTextSearchHandler *handler = [YapDatabaseFullTextSearchHandler withObjectBlock:
-	    ^(NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
+	    ^(YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
 		
 		[dict setObject:object forKey:@"content"];
 	}];
@@ -259,7 +259,7 @@
 	// Setup FTS
 	
 	YapDatabaseFullTextSearchHandler *handler = [YapDatabaseFullTextSearchHandler withObjectBlock:
-	    ^(NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
+	    ^(YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object){
 		
 		[dict setObject:object forKey:@"content"];
 	}];

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchHandler.h
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchHandler.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import "YapDatabaseExtensionTypes.h"
 
+@class YapDatabaseReadTransaction;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -22,16 +24,16 @@ NS_ASSUME_NONNULL_BEGIN
 typedef id YapDatabaseFullTextSearchBlock; // One of YapDatabaseFullTextSearchXBlock types
 
 typedef void (^YapDatabaseFullTextSearchWithKeyBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key);
 
 typedef void (^YapDatabaseFullTextSearchWithObjectBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key, id object);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object);
 
 typedef void (^YapDatabaseFullTextSearchWithMetadataBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key, __nullable id metadata);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, __nullable id metadata);
 
 typedef void (^YapDatabaseFullTextSearchWithRowBlock)
-                            (NSMutableDictionary *dict, NSString *collection, NSString *key, id object, __nullable id metadata);
+                            (YapDatabaseReadTransaction *transaction, NSMutableDictionary *dict, NSString *collection, NSString *key, id object, __nullable id metadata);
 
 + (instancetype)withKeyBlock:(YapDatabaseFullTextSearchWithKeyBlock)block;
 + (instancetype)withObjectBlock:(YapDatabaseFullTextSearchWithObjectBlock)block;

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
@@ -246,7 +246,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		[databaseTransaction _enumerateKeysInAllCollectionsUsingBlock:
 		    ^(int64_t rowid, NSString *collection, NSString *key, BOOL __unused *stop) {
 			
-			block(parentConnection->blockDict, collection, key);
+			block(databaseTransaction, parentConnection->blockDict, collection, key);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -263,7 +263,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		[databaseTransaction _enumerateKeysAndObjectsInAllCollectionsUsingBlock:
 		    ^(int64_t rowid, NSString *collection, NSString *key, id object, BOOL __unused *stop) {
 			
-			block(parentConnection->blockDict, collection, key, object);
+			block(databaseTransaction, parentConnection->blockDict, collection, key, object);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -280,7 +280,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		[databaseTransaction _enumerateKeysAndMetadataInAllCollectionsUsingBlock:
 		    ^(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL __unused *stop) {
 			
-			block(parentConnection->blockDict, collection, key, metadata);
+			block(databaseTransaction, parentConnection->blockDict, collection, key, metadata);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -297,7 +297,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 		[databaseTransaction _enumerateRowsInAllCollectionsUsingBlock:
 		    ^(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL __unused *stop) {
 			
-			block(parentConnection->blockDict, collection, key, object, metadata);
+			block(databaseTransaction, parentConnection->blockDict, collection, key, object, metadata);
 			
 			if ([parentConnection->blockDict count] > 0)
 			{
@@ -573,28 +573,28 @@ static NSString *const ext_key__version_deprecated = @"version";
 		__unsafe_unretained YapDatabaseFullTextSearchWithKeyBlock block =
 		    (YapDatabaseFullTextSearchWithKeyBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key);
+		block(databaseTransaction, parentConnection->blockDict, collection, key);
 	}
 	else if (handler->blockType == YapDatabaseBlockTypeWithObject)
 	{
 		__unsafe_unretained YapDatabaseFullTextSearchWithObjectBlock block =
 		    (YapDatabaseFullTextSearchWithObjectBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key, object);
+		block(databaseTransaction, parentConnection->blockDict, collection, key, object);
 	}
 	else if (handler->blockType == YapDatabaseBlockTypeWithMetadata)
 	{
 		__unsafe_unretained YapDatabaseFullTextSearchWithMetadataBlock block =
 		    (YapDatabaseFullTextSearchWithMetadataBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key, metadata);
+		block(databaseTransaction, parentConnection->blockDict, collection, key, metadata);
 	}
 	else
 	{
 		__unsafe_unretained YapDatabaseFullTextSearchWithRowBlock block =
 		    (YapDatabaseFullTextSearchWithRowBlock)handler->block;
 		
-		block(parentConnection->blockDict, collection, key, object, metadata);
+		block(databaseTransaction, parentConnection->blockDict, collection, key, object, metadata);
 	}
 	
 	if ([parentConnection->blockDict count] == 0)


### PR DESCRIPTION
This change brings the FTS extension inline with the other database extensions, and makes available the current read transaction to the FTS handler blocks.

This is very useful when you need to pull info from other objects in the database when indexing an object.