### PR TITLE
Support for updating an AutoView's sorting block without updating it's grouping block

### DIFF
--- a/Testing/UnitTesting/TestYapDatabaseView.m
+++ b/Testing/UnitTesting/TestYapDatabaseView.m
@@ -2844,6 +2844,25 @@
 	[self _testChangeBlocks_withPath:databasePath options:options];
 }
 
+- (void)testChangeSortBlock_persistent
+{
+	NSString *databasePath = [self databasePath:NSStringFromSelector(_cmd)];
+
+	YapDatabaseViewOptions *options = [[YapDatabaseViewOptions alloc] init];
+	options.isPersistent = YES;
+
+	[self _testChangeSortBlock_withPath:databasePath options:options];
+}
+- (void)testChangeSortBlock_nonPersistent
+{
+	NSString *databasePath = [self databasePath:NSStringFromSelector(_cmd)];
+
+	YapDatabaseViewOptions *options = [[YapDatabaseViewOptions alloc] init];
+	options.isPersistent = NO;
+
+	[self _testChangeSortBlock_withPath:databasePath options:options];
+}
+
 - (void)_testChangeBlocks_withPath:(NSString *)databasePath options:(YapDatabaseViewOptions *)options
 {
 	[[NSFileManager defaultManager] removeItemAtPath:databasePath error:NULL];
@@ -2948,6 +2967,111 @@
 	
 	XCTAssertTrue([sectionChanges count] == 0, @"Bad count");
 	XCTAssertTrue([rowChanges count] == 10, @"Bad count");
+}
+
+- (void)_testChangeSortBlock_withPath:(NSString *)databasePath options:(YapDatabaseViewOptions *)options
+{
+	[[NSFileManager defaultManager] removeItemAtPath:databasePath error:NULL];
+	YapDatabase *database = [[YapDatabase alloc] initWithPath:databasePath];
+
+	XCTAssertNotNil(database, @"Oops");
+
+	YapDatabaseConnection *connection1 = [database newConnection];
+	YapDatabaseConnection *connection2 = [database newConnection];
+
+	YapDatabaseViewGrouping *grouping = [YapDatabaseViewGrouping withObjectBlock:
+		^NSString *(YapDatabaseReadTransaction *transaction, NSString *collection, NSString *key, id obj)
+	{
+	 __unsafe_unretained NSNumber *number = (NSNumber *)obj;
+
+	 if ([number intValue] % 2 == 0)
+		 return @"";
+	 else
+		 return nil;
+	}];
+
+	YapDatabaseViewSorting *sorting = [YapDatabaseViewSorting withObjectBlock:
+		^(YapDatabaseReadTransaction *transaction, NSString *group,
+			NSString *collection1, NSString *key1, id obj1,
+			NSString *collection2, NSString *key2, id obj2)
+	{
+		__unsafe_unretained NSNumber *number1 = (NSNumber *)obj1;
+		__unsafe_unretained NSNumber *number2 = (NSNumber *)obj2;
+
+		return [number1 compare:number2];
+	}];
+
+	YapDatabaseAutoView *databaseView =
+	[[YapDatabaseAutoView alloc] initWithGrouping:grouping
+	                                      sorting:sorting
+	                                   versionTag:@"1"
+	                                      options:options];
+
+	BOOL registerResult = [database registerExtension:databaseView withName:@"order"];
+
+	XCTAssertTrue(registerResult, @"Failure registering extension");
+
+	// Add a bunch of values to the database & to the view
+
+	NSUInteger count = 10;
+
+	[connection1 readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+
+		for (int i = 0; i < count; i++)
+		{
+			NSString *key = [NSString stringWithFormat:@"key-%d", i];
+			NSNumber *num = [NSNumber numberWithInt:i];
+
+			[transaction setObject:num forKey:key inCollection:nil];
+		}
+	}];
+
+	// Make sure the view is populated
+
+	[connection1 readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+
+		XCTAssertTrue([[transaction ext:@"order"] numberOfItemsInGroup:@""] == 5, @"View count is wrong");
+	}];
+
+	// Now change the groupingBlock
+
+	YapDatabaseViewMappings *mappings = [YapDatabaseViewMappings mappingsWithGroups:@[ @"" ] view:@"order"];
+
+	[connection2 beginLongLivedReadTransaction];
+	[connection2 readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+
+		[mappings updateWithTransaction:transaction];
+	}];
+
+	YapDatabaseViewSorting *newSorting = [YapDatabaseViewSorting withObjectBlock:
+		^(YapDatabaseReadTransaction *transaction, NSString *group,
+			NSString *collection1, NSString *key1, id obj1,
+			NSString *collection2, NSString *key2, id obj2)
+	{
+		__unsafe_unretained NSNumber *number1 = (NSNumber *)obj1;
+		__unsafe_unretained NSNumber *number2 = (NSNumber *)obj2;
+
+		return [number2 compare:number1];
+	}];
+
+	[connection1 readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+
+		[[transaction ext:@"order"] setSorting:newSorting
+		                            versionTag:@"2"];
+	}];
+
+	NSArray *notifications =[connection2 beginLongLivedReadTransaction];
+
+	NSArray *sectionChanges = nil;
+	NSArray *rowChanges = nil;
+
+	[[connection2 ext:@"order"] getSectionChanges:&sectionChanges
+	                                   rowChanges:&rowChanges
+	                             forNotifications:notifications
+	                                 withMappings:mappings];
+
+	XCTAssertTrue([sectionChanges count] == 0, @"Bad count");
+	XCTAssertTrue([rowChanges count] == 5, @"Bad count");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/YapDatabase/Extensions/AutoView/Internal/YapDatabaseAutoViewPrivate.h
+++ b/YapDatabase/Extensions/AutoView/Internal/YapDatabaseAutoViewPrivate.h
@@ -85,6 +85,9 @@
             sorting:(YapDatabaseViewSorting *)newSorting
          versionTag:(NSString *)newVersionTag;
 
+- (void)setSorting:(YapDatabaseViewSorting *)newSorting
+        versionTag:(NSString *)newVersionTag;
+
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewConnection.m
+++ b/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewConnection.m
@@ -175,6 +175,16 @@
 	versionTagChanged = YES;
 }
 
+- (void)setSorting:(YapDatabaseViewSorting *)newSorting
+        versionTag:(NSString *)newVersionTag
+{
+	sorting = newSorting;
+	sortingChanged = YES;
+
+	versionTag = newVersionTag;
+	versionTagChanged = YES;
+}
+
 - (void)getGrouping:(YapDatabaseViewGrouping **)groupingPtr
             sorting:(YapDatabaseViewSorting **)sortingPtr
 {

--- a/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewTransaction.h
+++ b/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewTransaction.h
@@ -164,6 +164,15 @@ NS_ASSUME_NONNULL_BEGIN
             sorting:(YapDatabaseViewSorting *)sorting
          versionTag:(nullable NSString *)versionTag;
 
+/**
+ * This method allows you to change the sorting on-the-fly.
+ *
+ * Note: You must pass a different versionTag, or this method does nothing.
+ * If needed, you can fetch the current versionTag via the [viewTransaction versionTag] method.
+ **/
+- (void)setSorting:(YapDatabaseViewSorting *)sorting
+        versionTag:(nullable NSString *)versionTag;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewTransaction.m
+++ b/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewTransaction.m
@@ -451,6 +451,50 @@
 	isRepopulate = NO;
 }
 
+- (void)resortView {
+	YDBLogAutoTrace();
+
+	NSMutableDictionary *groups = NSMutableDictionary.new;
+
+	[self enumerateGroupsUsingBlock:^(NSString * _Nonnull group, BOOL * _Nonnull stop) {
+		NSMutableArray *rows = NSMutableArray.new;
+		[self enumerateRowidsInGroup:group usingBlock:^(int64_t rowid, NSUInteger index, BOOL *stop) {
+			[rows addObject:@(rowid)];
+		}];
+		groups[group] = rows;
+	}];
+
+	__unsafe_unretained YapDatabaseAutoViewConnection *viewConnection = (YapDatabaseAutoViewConnection *)parentConnection;
+	YapDatabaseBlockInvoke blockInvokeBitMask = YapDatabaseBlockInvokeIfObjectModified | YapDatabaseBlockInvokeIfMetadataModified;
+	YapDatabaseViewChangesBitMask changesBitMask = YapDatabaseViewChangedObject | YapDatabaseViewChangedMetadata;
+
+	[groups enumerateKeysAndObjectsUsingBlock:^(NSString *group, NSArray<NSNumber *> *rowIds, BOOL *stop) {
+		[rowIds enumerateObjectsUsingBlock:^(NSNumber *obj, NSUInteger idx, BOOL *stop) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-retain-self"
+			int64_t rowid = obj.integerValue;
+
+			YapDatabaseViewSorting *sorting = nil;
+
+			YapCollectionKey *collectionKey = [databaseTransaction collectionKeyForRowid:rowid];
+			id object = [databaseTransaction objectForCollectionKey:collectionKey withRowid:rowid];
+			id metadata = [databaseTransaction metadataForCollectionKey:collectionKey withRowid:rowid];
+
+			[viewConnection getGrouping:NULL sorting:&sorting];
+
+			[self _handleChangeWithRowid:rowid
+			               collectionKey:collectionKey
+			                      object:object
+			                    metadata:metadata
+			                     sorting:sorting
+			          blockInvokeBitMask:blockInvokeBitMask
+			              changesBitMask:changesBitMask
+			                    isInsert:NO];
+#pragma clang diagnostic pop
+		}];
+	}];
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Logic
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -875,6 +919,75 @@
 	
 	// Add row to the view or update its position.
 	
+	[self insertRowid:rowid
+	    collectionKey:collectionKey
+	           object:object
+	         metadata:metadata
+	          inGroup:group
+	      withChanges:changesBitMask
+	            isNew:isInsert];
+}
+
+- (void)_handleChangeWithRowid:(int64_t)rowid
+                 collectionKey:(YapCollectionKey *)collectionKey
+                        object:(id)object
+                      metadata:(id)metadata
+                       sorting:(YapDatabaseViewSorting *)sorting
+            blockInvokeBitMask:(YapDatabaseBlockInvoke)blockInvokeBitMask
+                changesBitMask:(YapDatabaseViewChangesBitMask)changesBitMask
+                      isInsert:(BOOL)isInsert
+{
+	YDBLogAutoTrace();
+
+	__unsafe_unretained YapDatabaseView *view = (YapDatabaseView *)parentConnection->parent;
+
+	__unsafe_unretained NSString *collection = collectionKey.collection;
+
+	// Should we ignore the row based on the allowedCollections ?
+
+	YapWhitelistBlacklist *allowedCollections = view->options.allowedCollections;
+
+	if (allowedCollections && ![allowedCollections isAllowed:collection])
+	{
+		return;
+	}
+
+	// Determine if the grouping or sorting may have changed
+	BOOL sortingMayHaveChanged = (sorting->blockInvokeOptions & blockInvokeBitMask);
+	if (!sortingMayHaveChanged)
+	{
+		// Nothing left to do.
+		// The sortingBlock does not need to run
+
+		YapDatabaseViewLocator *locator = [self locatorForRowid:rowid];
+
+		if (locator.group)
+		{
+			[parentConnection->changes addObject:
+			 [YapDatabaseViewRowChange updateCollectionKey:collectionKey
+			                                       inGroup:locator.group
+			                                       atIndex:locator.index
+			                                   withChanges:changesBitMask]];
+		}
+
+		return;
+	}
+
+	// Grouping hasn't changed.
+	// Fetch the current group.
+	YapDatabaseViewLocator *locator = [self locatorForRowid:rowid];
+	NSString *group = locator.group;
+
+	if (group == nil)
+	{
+		// Nothing to do.
+		// The row wasn't previously in the view, and still isn't in the view.
+
+		return;
+	}
+
+	// Add row to the view or update its position.
+
 	[self insertRowid:rowid
 	    collectionKey:collectionKey
 	           object:object
@@ -1522,58 +1635,86 @@
 	
 	NSAssert(grouping != nil, @"Invalid parameter: grouping == nil");
 	NSAssert(sorting != nil, @"Invalid parameter: sorting == nil");
-	
+
+	[self _setGrouping:grouping
+	           sorting:sorting
+	        versionTag:inVersionTag];
+}
+
+- (void)setSorting:(YapDatabaseViewSorting *)sorting
+        versionTag:(NSString *)versionTag {
+	YDBLogAutoTrace();
+
+	NSAssert(sorting != nil, @"Invalid parameter: sorting == nil");
+
+	[self _setGrouping:nil
+	           sorting:sorting
+	        versionTag:versionTag];
+}
+
+- (void)_setGrouping:(nullable YapDatabaseViewGrouping *)grouping
+             sorting:(YapDatabaseViewSorting *)sorting
+          versionTag:(NSString *)inVersionTag
+{
+	YDBLogAutoTrace();
+
 	if (!databaseTransaction->isReadWriteTransaction)
 	{
 		YDBLogWarn(@"%@ - Method only allowed in readWrite transaction", THIS_METHOD);
 		return;
 	}
-	
+
 	NSString *newVersionTag = inVersionTag ? [inVersionTag copy] : @"";
-	
+
 	if ([[self versionTag] isEqualToString:newVersionTag])
 	{
 		YDBLogWarn(@"%@ - versionTag didn't change, so not updating view", THIS_METHOD);
 		return;
 	}
-	
+
 	__unsafe_unretained YapDatabaseAutoViewConnection *viewConnection =
-	  (YapDatabaseAutoViewConnection *)parentConnection;
-	
-	[viewConnection setGrouping:grouping
-	                    sorting:sorting
-	                 versionTag:newVersionTag];
-	
-	[self repopulateView];
-	
+	(YapDatabaseAutoViewConnection *)parentConnection;
+
+	if (grouping) {
+		[viewConnection setGrouping:grouping
+		                    sorting:sorting
+		                 versionTag:newVersionTag];
+		[self repopulateView];
+	} else {
+		[viewConnection setSorting:sorting
+		                versionTag:newVersionTag];
+		[self resortView];
+	}
+
 	[self setStringValue:newVersionTag
 	     forExtensionKey:ext_key_versionTag
 	          persistent:[self isPersistentView]];
-	
+
 	// Notify any extensions dependent upon this one that we repopulated.
-	
+
 	NSString *registeredName = [self registeredName];
 	NSDictionary *extensionDependencies = databaseTransaction->connection->extensionDependencies;
-	
+
 	[extensionDependencies enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL __unused *stop){
 	#pragma clang diagnostic push
 	#pragma clang diagnostic ignored "-Wimplicit-retain-self"
-		
+
 		__unsafe_unretained NSString *extName = (NSString *)key;
 		__unsafe_unretained NSSet *extDependencies = (NSSet *)obj;
-		
+
 		if ([extDependencies containsObject:registeredName])
 		{
 			YapDatabaseExtensionTransaction *extTransaction = [databaseTransaction ext:extName];
-			
+
 			if ([extTransaction respondsToSelector:@selector(view:didRepopulateWithFlags:)])
 			{
+				// TODO: If grouping == nil, should we be including the YDB_GroupingMayHaveChanged flag?
 				int flags = YDB_GroupingMayHaveChanged | YDB_SortingMayHaveChanged;
 				[(id <YapDatabaseViewDependency>)extTransaction view:registeredName didRepopulateWithFlags:flags];
 			}
 		}
-		
-	#pragma clang diagnostic pop
+
+#pragma clang diagnostic pop
 	}];
 }
 

--- a/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewTransaction.m
+++ b/YapDatabase/Extensions/AutoView/YapDatabaseAutoViewTransaction.m
@@ -454,6 +454,14 @@
 - (void)resortView {
 	YDBLogAutoTrace();
 
+	// TODO: Refactor
+	// This is written this way to avoid mutating the view while enumerating it.
+	// I didn't see another way of doing this that didn't end up invoking the grouping
+	// block, which is what we're trying to avoid here.
+	//
+	// Refactor in at least one of two ways:
+	// 1. Stop using NSNumber. int64_t is 8 bytes, but an NSNumber boxing an int64_t is...probably a lot more.
+	// 2. Stop storing all row ids in memory. If that's possible, #1 doesn't matter so much.
 	NSMutableDictionary *groups = NSMutableDictionary.new;
 
 	[self enumerateGroupsUsingBlock:^(NSString * _Nonnull group, BOOL * _Nonnull stop) {


### PR DESCRIPTION
Related #222 
Resolves #286

Adds `setSorting:versionTag:` to `YapDatabaseAutoViewTransaction`, which allows you to update the sorting block without the overhead of re-grouping all records in the view. 

High points:
* [resortView](https://github.com/yapstudios/YapDatabase/compare/master...Tundaware:setSorting?expand=1#diff-02c1115218b921769037dbd78cb98b7dR454) method
* [new _handleChangeWithRowid:...](https://github.com/yapstudios/YapDatabase/compare/master...Tundaware:setSorting?expand=1#diff-02c1115218b921769037dbd78cb98b7dR939) method that is only interested in the sorting block
* Two new tests added that test updating just the sorting block.

I don't like the first half of the `resortView` method where it gathers the row ids. It shouldn't be a problem for most data sets, but loading all rowIds into memory, each boxed in an NSNumber doesn't feel good at all. This should be refactored to use a data structure with a predictable memory footprint, but I wanted to get something working first to make sure I wasn't missing any larger concepts.

The two `_handleChangeWithRowid:...` methods can also probably be refactored a bit to share some code. Again, want to make sure I haven't missed something important first.