### PR TITLE
Fix for _enumerateRowidsForKeys only working for 1 key

### DIFF
--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -4129,7 +4129,7 @@
 		// Bind parameters.
 		// And move objects from the missingIndexes array into keyIndexDict.
 		
-		if (keyIndexDict)
+		if (!keyIndexDict)
 			keyIndexDict = [NSMutableDictionary dictionaryWithCapacity:numKeyParams];
 		else
 			[keyIndexDict removeAllObjects];


### PR DESCRIPTION
If the fast path for 1 key lookup is not taken because there are > 1 keys, the `keyIndexDict` is never allocated a value due to a logic bug. Objective-C then conspired to hide this problem from us thanks to messaging of nil.