### PR TITLE
Fixed crash in YapDatabaseSearchResultsViewTransaction.

### DIFF
--- a/YapDatabase/Extensions/SearchResultsView/YapDatabaseSearchResultsViewTransaction.m
+++ b/YapDatabase/Extensions/SearchResultsView/YapDatabaseSearchResultsViewTransaction.m
@@ -1916,7 +1916,7 @@ static NSString *const ext_key_query           = @"query";
 		BOOL abort = [searchQueue shouldAbortSearchInProgressAndRollback:&rollback];
 		if (abort && rollback)
 		{
-			[databaseTransaction rollbackTransaction];
+			[(YapDatabaseReadWriteTransaction *)databaseTransaction rollback];
 		}
 	}
 	


### PR DESCRIPTION
This was caused by the transaction calling the wrong rollback method and eventually dereferencing a nil pointer for the parentConnection in [YapDatabaseViewTransaction cleanupPages].

The app would crash with the following stack:
```
Thread 15 Crashed:
0   YapDatabase                          0x000000010f01851d -[YapDatabaseViewTransaction cleanupPages] (in YapDatabase) (YapDatabaseViewTransaction.m:1960)
1   YapDatabase                          0x000000010f01888e -[YapDatabaseViewTransaction flushPendingChangesToExtensionTables] (in YapDatabase) (YapDatabaseViewTransaction.m:2019)
2   YapDatabase                          0x000000010ef7e898 -[YapDatabaseSearchResultsViewTransaction flushPendingChangesToExtensionTables] (in YapDatabase) (YapDatabaseSearchResultsViewTransaction.m:504)
3   CoreFoundation                       0x00007fff3a5535c2 -[__NSDictionaryM enumerateKeysAndObjectsWithOptions:usingBlock:] + 226
4   YapDatabase                          0x000000010f021053 -[YapDatabaseReadTransaction preCommitReadWriteTransaction] (in YapDatabase) (YapDatabaseTransaction.m:152)
5   YapDatabase                          0x000000010efc0d42 -[YapDatabaseConnection postReadWriteTransaction:] (in YapDatabase) (YapDatabaseConnection.m:2831)
6   YapDatabase                          0x000000010efbef8b __81-[YapDatabaseConnection asyncReadWriteWithBlock:completionQueue:completionBlock:]_block_invoke_2 (in YapDatabase) (YapDatabaseConnection.m:2159)
7   libdispatch.dylib                    0x00007fff6235cdb8 _dispatch_client_callout + 7
8   libdispatch.dylib                    0x00007fff623701e1 _dispatch_queue_barrier_sync_invoke_and_complete + 59
9   YapDatabase                          0x000000010efbeed8 __81-[YapDatabaseConnection asyncReadWriteWithBlock:completionQueue:completionBlock:]_block_invoke (in YapDatabase) (YapDatabaseConnection.m:2176)
10  libdispatch.dylib                    0x00007fff623645fa _dispatch_call_block_and_release + 11
11  libdispatch.dylib                    0x00007fff6235cdb8 _dispatch_client_callout + 7
12  libdispatch.dylib                    0x00007fff62371217 _dispatch_queue_serial_drain + 634
13  libdispatch.dylib                    0x00007fff62364166 _dispatch_queue_invoke + 372
14  libdispatch.dylib                    0x00007fff62371f0d _dispatch_root_queue_drain_deferred_wlh + 331
15  libdispatch.dylib                    0x00007fff62375d21 _dispatch_workloop_worker_thread + 879
16  libsystem_pthread.dylib              0x00007fff626adfd2 _pthread_wqthread + 979
17  libsystem_pthread.dylib              0x00007fff626adbe9 start_wqthread + 12
18  ???                                  0x0001000000010001 0x0 + 0
```