### PR TITLE
Feature/optional auto drop view tables

### DIFF
--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -3092,7 +3092,7 @@ static int connectionBusyHandler(void *ptr, int count)
 		
 		BOOL clearPreviouslyRegisteredExtensionNames = NO;
 		
-		if (changeset && !registeredExtensionsChanged && database->previouslyRegisteredExtensionNames)
+		if ( database.options.autoDropPreviouslyRegisteredPersistentViewsNoLongerInUse && changeset && !registeredExtensionsChanged && database->previouslyRegisteredExtensionNames )
 		{
 			for (NSString *prevExtensionName in database->previouslyRegisteredExtensionNames)
 			{

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -340,6 +340,14 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
 **/
 @property (nonatomic, assign, readwrite) BOOL enableMultiProcessSupport;
 
+/**
+ * This option enables automatic clean up (dropping tables) of previously registered views when they
+ * are detected to no longer be in use. This option is defaulted to YES. Setting it to NO will disable
+ * the connection's view table clean up routine.
+**/
+@property (nonatomic, assign, readwrite) BOOL autoDropPreviouslyRegisteredPersistentViewsNoLongerInUse;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -31,6 +31,7 @@
 #endif
 @synthesize aggressiveWALTruncationSize = aggressiveWALTruncationSize;
 @synthesize enableMultiProcessSupport = enableMultiProcessSupport;
+@synthesize autoDropPreviouslyRegisteredPersistentViewsNoLongerInUse = autoDropPreviouslyRegisteredPersistentViewsNoLongerInUse;
 
 - (id)init
 {
@@ -43,6 +44,7 @@
 		pragmaMMapSize = 0;
 		aggressiveWALTruncationSize = (1024 * 1024 * 4); // 4 MB
         enableMultiProcessSupport = NO;
+        autoDropPreviouslyRegisteredPersistentViewsNoLongerInUse = YES;
 	}
 	return self;
 }

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -68,7 +68,8 @@
 #endif
 	copy->aggressiveWALTruncationSize = aggressiveWALTruncationSize;
     copy->enableMultiProcessSupport = enableMultiProcessSupport;
-	
+    copy->autoDropPreviouslyRegisteredPersistentViewsNoLongerInUse = autoDropPreviouslyRegisteredPersistentViewsNoLongerInUse;
+    
 	return copy;
 }
 


### PR DESCRIPTION
My app was suffering slowness due to how I was registering views: asynchronously. Yap was considering my views as "unused" because they were not registered before the first readwrite transaction. This was not something I accounted for in my initial implementation and design, and the slowness wasn't observed until users started putting significant data in the app, and whenever they navigated to a screen with a view, it'd built it from scratch because the tables were dropped when the app started. 

The fastest path to getting my app back on track was to add this option which disables this behavior, but I'm open to a discussion if my implementation isn't following the correct pattern. 