### PR TITLE
Extensions: Add methods to override to public headers

### DIFF
--- a/Framework/Mac/module.modulemap
+++ b/Framework/Mac/module.modulemap
@@ -21,7 +21,11 @@ framework module YapDatabase {
 		header "YapWhitelistBlacklist.h"
 		header "YapMutationStack.h"
 	}
-	
+
+	explicit module YapDatabaseExtensionPrivate {
+		header "YapDatabaseExtensionPrivate.h"
+	}
+
 	// Extension: View
 
 	explicit module YapDatabaseView {
@@ -177,5 +181,12 @@ framework module YapDatabase {
 		header "YapDatabaseCloudCorePipelineDelegate.h"
 		header "YapDatabaseCloudCorePipeline.h"
 		header "YapDatabaseCloudCoreGraph.h"
+	}
+
+	explicit module YapDatabaseCloudCorePrivate {
+		header "YapDatabaseCloudCorePrivate.h"
+		header "YapDatabaseCloudCoreOperationPrivate.h"
+		header "YapDatabaseCloudCorePipelinePrivate.h"
+		header "YapDatabaseCloudCoreGraphPrivate.h"
 	}
 }

--- a/Framework/iOS/module.modulemap
+++ b/Framework/iOS/module.modulemap
@@ -21,7 +21,11 @@ framework module YapDatabase {
 		header "YapWhitelistBlacklist.h"
 		header "YapMutationStack.h"
 	}
-	
+
+	explicit module YapDatabaseExtensionPrivate {
+		header "YapDatabaseExtensionPrivate.h"
+	}
+
 	// Extension: View
 	
 	explicit module YapDatabaseView {
@@ -177,5 +181,12 @@ framework module YapDatabase {
 		header "YapDatabaseCloudCorePipelineDelegate.h"
 		header "YapDatabaseCloudCorePipeline.h"
 		header "YapDatabaseCloudCoreGraph.h"
+	}
+
+	explicit module YapDatabaseCloudCorePrivate {
+		header "YapDatabaseCloudCorePrivate.h"
+		header "YapDatabaseCloudCoreOperationPrivate.h"
+		header "YapDatabaseCloudCorePipelinePrivate.h"
+		header "YapDatabaseCloudCoreGraphPrivate.h"
 	}
 }

--- a/Framework/tvOS/module.modulemap
+++ b/Framework/tvOS/module.modulemap
@@ -21,7 +21,11 @@ framework module YapDatabase {
 		header "YapWhitelistBlacklist.h"
 		header "YapMutationStack.h"
 	}
-	
+
+	explicit module YapDatabaseExtensionPrivate {
+		header "YapDatabaseExtensionPrivate.h"
+	}
+
 	// Extension: View
 
 	explicit module YapDatabaseView {
@@ -177,5 +181,12 @@ framework module YapDatabase {
 		header "YapDatabaseCloudCorePipelineDelegate.h"
 		header "YapDatabaseCloudCorePipeline.h"
 		header "YapDatabaseCloudCoreGraph.h"
+	}
+
+	explicit module YapDatabaseCloudCorePrivate {
+		header "YapDatabaseCloudCorePrivate.h"
+		header "YapDatabaseCloudCoreOperationPrivate.h"
+		header "YapDatabaseCloudCorePipelinePrivate.h"
+		header "YapDatabaseCloudCoreGraphPrivate.h"
 	}
 }

--- a/Framework/watchOS/module.modulemap
+++ b/Framework/watchOS/module.modulemap
@@ -21,7 +21,11 @@ framework module YapDatabase {
 		header "YapWhitelistBlacklist.h"
 		header "YapMutationStack.h"
 	}
-	
+
+	explicit module YapDatabaseExtensionPrivate {
+		header "YapDatabaseExtensionPrivate.h"
+	}
+
 	// Extension: View
 
 	explicit module YapDatabaseView {
@@ -177,5 +181,12 @@ framework module YapDatabase {
 		header "YapDatabaseCloudCorePipelineDelegate.h"
 		header "YapDatabaseCloudCorePipeline.h"
 		header "YapDatabaseCloudCoreGraph.h"
+	}
+
+	explicit module YapDatabaseCloudCorePrivate {
+		header "YapDatabaseCloudCorePrivate.h"
+		header "YapDatabaseCloudCoreOperationPrivate.h"
+		header "YapDatabaseCloudCorePipelinePrivate.h"
+		header "YapDatabaseCloudCoreGraphPrivate.h"
 	}
 }

--- a/YapDatabase.podspec
+++ b/YapDatabase.podspec
@@ -21,6 +21,10 @@ Pod::Spec.new do |s|
   s.libraries = 'c++'
 
   s.default_subspecs = 'Standard'
+  s.osx.module_map = 'Framework/Mac/module.modulemap'
+  s.ios.module_map = 'Framework/iOS/module.modulemap'
+  s.tvos.module_map = 'Framework/tvOS/module.modulemap'
+  s.watchos.module_map = 'Framework/watchOS/module.modulemap'
 
   # There are 2 different versions you can choose from:
   # "Standard" uses the builtin version of sqlite3
@@ -35,7 +39,7 @@ Pod::Spec.new do |s|
       ssc.library = 'sqlite3'
       ssc.dependency 'CocoaLumberjack'
       ssc.source_files = 'YapDatabase/*.{h,m,mm,c}', 'YapDatabase/{Internal,Utilities}/*.{h,m,mm,c}', 'YapDatabase/Extensions/Protocol/**/*.{h,m,mm,c}'
-      ssc.private_header_files = 'YapDatabase/Internal/*.h', 'YapDatabase/Extensions/Protocol/Internal/*.h'
+      ssc.private_header_files = 'YapDatabase/Internal/*.h'
     end
 
     ss.subspec 'Extensions' do |sse|
@@ -125,7 +129,6 @@ Pod::Spec.new do |s|
       
       sse.subspec 'CloudCore' do |ssee|
         ssee.source_files = 'YapDatabase/Extensions/CloudCore/**/*.{h,m,mm,c}'
-        ssee.private_header_files = 'YapDatabase/Extensions/CloudCore/Internal/*.h'
       end
 
     end # Extensions
@@ -140,7 +143,7 @@ Pod::Spec.new do |s|
       ssc.dependency 'SQLCipher', '>= 3.4.0'
       ssc.dependency 'CocoaLumberjack'
       ssc.source_files = 'YapDatabase/*.{h,m,mm,c}', 'YapDatabase/{Internal,Utilities}/*.{h,m,mm,c}', 'YapDatabase/Extensions/Protocol/**/*.{h,m,mm,c}'
-      ssc.private_header_files = 'YapDatabase/Internal/*.h', 'YapDatabase/Extensions/Protocol/Internal/*.h'
+      ssc.private_header_files = 'YapDatabase/Internal/*.h'
     end
 
     ss.subspec 'Extensions' do |sse|
@@ -230,7 +233,6 @@ Pod::Spec.new do |s|
       
       sse.subspec 'CloudCore' do |ssee|
         ssee.source_files = 'YapDatabase/Extensions/CloudCore/**/*.{h,m,mm,c}'
-        ssee.private_header_files = 'YapDatabase/Extensions/CloudCore/Internal/*.h'
       end
 
     end # Extensions

--- a/YapDatabase/Extensions/Protocol/Internal/YapDatabaseExtensionPrivate.h
+++ b/YapDatabase/Extensions/Protocol/Internal/YapDatabaseExtensionPrivate.h
@@ -9,7 +9,6 @@
 #import "YapDatabaseTransaction.h"
 
 #import "YapCollectionKey.h"
-#import "YapMemoryTable.h"
 
 #import "sqlite3.h"
 


### PR DESCRIPTION
Hi,

I've been using YapDatabase in Swift in production for a while now, and so far it has filled all my needs. When I was looking for synchronisation options, `CloudCore` was an obvious choice and has really made my life easier. However to make it work in Swift I needed to add methods to override to public headers, as otherwise I simply couldn't override them.

This PR does exactly this: no code changes, just declarations. This branch is what I've been using in production for months now, and so far it's worked great for me. It'd be nice if this were part of the official code base, instead of me relying on my fork and having to update it once in a while.

I've taken care of only exposing methods with documentation specifying a required override, but you might want to double check these, and whether it might be beneficial to turn other declarations public.

Edit: Here's a [small project](https://github.com/flovouin/CloudCoreSwift) showing what it looks like in Swift. If you change the `Podfile` to use the official code base, the project will not compile.

Cheers,