### PR TITLE
upstream unencrypted headers

### DIFF
--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
@@ -58,13 +58,14 @@ typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 // The header does not contain any user data.  See:
 // https://www.sqlite.org/fileformat.html#the_database_header
 //
-// However, Sqlite normally uses the first 16 bytes of the Sqlite header to store
+// However, SQLCipher normally uses the first 16 bytes of the Sqlite header to store
 // a salt value.  Therefore when using unencrypted headers, it is also necessary
 // to explicitly specify a salt value.
 //
 // It is possible to convert SQLCipher databases with encrypted headers to use
 // unencrypted headers.  However, during this conversion, the salt must be extracted
-// and preserved by reading the first 16 bytes of the unconverted file.
+// by reading the first 16 bytes of the unconverted file and preserving it elsewhere,
+// e.g. the keychain.
 //
 //
 // Implementation
@@ -101,7 +102,7 @@ typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 // * If convertDatabaseIfNecessary converts the database, it will use its
 //   saltBlock and keySpecBlock parameters to inform you of the salt
 //   and keyspec for this database.  These values will be needed when
-//   opening the database, so they should presumably stored in the
+//   opening the database, so they should presumably be stored in the
 //   keychain (like the database password).
 //
 //
@@ -133,7 +134,7 @@ typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 // * If convertDatabaseIfNecessary converts the database, it will use its
 //   saltBlock and keySpecBlock parameters to inform you of the salt
 //   and keyspec for this database.  These values will be needed when
-//   opening the database, so they should presumably stored in the
+//   opening the database, so they should presumably be stored in the
 //   keychain (like the database password).
 + (nullable NSError *)convertDatabaseIfNecessary:(NSString *)databaseFilePath
                                 databasePassword:(NSData *)databasePassword

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
@@ -13,7 +13,12 @@ extern const NSUInteger kSQLCipherSaltLength;
 extern const NSUInteger kSQLCipherDerivedKeyLength;
 extern const NSUInteger kSQLCipherKeySpecLength;
 
-typedef void (^YapDatabaseSaltBlock)(NSData *saltData);
+// User specified block used to notify the caller of a database's salt when
+// converting SQLCipher headers to plaintext. Failing to properly record the
+// salt will leave the database unreadable.
+// @returns BOOL indicating if the salt was successfully recorded. Conversion
+//          will not proceed if recording the salt fails.
+typedef BOOL (^YapRecordDatabaseSaltBlock)(NSData *saltData);
 
 // This class contains utility methods for use with SQLCipher encrypted
 // databases, specifically to address an issue around database files that
@@ -136,7 +141,7 @@ typedef void (^YapDatabaseSaltBlock)(NSData *saltData);
 //   for this database. Within that block you must store the salt somewhere durable.
 + (nullable NSError *)convertDatabaseIfNecessary:(NSString *)databaseFilePath
                                 databasePassword:(NSData *)databasePassword
-                                 recordSaltBlock:(YapDatabaseSaltBlock)recordSaltBlock;
+                                 recordSaltBlock:(YapRecordDatabaseSaltBlock)recordSaltBlock;
 
 // This method can be used to derive a SQLCipher "key spec" from a
 // database password and salt.  Key spec derivation is somewhat costly.

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern const NSUInteger kSqliteHeaderLength;
 extern const NSUInteger kSQLCipherSaltLength;
-extern const NSUInteger kSQLCipherKeyLength;
+extern const NSUInteger kSQLCipherDerivedKeyLength;
 extern const NSUInteger kSQLCipherKeySpecLength;
 
 typedef void (^YapDatabaseSaltBlock)(NSData *saltData);

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
@@ -92,7 +92,7 @@ NSCAssert(0, message);                                                          
 
 const NSUInteger kSqliteHeaderLength = 32;
 const NSUInteger kSQLCipherSaltLength = 16;
-const NSUInteger kSQLCipherKeyLength = 32;
+const NSUInteger kSQLCipherDerivedKeyLength = 32;
 const NSUInteger kSQLCipherKeySpecLength = 48;
 
 NSString *const YapDatabaseErrorDomain = @"YapDatabaseErrorDomain";
@@ -169,7 +169,7 @@ NSError *YDBErrorWithDescription(NSString *description)
 
     return [self convertDatabase:databaseFilePath
                 databasePassword:databasePassword
-                       recordSaltBlock:recordSaltBlock];
+                 recordSaltBlock:recordSaltBlock];
 }
 
 + (nullable NSError *)convertDatabase:(NSString *)databaseFilePath
@@ -411,7 +411,7 @@ NSError *YDBErrorWithDescription(NSString *description)
     YapAssert(passwordData.length > 0);
     YapAssert(saltData.length == kSQLCipherSaltLength);
 
-    NSMutableData *_Nullable derivedKeyData = [NSMutableData dataWithLength:kSQLCipherKeyLength];
+    NSMutableData *_Nullable derivedKeyData = [NSMutableData dataWithLength:kSQLCipherDerivedKeyLength];
     if (!derivedKeyData) {
         YapFail(@"failed to allocate derivedKeyData");
         return nil;
@@ -444,7 +444,7 @@ NSError *YDBErrorWithDescription(NSString *description)
     YapAssert(saltData.length == kSQLCipherSaltLength);
 
     NSData *_Nullable derivedKeyData = [self deriveDatabaseKeyForPassword:passwordData saltData:saltData];
-    if (!derivedKeyData || derivedKeyData.length != kSQLCipherKeyLength) {
+    if (!derivedKeyData || derivedKeyData.length != kSQLCipherDerivedKeyLength) {
         YDBLogError(@"Error deriving key");
         return nil;
     }

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
@@ -160,7 +160,7 @@ NSError *YDBErrorWithDescription(NSString *description)
 
 + (nullable NSError *)convertDatabaseIfNecessary:(NSString *)databaseFilePath
                                 databasePassword:(NSData *)databasePassword
-                                 recordSaltBlock:(YapDatabaseSaltBlock)recordSaltBlock
+                                 recordSaltBlock:(YapRecordDatabaseSaltBlock)recordSaltBlock
 {
     if (![self doesDatabaseNeedToBeConverted:databaseFilePath]) {
         YDBLogInfo(@"%@ convertDatabaseIfNecessary: database does not need to be converted.", self.logTag);
@@ -174,7 +174,7 @@ NSError *YDBErrorWithDescription(NSString *description)
 
 + (nullable NSError *)convertDatabase:(NSString *)databaseFilePath
                      databasePassword:(NSData *)databasePassword
-                      recordSaltBlock:(YapDatabaseSaltBlock)recordSaltBlock
+                      recordSaltBlock:(YapRecordDatabaseSaltBlock)recordSaltBlock
 {
     YapAssert(databaseFilePath.length > 0);
     YapAssert(databasePassword.length > 0);
@@ -194,7 +194,11 @@ NSError *YDBErrorWithDescription(NSString *description)
         // proceeding with the database conversion or we could leave the app in an
         // unrecoverable state.
         YDBLogInfo(@"%@ convertDatabase: salt extracted.", self.logTag);
-        recordSaltBlock(saltData);
+        BOOL success = recordSaltBlock(saltData);
+        if (!success) {
+            YDBLogError(@"Failed to record salt, aborting conversion");
+            return YDBErrorWithDescription(@"Failed to record salt");
+        }
     }
     
     YDBLogInfo(@"%@ convertDatabase: key spec derived.", self.logTag);

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
@@ -433,7 +433,7 @@ NSError *YDBErrorWithDescription(NSString *description)
 
     unsigned char *derivedKeyBytes = malloc((size_t)kSQLCipherDerivedKeyLength);
     YapAssert(derivedKeyBytes);
-    // See: PBKDF2_ITER.
+    // See: PBKDF2_ITER from SQLCipher.
     const unsigned int workfactor = 64000;
 
     int result = CCKeyDerivationPBKDF(kCCPBKDF2,

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -835,8 +835,7 @@ static int connectionBusyHandler(void *ptr, int count) {
         if (options.cipherKeySpecBlock)
         {
             // Do nothing.
-        } else if (!options.cipherKeyBlock ||
-                   options.cipherSaltBlock) {
+        } else if (!(options.cipherKeyBlock && options.cipherSaltBlock)) {
             NSAssert(NO, @"If you're using YapDatabaseOptions.cipherUnencryptedHeaderLength, you need to set either cipherKeySpecBlock or both cipherKeyBlock and cipherSaltBlock.");
             return NO;
         }

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -244,7 +244,19 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
 /**
  * Set a block here that returns the key spec (not the key) for the SQLCipher database.
  *
- * This key spec incorporates the "derived key" and the "salt".
+ * The key spec incorporates the "derived key" and the "salt".
+ *
+ * The key spec should be kSQLCipherKeySpecLength bytes in length.
+ *
+ * If you a key spec, you do NOT need to specify the salt (using cipherSaltBlock)
+ * and "key/password" (using cipherKeyBlock).
+ *
+ * For new databases, the key spec can be any N bytes where N is kSQLCipherKeySpecLength.
+ * You should consider generating them with SecRandomCopyBytes().
+ *
+ * For existing databases that were created using a "key/password" (i.e. cipherKeyBlock),
+ * you can derive a key spec using that key/password and the database's salt.  See
+ * comments in YapDatabaseCryptoUtils.h.
  *
  * This block allows you to fetch the key spec from the keychain (or elsewhere)
  * only when you need it, instead of persisting it in memory.


### PR DESCRIPTION
Ok this is ready for review.

This builds on top of https://github.com/yapstudios/YapDatabase/pull/439

- Adds more documentation
- Adds some sanity checking asserts to make sure you're specifying either:
  -  a key-spec
   - a key+salt.
- simplifies the migration utils to only require a `recordSalt` callback (and tries to make it clearer what that callback should do). 

Using a key spec allows you to skip expensive key derivation which occurs ever time you create a new DB connection.

Since we're generating random key data, as opposed to having the user specify a passphrase, there's no reason *not* to just generate a key-spec length key and skip derivation.

FWIW - We've been using this in production for about 9 months.