### PR TITLE
Added __nullable to metadata in headers to make sure Swift 4.1 doesn't throw EXC_BAD_ACCESS

### DIFF
--- a/YapDatabase.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/YapDatabase.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/YapDatabase/Extensions/CloudCore/Utilities/YapManyToManyCache.h
+++ b/YapDatabase/Extensions/CloudCore/Utilities/YapManyToManyCache.h
@@ -128,15 +128,15 @@
  * 
  * All key/value tuples accessed during enumeration are moved to the beginning of the most-recently-used linked-list.
 **/
-- (void)enumerateValuesForKey:(id)key withBlock:(void (^)(id value, id metadata, BOOL *stop))block;
-- (void)enumerateKeysForValue:(id)value withBlock:(void (^)(id value, id metadata, BOOL *stop))block;
+- (void)enumerateValuesForKey:(id)key withBlock:(void (^)(id value, __nullable id metadata, BOOL *stop))block;
+- (void)enumerateKeysForValue:(id)value withBlock:(void (^)(id value, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Enumerates all key/value pairs in the cache.
  * 
  * As this method is designed to enumerate all values, it ddes not affect the most-recently-used linked-list.
 **/
-- (void)enumerateWithBlock:(void (^)(id key, id value, id metadata, BOOL *stop))block;
+- (void)enumerateWithBlock:(void (^)(id key, id value, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Removes the tuple that matches the given key/value pair.

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.h
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.h
@@ -36,13 +36,13 @@ NS_ASSUME_NONNULL_BEGIN
                    usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataMatching:(NSString *)query
-                              usingBlock:(void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+                              usingBlock:(void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (void)enumerateKeysAndObjectsMatching:(NSString *)query
                              usingBlock:(void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
 
 - (void)enumerateRowsMatching:(NSString *)query
-                   usingBlock:(void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+                   usingBlock:(void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 // FTS5 bm25 ordering
 
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)enumerateBm25OrderedKeysAndMetadataMatching:(NSString *)query
                                         withWeights:(nullable NSArray<NSNumber *> *)weights
-                                         usingBlock:(void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+                                         usingBlock:(void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (void)enumerateBm25OrderedKeysAndObjectsMatching:(NSString *)query
                                        withWeights:(nullable NSArray<NSNumber *> *)weights
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)enumerateBm25OrderedRowsMatching:(NSString *)query
                              withWeights:(nullable NSArray<NSNumber *> *)weights
-                              usingBlock:(void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+                              usingBlock:(void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 // Query matching + Snippets
 
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enumerateKeysAndMetadataMatching:(NSString *)query
                       withSnippetOptions:(nullable YapDatabaseFullTextSearchSnippetOptions *)options
                               usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+            (void (^)(NSString *snippet, NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (void)enumerateKeysAndObjectsMatching:(NSString *)query
                      withSnippetOptions:(nullable YapDatabaseFullTextSearchSnippetOptions *)options
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enumerateRowsMatching:(NSString *)query
            withSnippetOptions:(nullable YapDatabaseFullTextSearchSnippetOptions *)options
                    usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+            (void (^)(NSString *snippet, NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.h
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)enumerateKeysAndMetadataMatchingQuery:(YapDatabaseQuery *)query
                                    usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+                            (void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (BOOL)enumerateKeysAndObjectsMatchingQuery:(YapDatabaseQuery *)query
                                   usingBlock:
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)enumerateRowsMatchingQuery:(YapDatabaseQuery *)query
                         usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+                            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 - (BOOL)enumerateIndexedValuesInColumn:(NSString *)column matchingQuery:(YapDatabaseQuery *)query usingBlock:(void(^)(id indexedValue, BOOL *stop))block;
 

--- a/YapDatabase/Extensions/View/YapDatabaseViewTransaction.h
+++ b/YapDatabase/Extensions/View/YapDatabaseViewTransaction.h
@@ -270,18 +270,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                             withOptions:(NSEnumerationOptions)options
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                             withOptions:(NSEnumerationOptions)options
                                   range:(NSRange)range
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                             withOptions:(NSEnumerationOptions)options
@@ -289,7 +289,7 @@ NS_ASSUME_NONNULL_BEGIN
                                  filter:
                     (BOOL (^)(NSString *collection, NSString *key))filter
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 /**
  * The following methods are similar to invoking the enumerateKeysInGroup:... methods,
@@ -326,18 +326,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)enumerateRowsInGroup:(NSString *)group
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block;
+            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateRowsInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block;
+            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateRowsInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                        range:(NSRange)range
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block;
+            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateRowsInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
@@ -345,7 +345,7 @@ NS_ASSUME_NONNULL_BEGIN
                       filter:
             (BOOL (^)(NSString *collection, NSString *key))filter
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block;
+            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Internal/YapDatabasePrivate.h
+++ b/YapDatabase/Internal/YapDatabasePrivate.h
@@ -388,21 +388,21 @@ static NSString *const ext_key_class = @"class";
                             (void (^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block;
 
 - (void)_enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                   usingBlock:(void (^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block;
+                                   usingBlock:(void (^)(int64_t rowid, NSString *key, __nullable id metadata, BOOL *stop))block;
 - (void)_enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                   usingBlock:(void (^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
+                                   usingBlock:(void (^)(int64_t rowid, NSString *key, __nullable id metadata, BOOL *stop))block
                                    withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter;
 
 - (void)_enumerateKeysAndMetadataInCollections:(NSArray *)collections
-                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 - (void)_enumerateKeysAndMetadataInCollections:(NSArray *)collections
-                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block
                 withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                        (void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+                        (void (^)(int64_t rowid, NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 - (void)_enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                        (void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                        (void (^)(int64_t rowid, NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block
              withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateKeysAndObjectsInCollection:(NSString *)collection
@@ -424,21 +424,21 @@ static NSString *const ext_key_class = @"class";
                  withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateRowsInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block;
+                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 - (void)_enumerateRowsInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block
+                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, __nullable id metadata, BOOL *stop))block
                         withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter;
 
 - (void)_enumerateRowsInCollections:(NSArray *)collections
-     usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+     usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 - (void)_enumerateRowsInCollections:(NSArray *)collections
-     usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+     usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block
      withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateRowsInAllCollectionsUsingBlock:
-                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 - (void)_enumerateRowsInAllCollectionsUsingBlock:
-                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block
      withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateRowidsForKeys:(NSArray *)keys


### PR DESCRIPTION
As discussed in issue #450 