### PR TITLE
Block arguments decorated w/ NS_NOESCAPE where appropriate

### DIFF
--- a/YapDatabase/Extensions/CloudCore/Internal/YapDatabaseCloudCorePipelinePrivate.h
+++ b/YapDatabase/Extensions/CloudCore/Internal/YapDatabaseCloudCorePipelinePrivate.h
@@ -51,7 +51,7 @@
 
 - (YapDatabaseCloudCoreOperation *)_operationWithUUID:(NSUUID *)uuid;
 
-- (void)_enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                                 NSUInteger graphIdx, BOOL *stop))enumBlock;
+- (void)_enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                            NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 @end

--- a/YapDatabase/Extensions/CloudCore/Internal/YapDatabaseCloudCorePrivate.h
+++ b/YapDatabase/Extensions/CloudCore/Internal/YapDatabaseCloudCorePrivate.h
@@ -190,35 +190,35 @@ typedef NS_OPTIONS(uint8_t, YDBCloudCore_EnumOps) {
 - (YapDatabaseCloudCoreOperation *)_operationWithUUID:(NSUUID *)uuid;
 - (YapDatabaseCloudCoreOperation *)_operationWithUUID:(NSUUID *)uuid inPipeline:(NSString *)pipelineName;
 
-- (void)_enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                                 YapDatabaseCloudCoreOperation *operation,
-                                                 NSUInteger graphIdx, BOOL *stop))enumBlock;
+- (void)_enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                            YapDatabaseCloudCoreOperation *operation,
+                                                            NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 - (void)_enumerateOperationsInPipeline:(NSString *)pipelineName
-                            usingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                                 NSUInteger graphIdx, BOOL *stop))enumBlock;
+                            usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                            NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 - (void)_enumerateOperations:(YDBCloudCore_EnumOps)flags
-                  usingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                       YapDatabaseCloudCoreOperation *operation,
-                                       NSUInteger graphIdx, BOOL *stop))enumBlock;
+                  usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                  YapDatabaseCloudCoreOperation *operation,
+                                                  NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 - (void)_enumerateOperations:(YDBCloudCore_EnumOps)flags
                   inPipeline:(YapDatabaseCloudCorePipeline *)pipeline
-                  usingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                       NSUInteger graphIdx, BOOL *stop))enumBlock;
+                  usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                  NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 - (void)_enumerateAndModifyOperations:(YDBCloudCore_EnumOps)flags
                            usingBlock:(YapDatabaseCloudCoreOperation *
-                                      (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                          YapDatabaseCloudCoreOperation *operation,
-                                          NSUInteger graphIdx, BOOL *stop))enumBlock;
+                                      (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                     YapDatabaseCloudCoreOperation *operation,
+                                                     NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 - (void)_enumerateAndModifyOperations:(YDBCloudCore_EnumOps)flags
                            inPipeline:(YapDatabaseCloudCorePipeline *)pipeline
                            usingBlock:(YapDatabaseCloudCoreOperation *
-                                      (^)(YapDatabaseCloudCoreOperation *operation,
-                                          NSUInteger graphIdx, BOOL *stop))enumBlock;
+                                      (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                     NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 /**
  * Throw this if an attempt is made to invoke a read-write action within a read-only transaction.

--- a/YapDatabase/Extensions/CloudCore/Utilities/Execution/YapDatabaseCloudCorePipeline.h
+++ b/YapDatabase/Extensions/CloudCore/Utilities/Execution/YapDatabaseCloudCorePipeline.h
@@ -214,8 +214,8 @@ extern NSString *const YDBCloudCorePipelineActiveStatusChangedNotification;
  * This is useful for finding operation.
  * For example, you might use this to search for an upload operation with a certain cloudPath.
 **/
-- (void)enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                                NSUInteger graphIdx, BOOL *stop))enumBlock;
+- (void)enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                           NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 /**
  * Returns the number of graphs queued in the pipeline.

--- a/YapDatabase/Extensions/CloudCore/Utilities/Execution/YapDatabaseCloudCorePipeline.m
+++ b/YapDatabase/Extensions/CloudCore/Utilities/Execution/YapDatabaseCloudCorePipeline.m
@@ -390,8 +390,8 @@ NSString *const YDBCloudCore_EphemeralKey_Hold     = @"hold";
 	return results;
 }
 
-- (void)enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                                NSUInteger graphIdx, BOOL *stop))enumBlock
+- (void)enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                           NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	[self _enumerateOperationsUsingBlock:^(YapDatabaseCloudCoreOperation *operation, NSUInteger graphIdx, BOOL *stop) {
 		
@@ -399,8 +399,8 @@ NSString *const YDBCloudCore_EphemeralKey_Hold     = @"hold";
 	}];
 }
 
-- (void)_enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                                 NSUInteger graphIdx, BOOL *stop))enumBlock
+- (void)_enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                            NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	__block NSMutableArray<NSArray<YapDatabaseCloudCoreOperation *> *> *graphOperations = nil;
 	

--- a/YapDatabase/Extensions/CloudCore/Utilities/YapManyToManyCache.h
+++ b/YapDatabase/Extensions/CloudCore/Utilities/YapManyToManyCache.h
@@ -130,15 +130,15 @@ NS_ASSUME_NONNULL_BEGIN
  * 
  * All key/value tuples accessed during enumeration are moved to the beginning of the most-recently-used linked-list.
 **/
-- (void)enumerateValuesForKey:(id)key withBlock:(void (^)(id value, __nullable id metadata, BOOL *stop))block;
-- (void)enumerateKeysForValue:(id)value withBlock:(void (^)(id value, __nullable id metadata, BOOL *stop))block;
+- (void)enumerateValuesForKey:(id)key withBlock:(void (NS_NOESCAPE^)(id value, __nullable id metadata, BOOL *stop))block;
+- (void)enumerateKeysForValue:(id)value withBlock:(void (NS_NOESCAPE^)(id value, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Enumerates all key/value pairs in the cache.
  * 
  * As this method is designed to enumerate all values, it ddes not affect the most-recently-used linked-list.
 **/
-- (void)enumerateWithBlock:(void (^)(id key, id value, __nullable id metadata, BOOL *stop))block;
+- (void)enumerateWithBlock:(void (NS_NOESCAPE^)(id key, id value, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Removes the tuple that matches the given key/value pair.

--- a/YapDatabase/Extensions/CloudCore/Utilities/YapManyToManyCache.m
+++ b/YapDatabase/Extensions/CloudCore/Utilities/YapManyToManyCache.m
@@ -598,7 +598,7 @@ static const NSUInteger YapManyToManyCacheDefaultCountLimit = 40;
 	return range.length;
 }
 
-- (void)enumerateValuesForKey:(id)key withBlock:(void (^)(id value, id metadata, BOOL *stop))block
+- (void)enumerateValuesForKey:(id)key withBlock:(void (NS_NOESCAPE^)(id value, id metadata, BOOL *stop))block
 {
 	if (key == nil) return;
 	if (block == NULL) return;
@@ -660,7 +660,7 @@ static const NSUInteger YapManyToManyCacheDefaultCountLimit = 40;
 	}
 }
 
-- (void)enumerateKeysForValue:(id)value withBlock:(void (^)(id value, id metadata, BOOL *stop))block
+- (void)enumerateKeysForValue:(id)value withBlock:(void (NS_NOESCAPE^)(id value, id metadata, BOOL *stop))block
 {
 	if (value == nil) return;
 	if (block == NULL) return;
@@ -801,7 +801,7 @@ static const NSUInteger YapManyToManyCacheDefaultCountLimit = 40;
  * 
  * As this method is designed to enumerate all values, it ddes not affect the most-recently-used linked-list.
 **/
-- (void)enumerateWithBlock:(void (^)(id key, id value, id metadata, BOOL *stop))block
+- (void)enumerateWithBlock:(void (NS_NOESCAPE^)(id key, id value, id metadata, BOOL *stop))block
 {
 	if (block == NULL) return;
 	

--- a/YapDatabase/Extensions/CloudCore/YapDatabaseCloudCoreTransaction.h
+++ b/YapDatabase/Extensions/CloudCore/YapDatabaseCloudCoreTransaction.h
@@ -89,13 +89,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)skipOperationWithUUID:(NSUUID *)operationUUID;
 - (void)skipOperationWithUUID:(NSUUID *)operationUUID inPipeline:(nullable NSString *)pipelineName;
 
-- (void)skipOperationsPassingTest:(BOOL (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                            YapDatabaseCloudCoreOperation *operation,
-                                            NSUInteger graphIdx, BOOL *stop))testBlock;
+- (void)skipOperationsPassingTest:(BOOL (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                       YapDatabaseCloudCoreOperation *operation,
+                                                       NSUInteger graphIdx, BOOL *stop))testBlock;
 
 - (void)skipOperationsInPipeline:(NSString *)pipeline
-                     passingTest:(BOOL (^)(YapDatabaseCloudCoreOperation *operation,
-                                           NSUInteger graphIdx, BOOL *stop))testBlock;
+                     passingTest:(BOOL (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                      NSUInteger graphIdx, BOOL *stop))testBlock;
 
 #pragma mark Operation Searching
 
@@ -153,9 +153,9 @@ NS_ASSUME_NONNULL_BEGIN
  *   For example, if an operation has been modified within the read-write transaction,
  *   then you'll see the uncommitted modified version of the operation when enumerating.
  **/
-- (void)enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                                YapDatabaseCloudCoreOperation *operation,
-                                                NSUInteger graphIdx, BOOL *stop))enumBlock;
+- (void)enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                           YapDatabaseCloudCoreOperation *operation,
+                                                           NSUInteger graphIdx, BOOL *stop))enumBlock;
 /**
  * Enumerates the queued operations in a particluar pipeline.
  *
@@ -172,8 +172,8 @@ NS_ASSUME_NONNULL_BEGIN
  *   then you'll see the uncommitted modified version of the operation when enumerating.
 **/
 - (void)enumerateOperationsInPipeline:(NSString *)pipeline
-                      usingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                           NSUInteger graphIdx, BOOL *stop))enumBlock;
+                      usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                      NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 /**
  * Enumerates only those operations that have been added during this commit.
@@ -181,9 +181,9 @@ NS_ASSUME_NONNULL_BEGIN
  * That is, the operations added via the `addOperation:` method,
  * within the current readWriteTransaction.
 **/
-- (void)enumerateAddedOperationsUsingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                                     YapDatabaseCloudCoreOperation *operation,
-                                                     NSUInteger graphIdx, BOOL *stop))enumBlock;
+- (void)enumerateAddedOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                                YapDatabaseCloudCoreOperation *operation,
+                                                                NSUInteger graphIdx, BOOL *stop))enumBlock;
 /**
  * Enumerates only those operations that have been added during this commit.
  *
@@ -191,8 +191,8 @@ NS_ASSUME_NONNULL_BEGIN
  * within the current readWriteTransaction.
 **/
 - (void)enumerateAddedOperationsInPipeline:(NSString *)pipeline
-                                usingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                                     NSUInteger graphIdx, BOOL *stop))enumBlock;
+                                usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                                NSUInteger graphIdx, BOOL *stop))enumBlock;
 
 #pragma mark Tag Support
 
@@ -345,14 +345,14 @@ NS_ASSUME_NONNULL_BEGIN
  * added to the database yet, the pending flag will be set to YES.
 **/
 - (void)enumerateAttachedForCloudURI:(NSString *)cloudURI
-                          usingBlock:(void (^)(NSString *key, NSString *collection, BOOL pending, BOOL *stop))block;
+                          usingBlock:(void (NS_NOESCAPE^)(NSString *key, NSString *collection, BOOL pending, BOOL *stop))block;
 
 /**
  * Allows you to enumerate all attached cloudURI's for the given <collection, key> tuple.
 **/
 - (void)enumerateAttachedForKey:(NSString *)key
                      collection:(nullable NSString *)collection
-                     usingBlock:(void (^)(NSString *cloudURI, BOOL *stop))block;
+                     usingBlock:(void (NS_NOESCAPE^)(NSString *cloudURI, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Extensions/CloudCore/YapDatabaseCloudCoreTransaction.m
+++ b/YapDatabase/Extensions/CloudCore/YapDatabaseCloudCoreTransaction.m
@@ -2385,9 +2385,9 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 /**
  * Use this method to skip/abort operations (across all registered pipelines).
 **/
-- (void)skipOperationsPassingTest:(BOOL (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                            YapDatabaseCloudCoreOperation *operation,
-                                            NSUInteger graphIdx, BOOL *stop))testBlock
+- (void)skipOperationsPassingTest:(BOOL (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                       YapDatabaseCloudCoreOperation *operation,
+                                                       NSUInteger graphIdx, BOOL *stop))testBlock
 {
 	YDBLogAutoTrace();
 	
@@ -2436,8 +2436,8 @@ static NSString *const ext_key_versionTag   = @"versionTag";
  * Use this method to skip/abort operations in a specific pipeline.
 **/
 - (void)skipOperationsInPipeline:(NSString *)pipelineName
-                     passingTest:(BOOL (^)(YapDatabaseCloudCoreOperation *operation,
-                                           NSUInteger graphIdx, BOOL *stop))testBlock;
+                     passingTest:(BOOL (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                      NSUInteger graphIdx, BOOL *stop))testBlock;
 {
 	YDBLogAutoTrace();
 	
@@ -2741,9 +2741,9 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 /**
  * Public API
 **/
-- (void)enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                               YapDatabaseCloudCoreOperation *operation,
-                                               NSUInteger graphIdx, BOOL *stop))enumBlock
+- (void)enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                           YapDatabaseCloudCoreOperation *operation,
+                                                           NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	[self _enumerateOperationsUsingBlock:
 	    ^(YapDatabaseCloudCorePipeline *pipeline,
@@ -2758,7 +2758,7 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 **/
 - (void)enumerateOperationsInPipeline:(NSString *)pipelineName
                            usingBlock:
-    (void (^)(YapDatabaseCloudCoreOperation *operation, NSUInteger graphIdx, BOOL *stop))enumBlock
+    (void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation, NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	[self _enumerateOperationsInPipeline:pipelineName
 									  usingBlock:^(YapDatabaseCloudCoreOperation *operation, NSUInteger graphIdx, BOOL *stop)
@@ -2770,9 +2770,9 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 /**
  * Public API
 **/
-- (void)enumerateAddedOperationsUsingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                                     YapDatabaseCloudCoreOperation *operation,
-                                                     NSUInteger graphIdx, BOOL *stop))enumBlock
+- (void)enumerateAddedOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                                YapDatabaseCloudCoreOperation *operation,
+                                                                NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	if (enumBlock == nil) return;
 	if (databaseTransaction->isReadWriteTransaction == NO) return;
@@ -2792,8 +2792,8 @@ static NSString *const ext_key_versionTag   = @"versionTag";
  * Public API
 **/
 - (void)enumerateAddedOperationsInPipeline:(NSString *)pipelineName
-                                usingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                                     NSUInteger graphIdx, BOOL *stop))enumBlock
+                                usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                                NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	if (enumBlock == nil) return;
 	if (databaseTransaction->isReadWriteTransaction == NO) return;
@@ -2816,9 +2816,9 @@ static NSString *const ext_key_versionTag   = @"versionTag";
  * The public version returns a copy of the operation (for safety).
  * The internal version returns the operation sans copy (only safe for internal components).
 **/
-- (void)_enumerateOperationsUsingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                                 YapDatabaseCloudCoreOperation *operation,
-                                                 NSUInteger graphIdx, BOOL *stop))enumBlock
+- (void)_enumerateOperationsUsingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                            YapDatabaseCloudCoreOperation *operation,
+                                                            NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	if (enumBlock == nil) return;
 	
@@ -2869,7 +2869,7 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 **/
 - (void)_enumerateOperationsInPipeline:(NSString *)pipelineName
                             usingBlock:
-    (void (^)(YapDatabaseCloudCoreOperation *operation, NSUInteger graphIdx, BOOL *stop))enumBlock
+    (void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation, NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	if (enumBlock == nil) return;
 	
@@ -2905,9 +2905,9 @@ static NSString *const ext_key_versionTag   = @"versionTag";
  * Allows for enumeration of all existing, inserted & added operations (filtering as needed via parameter).
 **/
 - (void)_enumerateOperations:(YDBCloudCore_EnumOps)flags
-                  usingBlock:(void (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                       YapDatabaseCloudCoreOperation *operation,
-                                       NSUInteger graphIdx, BOOL *stop))enumBlock
+                  usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                  YapDatabaseCloudCoreOperation *operation,
+                                                  NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	[self _enumerateAndModifyOperations:flags
 	                         usingBlock:
@@ -2926,8 +2926,8 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 **/
 - (void)_enumerateOperations:(YDBCloudCore_EnumOps)flags
                   inPipeline:(YapDatabaseCloudCorePipeline *)pipeline
-                  usingBlock:(void (^)(YapDatabaseCloudCoreOperation *operation,
-                                       NSUInteger graphIdx, BOOL *stop))enumBlock
+                  usingBlock:(void (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                  NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	[self _enumerateAndModifyOperations:flags
 	                         inPipeline:pipeline
@@ -2947,9 +2947,9 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 **/
 - (void)_enumerateAndModifyOperations:(YDBCloudCore_EnumOps)flags
                            usingBlock:(YapDatabaseCloudCoreOperation *
-                                      (^)(YapDatabaseCloudCorePipeline *pipeline,
-                                          YapDatabaseCloudCoreOperation *operation,
-                                          NSUInteger graphIdx, BOOL *stop))enumBlock
+                                      (NS_NOESCAPE^)(YapDatabaseCloudCorePipeline *pipeline,
+                                                     YapDatabaseCloudCoreOperation *operation,
+                                                     NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	NSAssert(databaseTransaction->isReadWriteTransaction, @"Oops");
 	if (enumBlock == nil) return;
@@ -2977,8 +2977,8 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 - (void)_enumerateAndModifyOperations:(YDBCloudCore_EnumOps)flags
                            inPipeline:(YapDatabaseCloudCorePipeline *)pipeline
                            usingBlock:(YapDatabaseCloudCoreOperation *
-                                      (^)(YapDatabaseCloudCoreOperation *operation,
-                                          NSUInteger graphIdx, BOOL *stop))enumBlock
+                                      (NS_NOESCAPE^)(YapDatabaseCloudCoreOperation *operation,
+                                                     NSUInteger graphIdx, BOOL *stop))enumBlock
 {
 	NSAssert(databaseTransaction->isReadWriteTransaction, @"Oops");
 	if (enumBlock == nil) return;
@@ -3488,7 +3488,7 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 }
 
 - (void)enumerateAttachedForCloudURI:(NSString *)cloudURI
-                          usingBlock:(void (^)(NSString *key, NSString *collection, BOOL pending, BOOL *stop))block
+                          usingBlock:(void (NS_NOESCAPE^)(NSString *key, NSString *collection, BOOL pending, BOOL *stop))block
 {
 	BOOL stop = NO;
 	
@@ -3517,7 +3517,7 @@ static NSString *const ext_key_versionTag   = @"versionTag";
 
 - (void)enumerateAttachedForKey:(NSString *)key
                      collection:(nullable NSString *)collection
-                     usingBlock:(void (^)(NSString *cloudURI, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(NSString *cloudURI, BOOL *stop))block
 {
 	int64_t rowid = 0;
 	if ([databaseTransaction getRowid:&rowid forKey:key inCollection:collection])

--- a/YapDatabase/Extensions/CloudKit/Internal/YapDatabaseCloudKitPrivate.h
+++ b/YapDatabase/Extensions/CloudKit/Internal/YapDatabaseCloudKitPrivate.h
@@ -255,7 +255,7 @@ static NSString *const changeset_key_reset            = @"reset";
 // Blob to go in 'modifiedRecords' column of database row.
 - (NSData *)serializeModifiedRecords;
 
-- (void)enumerateMissingRecordsWithBlock:(CKRecord* (^)(CKRecordID *recordID, NSArray *changedKeys))block;
+- (void)enumerateMissingRecordsWithBlock:(CKRecord* (NS_NOESCAPE^)(CKRecordID *recordID, NSArray *changedKeys))block;
 
 @end
 

--- a/YapDatabase/Extensions/CloudKit/Utilities/YDBCKChangeSet.m
+++ b/YapDatabase/Extensions/CloudKit/Utilities/YDBCKChangeSet.m
@@ -212,7 +212,7 @@ databaseIdentifier:(NSString *)inDatabaseIdentifier
 	}
 }
 
-- (void)enumerateMissingRecordsWithBlock:(CKRecord* (^)(CKRecordID *recordID, NSArray *changedKeys))block
+- (void)enumerateMissingRecordsWithBlock:(CKRecord* (NS_NOESCAPE^)(CKRecordID *recordID, NSArray *changedKeys))block
 {
 	for (YDBCKChangeRecord *changeRecord in [modifiedRecords objectEnumerator])
 	{

--- a/YapDatabase/Extensions/FullTextSearch/Internal/YapDatabaseFullTextSearchPrivate.h
+++ b/YapDatabase/Extensions/FullTextSearch/Internal/YapDatabaseFullTextSearchPrivate.h
@@ -105,12 +105,12 @@
            databaseTransaction:(YapDatabaseReadTransaction *)databaseTransaction;
 
 - (void)enumerateRowidsMatching:(NSString *)query
-                     usingBlock:(void (^)(int64_t rowid, BOOL *stop))block;
+                     usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, BOOL *stop))block;
 
 - (void)enumerateRowidsMatching:(NSString *)query
              withSnippetOptions:(YapDatabaseFullTextSearchSnippetOptions *)inOptions
                      usingBlock:
-            (void (^)(NSString *snippet, int64_t rowid, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *snippet, int64_t rowid, BOOL *stop))block;
 
 - (BOOL)rowid:(int64_t)rowid matches:(NSString *)query;
 - (NSString *)rowid:(int64_t)rowid matches:(NSString *)query

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.h
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.h
@@ -33,56 +33,56 @@ NS_ASSUME_NONNULL_BEGIN
 // Regular query matching
 
 - (void)enumerateKeysMatching:(NSString *)query
-                   usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block;
+                   usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataMatching:(NSString *)query
-                              usingBlock:(void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (void)enumerateKeysAndObjectsMatching:(NSString *)query
-                             usingBlock:(void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
+                             usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
 
 - (void)enumerateRowsMatching:(NSString *)query
-                   usingBlock:(void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
+                   usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 // FTS5 bm25 ordering
 
 - (void)enumerateBm25OrderedKeysMatching:(NSString *)query
                              withWeights:(nullable NSArray<NSNumber *> *)weights
-                              usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block;
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block;
 
 - (void)enumerateBm25OrderedKeysAndMetadataMatching:(NSString *)query
                                         withWeights:(nullable NSArray<NSNumber *> *)weights
-                                         usingBlock:(void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
+                                         usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (void)enumerateBm25OrderedKeysAndObjectsMatching:(NSString *)query
                                        withWeights:(nullable NSArray<NSNumber *> *)weights
-                                        usingBlock:(void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
+                                        usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
 
 - (void)enumerateBm25OrderedRowsMatching:(NSString *)query
                              withWeights:(nullable NSArray<NSNumber *> *)weights
-                              usingBlock:(void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 // Query matching + Snippets
 
 - (void)enumerateKeysMatching:(NSString *)query
            withSnippetOptions:(nullable YapDatabaseFullTextSearchSnippetOptions *)options
                    usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataMatching:(NSString *)query
                       withSnippetOptions:(nullable YapDatabaseFullTextSearchSnippetOptions *)options
                               usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (void)enumerateKeysAndObjectsMatching:(NSString *)query
                      withSnippetOptions:(nullable YapDatabaseFullTextSearchSnippetOptions *)options
                              usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, id object, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, id object, BOOL *stop))block;
 
 - (void)enumerateRowsMatching:(NSString *)query
            withSnippetOptions:(nullable YapDatabaseFullTextSearchSnippetOptions *)options
                    usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
+++ b/YapDatabase/Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.m
@@ -884,7 +884,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (void)enumerateRowidsMatching:(NSString *)query
-                     usingBlock:(void (^)(int64_t rowid, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, BOOL *stop))block
 {
 	if (block == nil) return;
 	if ([query length] == 0) return;
@@ -930,7 +930,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 }
 
 - (void)enumerateKeysMatching:(NSString *)query
-                   usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block
+                   usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -941,7 +941,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 }
 
 - (void)enumerateKeysAndMetadataMatching:(NSString *)query
-                              usingBlock:(void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -954,7 +954,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 }
 
 - (void)enumerateKeysAndObjectsMatching:(NSString *)query
-                             usingBlock:(void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block
+                             usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -967,7 +967,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 }
 
 - (void)enumerateRowsMatching:(NSString *)query
-                   usingBlock:(void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                   usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -986,7 +986,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 
 - (void)enumerateBm25OrderedRowidsMatching:(NSString *)query
                                withWeights:(nullable NSArray<NSNumber *> *)weights
-                                usingBlock:(void (^)(int64_t rowid, BOOL *stop))block
+                                usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, BOOL *stop))block
 {
     if (![parentConnection->parent.ftsVersion isEqualToString:YapDatabaseFullTextSearchFTS5Version]) {
         NSString *reason = [NSString stringWithFormat:
@@ -1044,7 +1044,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 
 - (void)enumerateBm25OrderedKeysMatching:(NSString *)query
                              withWeights:(nullable NSArray<NSNumber *> *)weights
-                              usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block {
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block {
     [self enumerateBm25OrderedRowidsMatching:query withWeights:weights usingBlock:^(int64_t rowid, BOOL *stop) {
         
         YapCollectionKey *ck = [self->databaseTransaction collectionKeyForRowid:rowid];
@@ -1055,7 +1055,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 
 - (void)enumerateBm25OrderedKeysAndMetadataMatching:(NSString *)query
                                         withWeights:(nullable NSArray<NSNumber *> *)weights
-                                         usingBlock:(void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block {
+                                         usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block {
     [self enumerateBm25OrderedRowidsMatching:query withWeights:weights usingBlock:^(int64_t rowid, BOOL *stop) {
         
         YapCollectionKey *ck = nil;
@@ -1068,7 +1068,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 
 - (void)enumerateBm25OrderedKeysAndObjectsMatching:(NSString *)query
                                        withWeights:(nullable NSArray<NSNumber *> *)weights
-                                        usingBlock:(void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block {
+                                        usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block {
     [self enumerateBm25OrderedRowidsMatching:query withWeights:weights usingBlock:^(int64_t rowid, BOOL *stop) {
         
         YapCollectionKey *ck = nil;
@@ -1081,7 +1081,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 
 - (void)enumerateBm25OrderedRowsMatching:(NSString *)query
                              withWeights:(nullable NSArray<NSNumber *> *)weights
-                              usingBlock:(void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block {
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block {
     [self enumerateBm25OrderedRowidsMatching:query withWeights:weights usingBlock:^(int64_t rowid, BOOL *stop) {
         
         YapCollectionKey *ck = nil;
@@ -1100,7 +1100,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 - (void)enumerateRowidsMatching:(NSString *)query
              withSnippetOptions:(YapDatabaseFullTextSearchSnippetOptions *)inOptions
                      usingBlock:
-            (void (^)(NSString *snippet, int64_t rowid, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *snippet, int64_t rowid, BOOL *stop))block
 {
 	if (block == nil) return;
 	if ([query length] == 0) return;
@@ -1195,7 +1195,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 - (void)enumerateKeysMatching:(NSString *)query
            withSnippetOptions:(YapDatabaseFullTextSearchSnippetOptions *)options
                    usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query
 	           withSnippetOptions:options
@@ -1210,7 +1210,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 - (void)enumerateKeysAndMetadataMatching:(NSString *)query
                       withSnippetOptions:(YapDatabaseFullTextSearchSnippetOptions *)options
                               usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, id metadata, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query
 	           withSnippetOptions:options
@@ -1227,7 +1227,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 - (void)enumerateKeysAndObjectsMatching:(NSString *)query
                      withSnippetOptions:(YapDatabaseFullTextSearchSnippetOptions *)options
                              usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, id object, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, id object, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query
 	           withSnippetOptions:options
@@ -1244,7 +1244,7 @@ static NSString *const ext_key__version_deprecated = @"version";
 - (void)enumerateRowsMatching:(NSString *)query
            withSnippetOptions:(YapDatabaseFullTextSearchSnippetOptions *)options
                    usingBlock:
-            (void (^)(NSString *snippet, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *snippet, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	[self enumerateRowidsMatching:query
 	           withSnippetOptions:options

--- a/YapDatabase/Extensions/RTreeIndex/YapDatabaseRTreeIndexTransaction.h
+++ b/YapDatabase/Extensions/RTreeIndex/YapDatabaseRTreeIndexTransaction.h
@@ -37,19 +37,19 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 
 - (BOOL)enumerateKeysMatchingQuery:(YapDatabaseQuery *)query
-                        usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block;
+                        usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block;
 
 - (BOOL)enumerateKeysAndMetadataMatchingQuery:(YapDatabaseQuery *)query
                                    usingBlock:
-                            (void (^)(NSString *collection, NSString *key, _Nullable id metadata, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, _Nullable id metadata, BOOL *stop))block;
 
 - (BOOL)enumerateKeysAndObjectsMatchingQuery:(YapDatabaseQuery *)query
                                   usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
 
 - (BOOL)enumerateRowsMatchingQuery:(YapDatabaseQuery *)query
                         usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, _Nullable id metadata, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, _Nullable id metadata, BOOL *stop))block;
 /**
  * Skips the enumeration process, and just gives you the count of matching rows.
 **/

--- a/YapDatabase/Extensions/RTreeIndex/YapDatabaseRTreeIndexTransaction.m
+++ b/YapDatabase/Extensions/RTreeIndex/YapDatabaseRTreeIndexTransaction.m
@@ -994,7 +994,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (BOOL)_enumerateRowidsMatchingQuery:(YapDatabaseQuery *)query
-                           usingBlock:(void (^)(int64_t rowid, BOOL *stop))block
+                           usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, BOOL *stop))block
 {
 	// Create full query using given filtering clause(s)
 
@@ -1111,7 +1111,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 }
 
 - (BOOL)enumerateKeysMatchingQuery:(YapDatabaseQuery *)query
-                        usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block
+                        usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block
 {
 	if (query == nil) return NO;
 	if (block == nil) return NO;
@@ -1128,7 +1128,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)enumerateKeysAndMetadataMatchingQuery:(YapDatabaseQuery *)query
                                    usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
 {
 	if (query == nil) return NO;
 	if (block == nil) return NO;
@@ -1147,7 +1147,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)enumerateKeysAndObjectsMatchingQuery:(YapDatabaseQuery *)query
                                   usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block
 {
 	if (query == nil) return NO;
 	if (block == nil) return NO;
@@ -1166,7 +1166,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)enumerateRowsMatchingQuery:(YapDatabaseQuery *)query
                         usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	if (query == nil) return NO;
 	if (block == nil) return NO;

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.h
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   The name of the edge (case sensitive).
 **/
 - (void)enumerateEdgesWithName:(NSString *)name
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
 
 /**
  * Enumerates every edge that matches any parameters you specify.
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enumerateEdgesWithName:(nullable NSString *)name
                      sourceKey:(nullable NSString *)sourceKey
                     collection:(nullable NSString *)sourceCollection
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
 
 /**
  * Enumerates every edge that matches any parameters you specify.
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enumerateEdgesWithName:(nullable NSString *)name
                 destinationKey:(nullable NSString *)destinationKey
                     collection:(nullable NSString *)destinationCollection
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
 
 /**
  * Enumerates every edge that matches any parameters you specify.
@@ -119,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 - (void)enumerateEdgesWithName:(nullable NSString *)name
             destinationFileURL:(nullable NSURL *)destinationFileURL
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
 
 /**
  * Enumerates every edge that matches any parameters you specify.
@@ -158,7 +158,7 @@ NS_ASSUME_NONNULL_BEGIN
                     collection:(nullable NSString *)sourceCollection
                 destinationKey:(nullable NSString *)destinationKey
                     collection:(nullable NSString *)destinationCollection
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
 
 /**
  * Enumerates every edge that matches any parameters you specify.
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
                      sourceKey:(nullable NSString *)sourceKey
                     collection:(nullable NSString *)sourceCollection
             destinationFileURL:(nullable NSURL *)destinationFileURL
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block;
 
 #pragma mark Count
 

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -1830,7 +1830,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
  * Does not take into account anything in memory (parentConnection->changes dictionary).
 **/
 - (void)enumerateExistingEdgesWithSource:(int64_t)srcRowid
-                              usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge))block
+                              usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge))block
 {
 	BOOL needsFinalize;
 	sqlite3_stmt *statement = [parentConnection enumerateForSrcStatement:&needsFinalize];
@@ -1919,7 +1919,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
  * Does not take into account anything in memory (parentConnection->changes dictionary).
 **/
 - (void)enumerateExistingEdgesWithDestination:(int64_t)dstRowid
-                                   usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge))block
+                                   usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge))block
 {
 	BOOL needsFinalize;
 	sqlite3_stmt *statement = [parentConnection enumerateForDstStatement:&needsFinalize];
@@ -4330,7 +4330,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
  * This internal method does NOT prep the edge for the public (e.g. srcKey/dstKey/dstFileURL may be nil).
 **/
 - (void)_enumerateEdgesWithName:(NSString *)name
-                     usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	if (name == nil) return;
 	if (block == NULL) return;
@@ -4531,7 +4531,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 - (void)_enumerateEdgesWithName:(NSString *)name
                       sourceKey:(NSString *)srcKey
                      collection:(NSString *)srcCollection
-                     usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	if (srcKey == nil) {
 		[self enumerateEdgesWithName:name usingBlock:block];
@@ -4848,7 +4848,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 - (void)_enumerateEdgesWithName:(NSString *)name
                  destinationKey:(NSString *)dstKey
                      collection:(NSString *)dstCollection
-                     usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	if (dstKey == nil) {
 		[self enumerateEdgesWithName:name usingBlock:block];
@@ -5120,7 +5120,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 **/
 - (void)_enumerateEdgesWithName:(NSString *)name
              destinationFileURL:(NSURL *)dstFileURL
-                     usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	if (dstFileURL == nil) {
 		[self enumerateEdgesWithName:name usingBlock:block];
@@ -5426,7 +5426,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
                      collection:(NSString *)srcCollection
                  destinationKey:(NSString *)dstKey
                      collection:(NSString *)dstCollection
-                     usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	if (srcKey == nil)
 	{
@@ -5725,7 +5725,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
                       sourceKey:(NSString *)srcKey
                      collection:(NSString *)srcCollection
              destinationFileURL:(NSURL *)dstFileURL
-                     usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                     usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	if (srcKey == nil)
 	{
@@ -6023,7 +6023,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
  *   The name of the edge (case sensitive).
 **/
 - (void)enumerateEdgesWithName:(NSString *)name
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	[self _enumerateEdgesWithName:name usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
 		
@@ -6055,7 +6055,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 - (void)enumerateEdgesWithName:(NSString *)name
                      sourceKey:(NSString *)srcKey
                     collection:(NSString *)srcCollection
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	[self _enumerateEdgesWithName:name
 	                    sourceKey:srcKey
@@ -6082,7 +6082,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 - (void)enumerateEdgesWithName:(NSString *)name
                 destinationKey:(NSString *)dstKey
                     collection:(NSString *)dstCollection
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	[self _enumerateEdgesWithName:name
 	               destinationKey:dstKey
@@ -6104,7 +6104,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 **/
 - (void)enumerateEdgesWithName:(NSString *)name
             destinationFileURL:(NSURL *)dstFileURL
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	[self _enumerateEdgesWithName:name
 	           destinationFileURL:dstFileURL
@@ -6137,7 +6137,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
                     collection:(NSString *)srcCollection
                 destinationKey:(NSString *)dstKey
                     collection:(NSString *)dstCollection
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	[self _enumerateEdgesWithName:name
 	                    sourceKey:srcKey
@@ -6169,7 +6169,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
                      sourceKey:(NSString *)srcKey
                     collection:(NSString *)srcCollection
             destinationFileURL:(NSURL *)dstFileURL
-                    usingBlock:(void (^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(YapDatabaseRelationshipEdge *edge, BOOL *stop))block
 {
 	[self _enumerateEdgesWithName:name
 	                    sourceKey:srcKey

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.h
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.h
@@ -37,21 +37,21 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 
 - (BOOL)enumerateKeysMatchingQuery:(YapDatabaseQuery *)query
-                        usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block;
+                        usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block;
 
 - (BOOL)enumerateKeysAndMetadataMatchingQuery:(YapDatabaseQuery *)query
                                    usingBlock:
-                            (void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 - (BOOL)enumerateKeysAndObjectsMatchingQuery:(YapDatabaseQuery *)query
                                   usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
 
 - (BOOL)enumerateRowsMatchingQuery:(YapDatabaseQuery *)query
                         usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
-- (BOOL)enumerateIndexedValuesInColumn:(NSString *)column matchingQuery:(YapDatabaseQuery *)query usingBlock:(void(^)(id indexedValue, BOOL *stop))block;
+- (BOOL)enumerateIndexedValuesInColumn:(NSString *)column matchingQuery:(YapDatabaseQuery *)query usingBlock:(void(NS_NOESCAPE^)(id indexedValue, BOOL *stop))block;
 
 /**
  * Skips the enumeration process, and just gives you the count of matching rows.

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
@@ -1176,7 +1176,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (BOOL)_enumerateRowidsMatchingQuery:(YapDatabaseQuery *)query
-                           usingBlock:(void (^)(int64_t rowid, BOOL *stop))block
+                           usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, BOOL *stop))block
 {
 	if (query == nil) return NO;
 	if (query.isAggregateQuery) return NO;
@@ -1231,7 +1231,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 }
 
 - (BOOL)enumerateKeysMatchingQuery:(YapDatabaseQuery *)query
-                        usingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block
+                        usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block
 {
 	BOOL result = [self _enumerateRowidsMatchingQuery:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -1251,7 +1251,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)enumerateKeysAndMetadataMatchingQuery:(YapDatabaseQuery *)query
                                    usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
 {
 	BOOL result = [self _enumerateRowidsMatchingQuery:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -1273,7 +1273,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)enumerateKeysAndObjectsMatchingQuery:(YapDatabaseQuery *)query
                                   usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block
 {
 	BOOL result = [self _enumerateRowidsMatchingQuery:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -1295,7 +1295,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)enumerateRowsMatchingQuery:(YapDatabaseQuery *)query
                         usingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	BOOL result = [self _enumerateRowidsMatchingQuery:query usingBlock:^(int64_t rowid, BOOL *stop) {
 		
@@ -1318,7 +1318,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)_enumerateIndexedValuesInColumn:(NSString *)column
                           matchingQuery:(YapDatabaseQuery *)query
-                             usingBlock:(void (^)(id indexedValue, BOOL *stop))block
+                             usingBlock:(void (NS_NOESCAPE^)(id indexedValue, BOOL *stop))block
 {
 	if (column == nil) return NO;
 	if (query == nil) return NO;
@@ -1409,7 +1409,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 
 - (BOOL)enumerateIndexedValuesInColumn:(NSString *)column
                          matchingQuery:(YapDatabaseQuery *)query
-                            usingBlock:(void(^)(id indexedValue, BOOL *stop))block
+                            usingBlock:(void(NS_NOESCAPE^)(id indexedValue, BOOL *stop))block
 {
 	BOOL result = [self _enumerateIndexedValuesInColumn:column
 	                                      matchingQuery:query

--- a/YapDatabase/Extensions/View/Internal/YapDatabaseViewPage.h
+++ b/YapDatabase/Extensions/View/Internal/YapDatabaseViewPage.h
@@ -27,13 +27,13 @@
 
 - (BOOL)getIndex:(NSUInteger *)indexPtr ofRowid:(int64_t)rowid;
 
-- (void)enumerateRowidsUsingBlock:(void (^)(int64_t rowid, NSUInteger idx, BOOL *stop))block;
+- (void)enumerateRowidsUsingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger idx, BOOL *stop))block;
 
 - (void)enumerateRowidsWithOptions:(NSEnumerationOptions)options
-                        usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateRowidsWithOptions:(NSEnumerationOptions)options
                              range:(NSRange)range
-                        usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
 
 @end

--- a/YapDatabase/Extensions/View/Internal/YapDatabaseViewPage.mm
+++ b/YapDatabase/Extensions/View/Internal/YapDatabaseViewPage.mm
@@ -171,13 +171,13 @@
 	return NO;
 }
 
-- (void)enumerateRowidsUsingBlock:(void (^)(int64_t rowid, NSUInteger idx, BOOL *stop))block
+- (void)enumerateRowidsUsingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger idx, BOOL *stop))block
 {
 	[self enumerateRowidsWithOptions:0 usingBlock:block];
 }
 
 - (void)enumerateRowidsWithOptions:(NSEnumerationOptions)options
-                        usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -229,7 +229,7 @@
 
 - (void)enumerateRowidsWithOptions:(NSEnumerationOptions)options
                              range:(NSRange)range
-                        usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	

--- a/YapDatabase/Extensions/View/Internal/YapDatabaseViewPrivate.h
+++ b/YapDatabase/Extensions/View/Internal/YapDatabaseViewPrivate.h
@@ -178,14 +178,14 @@ static NSString *const changeset_key_versionTag = @"versionTag";
 - (NSString *)pageMetadataTableName;
 
 - (void)enumerateRowidsInGroup:(NSString *)group
-                    usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
 - (void)enumerateRowidsInGroup:(NSString *)group
                    withOptions:(NSEnumerationOptions)inOptions
-                    usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
 - (void)enumerateRowidsInGroup:(NSString *)group
                    withOptions:(NSEnumerationOptions)inOptions
                          range:(NSRange)range
-                    usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
+                    usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block;
 
 // Logic - ReadOnly
 

--- a/YapDatabase/Extensions/View/Internal/YapDatabaseViewState.h
+++ b/YapDatabase/Extensions/View/Internal/YapDatabaseViewState.h
@@ -13,8 +13,8 @@
 
 - (NSUInteger)numberOfGroups;
 
-- (void)enumerateGroupsWithBlock:(void (^)(NSString *group, BOOL *stop))block;
-- (void)enumerateWithBlock:(void (^)(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop))block;
+- (void)enumerateGroupsWithBlock:(void (NS_NOESCAPE^)(NSString *group, BOOL *stop))block;
+- (void)enumerateWithBlock:(void (NS_NOESCAPE^)(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop))block;
 
 #pragma mark Mutation
 

--- a/YapDatabase/Extensions/View/Internal/YapDatabaseViewState.m
+++ b/YapDatabase/Extensions/View/Internal/YapDatabaseViewState.m
@@ -99,7 +99,7 @@
 	return [group_pagesMetadata_dict count];
 }
 
-- (void)enumerateGroupsWithBlock:(void (^)(NSString *group, BOOL *stop))block
+- (void)enumerateGroupsWithBlock:(void (NS_NOESCAPE^)(NSString *group, BOOL *stop))block
 {
 	BOOL stop = NO;
 	for (NSString *group in group_pagesMetadata_dict)
@@ -110,7 +110,7 @@
 	}
 }
 
-- (void)enumerateWithBlock:(void (^)(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop))block
+- (void)enumerateWithBlock:(void (NS_NOESCAPE^)(NSString *group, NSArray *pagesMetadataForGroup, BOOL *stop))block
 {
 	[group_pagesMetadata_dict enumerateKeysAndObjectsUsingBlock:block];
 }

--- a/YapDatabase/Extensions/View/YapDatabaseViewTransaction.h
+++ b/YapDatabase/Extensions/View/YapDatabaseViewTransaction.h
@@ -124,13 +124,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Enumerates the groups in the view.
 **/
-- (void)enumerateGroupsUsingBlock:(void (^)(NSString *group, BOOL *stop))block;
+- (void)enumerateGroupsUsingBlock:(void (NS_NOESCAPE^)(NSString *group, BOOL *stop))block;
 
 /**
  * Enumerates the keys in the given group.
 **/
 - (void)enumerateKeysInGroup:(NSString *)group
-                  usingBlock:(void (^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block;
+                  usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block;
 
 /**
  * Enumerates the keys in the given group.
@@ -138,7 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 - (void)enumerateKeysInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
-                  usingBlock:(void (^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block;
+                  usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block;
 
 /**
  * Enumerates the keys in the range of the given group.
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enumerateKeysInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                        range:(NSRange)range
-                  usingBlock:(void (^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block;
+                  usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block;
 
 @end
 
@@ -270,26 +270,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                             withOptions:(NSEnumerationOptions)options
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                             withOptions:(NSEnumerationOptions)options
                                   range:(NSRange)range
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                             withOptions:(NSEnumerationOptions)options
                                   range:(NSRange)range
                                  filter:
-                    (BOOL (^)(NSString *collection, NSString *key))filter
+                    (BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 /**
  * The following methods are similar to invoking the enumerateKeysInGroup:... methods,
@@ -298,26 +298,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)enumerateKeysAndObjectsInGroup:(NSString *)group
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndObjectsInGroup:(NSString *)group
                            withOptions:(NSEnumerationOptions)options
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndObjectsInGroup:(NSString *)group
                            withOptions:(NSEnumerationOptions)options
                                  range:(NSRange)range
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateKeysAndObjectsInGroup:(NSString *)group
                            withOptions:(NSEnumerationOptions)options
                                  range:(NSRange)range
                                 filter:
-            (BOOL (^)(NSString *collection, NSString *key))filter
+            (BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block;
 
 /**
  * The following methods are similar to invoking the enumerateKeysInGroup:... methods,
@@ -326,26 +326,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)enumerateRowsInGroup:(NSString *)group
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateRowsInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateRowsInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                        range:(NSRange)range
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 - (void)enumerateRowsInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                        range:(NSRange)range
                       filter:
-            (BOOL (^)(NSString *collection, NSString *key))filter
+            (BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, NSUInteger index, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Extensions/View/YapDatabaseViewTransaction.m
+++ b/YapDatabase/Extensions/View/YapDatabaseViewTransaction.m
@@ -2894,7 +2894,7 @@
 #pragma mark Public API - Enumerating
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (void)enumerateGroupsUsingBlock:(void (^)(NSString *group, BOOL *stop))block
+- (void)enumerateGroupsUsingBlock:(void (NS_NOESCAPE^)(NSString *group, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -2918,7 +2918,7 @@
 }
 
 - (void)enumerateKeysInGroup:(NSString *)group
-                  usingBlock:(void (^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block
+                  usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -2932,7 +2932,7 @@
 
 - (void)enumerateKeysInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
-                  usingBlock:(void (^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block
+                  usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -2947,7 +2947,7 @@
 - (void)enumerateKeysInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                        range:(NSRange)range
-                  usingBlock:(void (^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block
+                  usingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -2967,7 +2967,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (void)enumerateRowidsInGroup:(NSString *)group
-                    usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3002,7 +3002,7 @@
 
 - (void)enumerateRowidsInGroup:(NSString *)group
                    withOptions:(NSEnumerationOptions)inOptions
-                    usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3053,7 +3053,7 @@
 - (void)enumerateRowidsInGroup:(NSString *)group
                    withOptions:(NSEnumerationOptions)inOptions
                          range:(NSRange)range
-                    usingBlock:(void (^)(int64_t rowid, NSUInteger index, BOOL *stop))block
+                    usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3355,7 +3355,7 @@
 
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3372,7 +3372,7 @@
 - (void)enumerateKeysAndMetadataInGroup:(NSString *)group
                             withOptions:(NSEnumerationOptions)options
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3392,7 +3392,7 @@
                             withOptions:(NSEnumerationOptions)options
                                   range:(NSRange)range
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3413,9 +3413,9 @@
                             withOptions:(NSEnumerationOptions)options
                                   range:(NSRange)range
                                  filter:
-                    (BOOL (^)(NSString *collection, NSString *key))filter
+                    (BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
                              usingBlock:
-                    (void (^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (filter == NULL) {
 		[self enumerateKeysAndMetadataInGroup:group withOptions:options range:range usingBlock:block];
@@ -3445,7 +3445,7 @@
 
 - (void)enumerateKeysAndObjectsInGroup:(NSString *)group
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3462,7 +3462,7 @@
 - (void)enumerateKeysAndObjectsInGroup:(NSString *)group
                            withOptions:(NSEnumerationOptions)options
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3482,7 +3482,7 @@
                            withOptions:(NSEnumerationOptions)options
                                  range:(NSRange)range
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3503,9 +3503,9 @@
                            withOptions:(NSEnumerationOptions)options
                                  range:(NSRange)range
                                 filter:
-            (BOOL (^)(NSString *collection, NSString *key))filter
+            (BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
                             usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop))block
 {
 	if (filter == NULL) {
 		[self enumerateKeysAndObjectsInGroup:group withOptions:options range:range usingBlock:block];
@@ -3535,7 +3535,7 @@
 
 - (void)enumerateRowsInGroup:(NSString *)group
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3553,7 +3553,7 @@
 - (void)enumerateRowsInGroup:(NSString *)group
                  withOptions:(NSEnumerationOptions)options
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3574,7 +3574,7 @@
                  withOptions:(NSEnumerationOptions)options
                        range:(NSRange)range
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -3596,9 +3596,9 @@
                  withOptions:(NSEnumerationOptions)options
                        range:(NSRange)range
                       filter:
-            (BOOL (^)(NSString *collection, NSString *key))filter
+            (BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
                   usingBlock:
-            (void (^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
+            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop))block
 {
 	if (filter == NULL) {
 		[self enumerateRowsInGroup:group withOptions:options range:range usingBlock:block];

--- a/YapDatabase/Internal/YapDatabasePrivate.h
+++ b/YapDatabase/Internal/YapDatabasePrivate.h
@@ -384,71 +384,71 @@ static NSString *const ext_key_class = @"class";
         withRowid:(int64_t)rowid;
 
 - (void)_enumerateKeysInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, BOOL *stop))block;
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, BOOL *stop))block;
 
 - (void)_enumerateKeysInCollections:(NSArray *)collections
-                         usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block;
+                         usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block;
 
 - (void)_enumerateKeysInAllCollectionsUsingBlock:
-                            (void (^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block;
 
 - (void)_enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                   usingBlock:(void (^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block;
+                                   usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block;
 - (void)_enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                   usingBlock:(void (^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
-                                   withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter;
+                                   usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
+                                   withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *key))filter;
 
 - (void)_enumerateKeysAndMetadataInCollections:(NSArray *)collections
-                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+                usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block;
 - (void)_enumerateKeysAndMetadataInCollections:(NSArray *)collections
-                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
-                withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
+                usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                        (void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block;
+                        (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block;
 - (void)_enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                        (void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
-             withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
+                        (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+             withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateKeysAndObjectsInCollection:(NSString *)collection
-                                  usingBlock:(void (^)(int64_t rowid, NSString *key, id object, BOOL *stop))block;
+                                  usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, BOOL *stop))block;
 - (void)_enumerateKeysAndObjectsInCollection:(NSString *)collection
-                                  usingBlock:(void (^)(int64_t rowid, NSString *key, id object, BOOL *stop))block
-                                  withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter;
+                                  usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, BOOL *stop))block
+                                  withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *key))filter;
 
 - (void)_enumerateKeysAndObjectsInCollections:(NSArray *)collections
-                 usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block;
+                 usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block;
 - (void)_enumerateKeysAndObjectsInCollections:(NSArray *)collections
-                 usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
-                 withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
+                 usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
+                 withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                            (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block;
 - (void)_enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                            (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
-                 withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
+                            (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
+                 withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateRowsInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block;
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block;
 - (void)_enumerateRowsInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block
-                        withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter;
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block
+                        withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *key))filter;
 
 - (void)_enumerateRowsInCollections:(NSArray *)collections
-     usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+     usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
 - (void)_enumerateRowsInCollections:(NSArray *)collections
-     usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
-     withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
+     usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+     withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateRowsInAllCollectionsUsingBlock:
-                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
+                (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block;
 - (void)_enumerateRowsInAllCollectionsUsingBlock:
-                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
-     withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter;
+                (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+     withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter;
 
 - (void)_enumerateRowidsForKeys:(NSArray *)keys
                    inCollection:(NSString *)collection
-            unorderedUsingBlock:(void (^)(NSUInteger keyIndex, int64_t rowid, BOOL *stop))block;
+            unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, int64_t rowid, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Internal/YapMemoryTable.h
+++ b/YapDatabase/Internal/YapMemoryTable.h
@@ -45,9 +45,9 @@
 
 - (id)objectForKey:(id)key;
 
-- (void)enumerateKeysWithBlock:(void (^)(id key, BOOL *stop))block;
+- (void)enumerateKeysWithBlock:(void (NS_NOESCAPE^)(id key, BOOL *stop))block;
 
-- (void)enumerateKeysAndObjectsWithBlock:(void (^)(id key, id obj, BOOL *stop))block;
+- (void)enumerateKeysAndObjectsWithBlock:(void (NS_NOESCAPE^)(id key, id obj, BOOL *stop))block;
 
 //
 // For ReadWrite transactions:

--- a/YapDatabase/Internal/YapMemoryTable.m
+++ b/YapDatabase/Internal/YapMemoryTable.m
@@ -298,7 +298,7 @@
 	return result;
 }
 
-- (void)enumerateKeysWithBlock:(void (^)(id key, BOOL *stop))userBlock
+- (void)enumerateKeysWithBlock:(void (NS_NOESCAPE^)(id key, BOOL *stop))userBlock
 {
 	dispatch_block_t block = ^{ @autoreleasepool {
 	#pragma clang diagnostic push
@@ -333,7 +333,7 @@
 		dispatch_sync(table->queue, block);
 }
 
-- (void)enumerateKeysAndObjectsWithBlock:(void (^)(id key, id obj, BOOL *stop))userBlock
+- (void)enumerateKeysAndObjectsWithBlock:(void (NS_NOESCAPE^)(id key, id obj, BOOL *stop))userBlock
 {
 	dispatch_block_t block = ^{ @autoreleasepool {
 	#pragma clang diagnostic push

--- a/YapDatabase/Utilities/YapBidirectionalCache.h
+++ b/YapDatabase/Utilities/YapBidirectionalCache.h
@@ -136,9 +136,9 @@ extern const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBac
 - (void)removeKeyForObject:(ObjectType)object;
 - (void)removeKeysForObjects:(id <NSFastEnumeration>)objects;
 
-- (void)enumerateKeysWithBlock:(void (^)(KeyType key, BOOL *stop))block;
-- (void)enumerateObjectsWithBlock:(void (^)(ObjectType object, BOOL *stop))block;
-- (void)enumerateKeysAndObjectsWithBlock:(void (^)(KeyType key, ObjectType obj, BOOL *stop))block;
+- (void)enumerateKeysWithBlock:(void (NS_NOESCAPE^)(KeyType key, BOOL *stop))block;
+- (void)enumerateObjectsWithBlock:(void (NS_NOESCAPE^)(ObjectType object, BOOL *stop))block;
+- (void)enumerateKeysAndObjectsWithBlock:(void (NS_NOESCAPE^)(KeyType key, ObjectType obj, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Utilities/YapBidirectionalCache.m
+++ b/YapDatabase/Utilities/YapBidirectionalCache.m
@@ -597,7 +597,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	}
 }
 
-- (void)enumerateKeysWithBlock:(void (^)(id key, BOOL *stop))block
+- (void)enumerateKeysWithBlock:(void (NS_NOESCAPE^)(id key, BOOL *stop))block
 {
 	// We could simply walk the linked-list starting with mostRecentCacheItem,
 	// but that breaks the API contract in certain cases.
@@ -619,7 +619,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	}
 }
 
-- (void)enumerateObjectsWithBlock:(void (^)(id object, BOOL *stop))block
+- (void)enumerateObjectsWithBlock:(void (NS_NOESCAPE^)(id object, BOOL *stop))block
 {
 	// We could simply walk the linked-list starting with mostRecentCacheItem,
 	// but that breaks the API contract in certain cases.
@@ -641,7 +641,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	}
 }
 
-- (void)enumerateKeysAndObjectsWithBlock:(void (^)(id key, id obj, BOOL *stop))block
+- (void)enumerateKeysAndObjectsWithBlock:(void (NS_NOESCAPE^)(id key, id obj, BOOL *stop))block
 {
 	// We could simply walk the linked-list starting with mostRecentCacheItem,
 	// but that breaks the API contract in certain cases.

--- a/YapDatabase/Utilities/YapCache.h
+++ b/YapDatabase/Utilities/YapCache.h
@@ -116,8 +116,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeObjectForKey:(KeyType)key;
 - (void)removeObjectsForKeys:(id <NSFastEnumeration>)keys;
 
-- (void)enumerateKeysWithBlock:(void (^)(KeyType key, BOOL *stop))block;
-- (void)enumerateKeysAndObjectsWithBlock:(void (^)(KeyType key, ObjectType obj, BOOL *stop))block;
+- (void)enumerateKeysWithBlock:(void (NS_NOESCAPE^)(KeyType key, BOOL *stop))block;
+- (void)enumerateKeysAndObjectsWithBlock:(void (NS_NOESCAPE^)(KeyType key, ObjectType obj, BOOL *stop))block;
 
 //
 // Some debugging stuff that gets compiled out

--- a/YapDatabase/Utilities/YapCache.m
+++ b/YapDatabase/Utilities/YapCache.m
@@ -416,7 +416,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 	}
 }
 
-- (void)enumerateKeysWithBlock:(void (^)(id key, BOOL *stop))block
+- (void)enumerateKeysWithBlock:(void (NS_NOESCAPE^)(id key, BOOL *stop))block
 {
 	NSDictionary *nsdict = (__bridge NSDictionary *)cfdict;
 	BOOL stop = NO;
@@ -429,7 +429,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 	}
 }
 
-- (void)enumerateKeysAndObjectsWithBlock:(void (^)(id key, id obj, BOOL *stop))block
+- (void)enumerateKeysAndObjectsWithBlock:(void (NS_NOESCAPE^)(id key, id obj, BOOL *stop))block
 {
 	NSDictionary *nsdict = (__bridge NSDictionary *)cfdict;
 	

--- a/YapDatabase/Utilities/YapDirtyDictionary.h
+++ b/YapDatabase/Utilities/YapDirtyDictionary.h
@@ -61,12 +61,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Enumerates all key/value pairs, including both "dirty" & "clean" values.
 **/
-- (void)enumerateKeysAndObjectsUsingBlock:(void (^)(KeyType key, ObjectType obj, BOOL *stop))block;
+- (void)enumerateKeysAndObjectsUsingBlock:(void (NS_NOESCAPE^)(KeyType key, ObjectType obj, BOOL *stop))block;
 
 /**
  * Enumerates only the key/value pairs that are dirty (current value differs from original value).
 **/
-- (void)enumerateDirtyKeysAndObjectsUsingBlock:(void (^)(KeyType key, ObjectType obj, BOOL *stop))block;
+- (void)enumerateDirtyKeysAndObjectsUsingBlock:(void (NS_NOESCAPE^)(KeyType key, ObjectType obj, BOOL *stop))block;
 
 @end
 

--- a/YapDatabase/Utilities/YapDirtyDictionary.m
+++ b/YapDatabase/Utilities/YapDirtyDictionary.m
@@ -161,7 +161,7 @@
 /**
  * Enumerates all key/value pairs, including both "dirty" & "clean" values.
 **/
-- (void)enumerateKeysAndObjectsUsingBlock:(void (^)(id key, id obj, BOOL *stop))block
+- (void)enumerateKeysAndObjectsUsingBlock:(void (NS_NOESCAPE^)(id key, id obj, BOOL *stop))block
 {
 	[dict enumerateKeysAndObjectsUsingBlock:^(id key, YapDirtyDictionaryItem *item, BOOL *stop) {
 		
@@ -172,7 +172,7 @@
 /**
  * Enumerates only the key/value pairs that are dirty (current value differs from original value).
 **/
-- (void)enumerateDirtyKeysAndObjectsUsingBlock:(void (^)(id key, id obj, BOOL *stop))block
+- (void)enumerateDirtyKeysAndObjectsUsingBlock:(void (NS_NOESCAPE^)(id key, id obj, BOOL *stop))block
 {
 	[dict enumerateKeysAndObjectsUsingBlock:^(id key, YapDirtyDictionaryItem *item, BOOL *stop) {
 		

--- a/YapDatabase/Utilities/YapSet.h
+++ b/YapDatabase/Utilities/YapSet.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)containsObject:(id)anObject;
 - (BOOL)intersectsSet:(NSSet *)otherSet;
 
-- (void)enumerateObjectsUsingBlock:(void (^)(id obj, BOOL *stop))block;
+- (void)enumerateObjectsUsingBlock:(void (NS_NOESCAPE^)(id obj, BOOL *stop))block;
 
 // It's open source!
 // You are encouraged to add any methods you may need that are available in the NSSet API.

--- a/YapDatabase/Utilities/YapSet.m
+++ b/YapDatabase/Utilities/YapSet.m
@@ -63,7 +63,7 @@
 	}
 }
 
-- (void)enumerateObjectsUsingBlock:(void (^)(id obj, BOOL *stop))block
+- (void)enumerateObjectsUsingBlock:(void (NS_NOESCAPE^)(id obj, BOOL *stop))block
 {
 	if (set)
 	{

--- a/YapDatabase/YapDatabaseConnection.h
+++ b/YapDatabase/YapDatabaseConnection.h
@@ -312,7 +312,7 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
  *
  * This method is synchronous.
 **/
-- (void)readWithBlock:(void (^)(YapDatabaseReadTransaction *transaction))block;
+- (void)readWithBlock:(void (NS_NOESCAPE^)(YapDatabaseReadTransaction *transaction))block;
 
 /**
  * Read-write access to the database.
@@ -320,7 +320,7 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
  * Only a single read-write block can execute among all sibling connections.
  * Thus this method may block if another sibling connection is currently executing a read-write block.
 **/
-- (void)readWriteWithBlock:(void (^)(YapDatabaseReadWriteTransaction *transaction))block;
+- (void)readWriteWithBlock:(void (NS_NOESCAPE^)(YapDatabaseReadWriteTransaction *transaction))block;
 
 /**
  * Read-only access to the database.
@@ -554,7 +554,7 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
 **/
 - (void)enumerateChangedKeysInCollection:(NSString *)collection
                          inNotifications:(NSArray<NSNotification *> *)notifications
-                              usingBlock:(void (^)(NSString *key, BOOL *stop))block;
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *key, BOOL *stop))block;
 
 /**
  * Allows you to enumerate all the changed collection/key tuples for the given commits.
@@ -570,7 +570,7 @@ typedef NS_OPTIONS(NSUInteger, YapDatabaseConnectionFlushMemoryFlags) {
  * @see didClearAllCollectionsInNotifications:
 **/
 - (void)enumerateChangedCollectionKeysInNotifications:(NSArray<NSNotification *> *)notifications
-                                           usingBlock:(void (^)(YapCollectionKey *ck, BOOL *stop))block;
+                                           usingBlock:(void (NS_NOESCAPE^)(YapCollectionKey *ck, BOOL *stop))block;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Extensions

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -1984,7 +1984,7 @@ static int connectionBusyHandler(void *ptr, int count)
  *
  * This method is synchronous.
 **/
-- (void)readWithBlock:(void (^)(YapDatabaseReadTransaction *))block
+- (void)readWithBlock:(void (NS_NOESCAPE^)(YapDatabaseReadTransaction *))block
 {
 #if YapDatabaseEnforcePermittedTransactions
 	YapDatabasePermittedTransactions flags = self.permittedTransactions;
@@ -2050,7 +2050,7 @@ static int connectionBusyHandler(void *ptr, int count)
  * 
  * This method is synchronous.
 **/
-- (void)readWriteWithBlock:(void (^)(YapDatabaseReadWriteTransaction *transaction))block
+- (void)readWriteWithBlock:(void (NS_NOESCAPE^)(YapDatabaseReadWriteTransaction *transaction))block
 {
 #if YapDatabaseEnforcePermittedTransactions
 	YapDatabasePermittedTransactions flags = self.permittedTransactions;
@@ -4950,7 +4950,7 @@ static int connectionBusyHandler(void *ptr, int count)
 **/
 - (void)enumerateChangedKeysInCollection:(NSString *)collection
                          inNotifications:(NSArray *)notifications
-                              usingBlock:(void (^)(NSString *key, BOOL *stop))block
+                              usingBlock:(void (NS_NOESCAPE^)(NSString *key, BOOL *stop))block
 {
 	if (block == NULL) return;
 	if (collection == nil)
@@ -5030,7 +5030,7 @@ static int connectionBusyHandler(void *ptr, int count)
  * @see didClearAllCollectionsInNotifications:
 **/
 - (void)enumerateChangedCollectionKeysInNotifications:(NSArray *)notifications
-                                           usingBlock:(void (^)(YapCollectionKey *ck, BOOL *stop))block
+                                           usingBlock:(void (NS_NOESCAPE^)(YapCollectionKey *ck, BOOL *stop))block
 {
 	if (block == NULL) return;
 	

--- a/YapDatabase/YapDatabaseTransaction.h
+++ b/YapDatabase/YapDatabaseTransaction.h
@@ -186,7 +186,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This uses a "SELECT collection FROM database" operation,
  * and then steps over the results invoking the given block handler.
 **/
-- (void)enumerateCollectionsUsingBlock:(void (^)(NSString *collection, BOOL *stop))block;
+- (void)enumerateCollectionsUsingBlock:(void (NS_NOESCAPE^)(NSString *collection, BOOL *stop))block;
 
 /**
  * This method is rarely needed, but may be helpful in certain situations.
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
  * 
  * Since there may be numerous collections for a given key, this method enumerates all possible collections.
 **/
-- (void)enumerateCollectionsForKey:(NSString *)key usingBlock:(void (^)(NSString *collection, BOOL *stop))block;
+- (void)enumerateCollectionsForKey:(NSString *)key usingBlock:(void (NS_NOESCAPE^)(NSString *collection, BOOL *stop))block;
 
 /**
  * Fast enumeration over all keys in the given collection.
@@ -205,7 +205,7 @@ NS_ASSUME_NONNULL_BEGIN
  * and then steps over the results invoking the given block handler.
 **/
 - (void)enumerateKeysInCollection:(nullable NSString *)collection
-                       usingBlock:(void (^)(NSString *key, BOOL *stop))block;
+                       usingBlock:(void (NS_NOESCAPE^)(NSString *key, BOOL *stop))block;
 
 /**
  * Fast enumeration over all keys in the given collection.
@@ -213,7 +213,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This uses a "SELECT collection, key FROM database" operation,
  * and then steps over the results invoking the given block handler.
 **/
-- (void)enumerateKeysInAllCollectionsUsingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block;
+- (void)enumerateKeysInAllCollectionsUsingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block;
 
 /**
  * Fast enumeration over all objects in the database.
@@ -226,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)enumerateKeysAndObjectsInCollection:(nullable NSString *)collection
-                                 usingBlock:(void (^)(NSString *key, id object, BOOL *stop))block;
+                                 usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, BOOL *stop))block;
 
 /**
  * Fast enumeration over objects in the database for which you're interested in.
@@ -237,8 +237,8 @@ NS_ASSUME_NONNULL_BEGIN
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)enumerateKeysAndObjectsInCollection:(nullable NSString *)collection
-                                 usingBlock:(void (^)(NSString *key, id object, BOOL *stop))block
-                                 withFilter:(nullable BOOL (^)(NSString *key))filter;
+                                 usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, BOOL *stop))block
+                                 withFilter:(nullable BOOL (NS_NOESCAPE^)(NSString *key))filter;
 
 /**
  * Enumerates all key/object pairs in all collections.
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
+                                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block;
 
 /**
  * Enumerates all key/object pairs in all collections.
@@ -265,8 +265,8 @@ NS_ASSUME_NONNULL_BEGIN
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block
-                                 withFilter:(nullable BOOL (^)(NSString *collection, NSString *key))filter;
+                                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block
+                                 withFilter:(nullable BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter;
 
 /**
  * Fast enumeration over all keys and associated metadata in the given collection.
@@ -280,7 +280,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)enumerateKeysAndMetadataInCollection:(nullable NSString *)collection
-                                  usingBlock:(void (^)(NSString *key, __nullable id metadata, BOOL *stop))block;
+                                  usingBlock:(void (NS_NOESCAPE^)(NSString *key, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Fast enumeration over all keys and associated metadata in the given collection.
@@ -292,8 +292,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)enumerateKeysAndMetadataInCollection:(nullable NSString *)collection
-                                  usingBlock:(void (^)(NSString *key, __nullable id metadata, BOOL *stop))block
-                                  withFilter:(nullable BOOL (^)(NSString *key))filter;
+                                  usingBlock:(void (NS_NOESCAPE^)(NSString *key, __nullable id metadata, BOOL *stop))block
+                                  withFilter:(nullable BOOL (NS_NOESCAPE^)(NSString *key))filter;
 
 
 
@@ -309,7 +309,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Keep in mind that you cannot modify the database mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                            (void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Fast enumeration over all key/metadata pairs in all collections.
@@ -323,8 +323,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Keep in mind that you cannot modify the database mid-enumeration (just like any other kind of enumeration).
  **/
 - (void)enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                            (void (^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block
-                 withFilter:(nullable BOOL (^)(NSString *collection, NSString *key))filter;
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, __nullable id metadata, BOOL *stop))block
+                 withFilter:(nullable BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter;
 
 /**
  * Fast enumeration over all rows in the database.
@@ -337,7 +337,7 @@ NS_ASSUME_NONNULL_BEGIN
  * allowing you to skip the serialization step for those rows you're not interested in.
 **/
 - (void)enumerateRowsInCollection:(nullable NSString *)collection
-                       usingBlock:(void (^)(NSString *key, id object, __nullable id metadata, BOOL *stop))block;
+                       usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Fast enumeration over rows in the database for which you're interested in.
@@ -348,8 +348,8 @@ NS_ASSUME_NONNULL_BEGIN
  * which avoids the cost associated with deserializing the object & metadata.
 **/
 - (void)enumerateRowsInCollection:(nullable NSString *)collection
-                       usingBlock:(void (^)(NSString *key, id object, __nullable id metadata, BOOL *stop))block
-                       withFilter:(nullable BOOL (^)(NSString *key))filter;
+                       usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, __nullable id metadata, BOOL *stop))block
+                       withFilter:(nullable BOOL (NS_NOESCAPE^)(NSString *key))filter;
 
 /**
  * Enumerates all rows in all collections.
@@ -362,7 +362,7 @@ NS_ASSUME_NONNULL_BEGIN
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)enumerateRowsInAllCollectionsUsingBlock:
-                    (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Enumerates all rows in all collections.
@@ -376,8 +376,8 @@ NS_ASSUME_NONNULL_BEGIN
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)enumerateRowsInAllCollectionsUsingBlock:
-                    (void (^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block
-         withFilter:(nullable BOOL (^)(NSString *collection, NSString *key))filter;
+                    (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, __nullable id metadata, BOOL *stop))block
+         withFilter:(nullable BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter;
 
 /**
  * Enumerates over the given list of keys (unordered).
@@ -393,7 +393,7 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 - (void)enumerateObjectsForKeys:(NSArray<NSString *> *)keys
                    inCollection:(nullable NSString *)collection
-            unorderedUsingBlock:(void (^)(NSUInteger keyIndex, id __nullable object, BOOL *stop))block;
+            unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, id __nullable object, BOOL *stop))block;
 
 /**
  * Enumerates over the given list of keys (unordered).
@@ -409,7 +409,7 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 - (void)enumerateMetadataForKeys:(NSArray<NSString *> *)keys
                     inCollection:(nullable NSString *)collection
-             unorderedUsingBlock:(void (^)(NSUInteger keyIndex, __nullable id metadata, BOOL *stop))block;
+             unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, __nullable id metadata, BOOL *stop))block;
 
 /**
  * Enumerates over the given list of keys (unordered).
@@ -425,7 +425,7 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 - (void)enumerateRowsForKeys:(NSArray<NSString *> *)keys
                 inCollection:(nullable NSString *)collection
-         unorderedUsingBlock:(void (^)(NSUInteger keyIndex, __nullable id object, __nullable id metadata, BOOL *stop))block;
+         unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, __nullable id object, __nullable id metadata, BOOL *stop))block;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Extensions

--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -1560,7 +1560,7 @@
  * This uses a "SELECT collection FROM database" operation,
  * and then steps over the results invoking the given block handler.
 **/
-- (void)enumerateCollectionsUsingBlock:(void (^)(NSString *collection, BOOL *stop))block
+- (void)enumerateCollectionsUsingBlock:(void (NS_NOESCAPE^)(NSString *collection, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -1609,7 +1609,7 @@
  * 
  * Since there may be numerous collections for a given key, this method enumerates all possible collections.
 **/
-- (void)enumerateCollectionsForKey:(NSString *)key usingBlock:(void (^)(NSString *collection, BOOL *stop))block
+- (void)enumerateCollectionsForKey:(NSString *)key usingBlock:(void (NS_NOESCAPE^)(NSString *collection, BOOL *stop))block
 {
 	if (key == nil) return;
 	if (block == NULL) return;
@@ -1663,7 +1663,7 @@
  * and then steps over the results invoking the given block handler.
 **/
 - (void)enumerateKeysInCollection:(NSString *)collection
-                       usingBlock:(void (^)(NSString *key, BOOL *stop))block
+                       usingBlock:(void (NS_NOESCAPE^)(NSString *key, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -1679,7 +1679,7 @@
  * This uses a "SELECT collection, key FROM database" operation,
  * and then steps over the results invoking the given block handler.
 **/
-- (void)enumerateKeysInAllCollectionsUsingBlock:(void (^)(NSString *collection, NSString *key, BOOL *stop))block
+- (void)enumerateKeysInAllCollectionsUsingBlock:(void (NS_NOESCAPE^)(NSString *collection, NSString *key, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -1700,7 +1700,7 @@
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)enumerateKeysAndObjectsInCollection:(NSString *)collection
-                                 usingBlock:(void (^)(NSString *key, id object, BOOL *stop))block
+                                 usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, BOOL *stop))block
 {
 	[self enumerateKeysAndObjectsInCollection:collection usingBlock:block withFilter:NULL];
 }
@@ -1714,8 +1714,8 @@
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)enumerateKeysAndObjectsInCollection:(NSString *)collection
-                                 usingBlock:(void (^)(NSString *key, id object, BOOL *stop))block
-                                 withFilter:(BOOL (^)(NSString *key))filter
+                                 usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, BOOL *stop))block
+                                 withFilter:(BOOL (NS_NOESCAPE^)(NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -1753,7 +1753,7 @@
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block
 {
 	[self enumerateKeysAndObjectsInAllCollectionsUsingBlock:block withFilter:NULL];
 }
@@ -1770,8 +1770,8 @@
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, BOOL *stop))block
-                 withFilter:(BOOL (^)(NSString *collection, NSString *key))filter
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, BOOL *stop))block
+                 withFilter:(BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -1810,7 +1810,7 @@
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                  usingBlock:(void (^)(NSString *key, id metadata, BOOL *stop))block
+                                  usingBlock:(void (NS_NOESCAPE^)(NSString *key, id metadata, BOOL *stop))block
 {
 	[self enumerateKeysAndMetadataInCollection:collection usingBlock:block withFilter:NULL];
 }
@@ -1825,8 +1825,8 @@
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                  usingBlock:(void (^)(NSString *key, id metadata, BOOL *stop))block
-                                  withFilter:(BOOL (^)(NSString *key))filter
+                                  usingBlock:(void (NS_NOESCAPE^)(NSString *key, id metadata, BOOL *stop))block
+                                  withFilter:(BOOL (NS_NOESCAPE^)(NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -1865,7 +1865,7 @@
  * Keep in mind that you cannot modify the database mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                                        (void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                                        (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
 {
 	[self enumerateKeysAndMetadataInAllCollectionsUsingBlock:block withFilter:NULL];
 }
@@ -1882,8 +1882,8 @@
  * Keep in mind that you cannot modify the database mid-enumeration (just like any other kind of enumeration).
  **/
 - (void)enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                                        (void (^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
-                             withFilter:(BOOL (^)(NSString *collection, NSString *key))filter
+                                        (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                             withFilter:(BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -1921,7 +1921,7 @@
  * allowing you to skip the serialization step for those rows you're not interested in.
 **/
 - (void)enumerateRowsInCollection:(NSString *)collection
-                       usingBlock:(void (^)(NSString *key, id object, id metadata, BOOL *stop))block
+                       usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, id metadata, BOOL *stop))block
 {
 	[self enumerateRowsInCollection:collection usingBlock:block withFilter:NULL];
 }
@@ -1935,8 +1935,8 @@
  * which avoids the cost associated with deserializing the object & metadata.
 **/
 - (void)enumerateRowsInCollection:(NSString *)collection
-                       usingBlock:(void (^)(NSString *key, id object, id metadata, BOOL *stop))block
-                       withFilter:(BOOL (^)(NSString *key))filter
+                       usingBlock:(void (NS_NOESCAPE^)(NSString *key, id object, id metadata, BOOL *stop))block
+                       withFilter:(BOOL (NS_NOESCAPE^)(NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -1974,7 +1974,7 @@
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)enumerateRowsInAllCollectionsUsingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	[self enumerateRowsInAllCollectionsUsingBlock:block withFilter:NULL];
 }
@@ -1991,8 +1991,8 @@
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)enumerateRowsInAllCollectionsUsingBlock:
-                            (void (^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
-                 withFilter:(BOOL (^)(NSString *collection, NSString *key))filter
+                            (void (NS_NOESCAPE^)(NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                 withFilter:(BOOL (NS_NOESCAPE^)(NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -2033,7 +2033,7 @@
 **/
 - (void)enumerateObjectsForKeys:(NSArray *)keys
                    inCollection:(NSString *)collection
-            unorderedUsingBlock:(void (^)(NSUInteger keyIndex, id object, BOOL *stop))block
+            unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, id object, BOOL *stop))block
 {
 	if (block == NULL) return;
 	if ([keys count] == 0) return;
@@ -2242,7 +2242,7 @@
 **/
 - (void)enumerateMetadataForKeys:(NSArray *)keys
                     inCollection:(NSString *)collection
-             unorderedUsingBlock:(void (^)(NSUInteger keyIndex, id metadata, BOOL *stop))block
+             unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, id metadata, BOOL *stop))block
 {
 	if (block == NULL) return;
 	if ([keys count] == 0) return;
@@ -2453,7 +2453,7 @@
 **/
 - (void)enumerateRowsForKeys:(NSArray *)keys
                 inCollection:(NSString *)collection
-         unorderedUsingBlock:(void (^)(NSUInteger keyIndex, id object, id metadata, BOOL *stop))block
+         unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, id object, id metadata, BOOL *stop))block
 {
 	if (block == NULL) return;
 	if ([keys count] == 0) return;
@@ -2698,7 +2698,7 @@
  * and then steps over the results invoking the given block handler.
 **/
 - (void)_enumerateKeysInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, BOOL *stop))block
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, BOOL *stop))block
 {
 	if (block == NULL) return;
 	if (collection == nil) collection = @"";
@@ -2755,7 +2755,7 @@
  * and then steps over the results invoking the given block handler.
 **/
 - (void)_enumerateKeysInCollections:(NSArray *)collections
-                         usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block
+                         usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block
 {
 	if (block == NULL) return;
 	if ([collections count] == 0) return;
@@ -2821,7 +2821,7 @@
  * and then steps over the results invoking the given block handler.
 **/
 - (void)_enumerateKeysInAllCollectionsUsingBlock:
-                            (void (^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, BOOL *stop))block
 {
 	if (block == NULL) return;
 	
@@ -2883,7 +2883,7 @@
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)_enumerateKeysAndObjectsInCollection:(NSString *)collection
-                                  usingBlock:(void (^)(int64_t rowid, NSString *key, id object, BOOL *stop))block
+                                  usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, BOOL *stop))block
 {
 	[self _enumerateKeysAndObjectsInCollection:collection usingBlock:block withFilter:NULL];
 }
@@ -2897,8 +2897,8 @@
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)_enumerateKeysAndObjectsInCollection:(NSString *)collection
-                                  usingBlock:(void (^)(int64_t rowid, NSString *key, id object, BOOL *stop))block
-                                  withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter
+                                  usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, BOOL *stop))block
+                                  withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *key))filter
 {
 	if (block == NULL) return;
 	if (collection == nil) collection = @"";
@@ -2994,7 +2994,7 @@
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)_enumerateKeysAndObjectsInCollections:(NSArray *)collections usingBlock:
-                            (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
 {
 	[self _enumerateKeysAndObjectsInCollections:collections usingBlock:block withFilter:NULL];
 }
@@ -3008,8 +3008,8 @@
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)_enumerateKeysAndObjectsInCollections:(NSArray *)collections
-                 usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
-                 withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter
+                 usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
+                 withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	if ([collections count] == 0) return;
@@ -3118,7 +3118,7 @@
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)_enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                            (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
+                            (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
 {
 	[self _enumerateKeysAndObjectsInAllCollectionsUsingBlock:block withFilter:NULL];
 }
@@ -3135,8 +3135,8 @@
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)_enumerateKeysAndObjectsInAllCollectionsUsingBlock:
-                            (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
-                 withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter
+                            (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, BOOL *stop))block
+                 withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -3224,7 +3224,7 @@
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)_enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                   usingBlock:(void (^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
+                                   usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
 {
 	[self _enumerateKeysAndMetadataInCollection:collection usingBlock:block withFilter:NULL];
 }
@@ -3239,8 +3239,8 @@
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)_enumerateKeysAndMetadataInCollection:(NSString *)collection
-                                   usingBlock:(void (^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
-                                   withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter
+                                   usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id metadata, BOOL *stop))block
+                                   withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *key))filter
 {
 	if (block == NULL) return;
 	if (collection == nil) collection = @"";
@@ -3348,7 +3348,7 @@
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)_enumerateKeysAndMetadataInCollections:(NSArray *)collections
-                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
 {
 	[self _enumerateKeysAndMetadataInCollections:collections usingBlock:block withFilter:NULL];
 }
@@ -3363,8 +3363,8 @@
  * Keep in mind that you cannot modify the collection mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)_enumerateKeysAndMetadataInCollections:(NSArray *)collections
-                usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
-                withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter
+                usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	if ([collections count] == 0) return;
@@ -3484,7 +3484,7 @@
  * Keep in mind that you cannot modify the database mid-enumeration (just like any other kind of enumeration).
 **/
 - (void)_enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                        (void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+                        (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
 {
 	[self _enumerateKeysAndMetadataInAllCollectionsUsingBlock:block withFilter:NULL];
 }
@@ -3501,8 +3501,8 @@
  * Keep in mind that you cannot modify the database mid-enumeration (just like any other kind of enumeration).
  **/
 - (void)_enumerateKeysAndMetadataInAllCollectionsUsingBlock:
-                        (void (^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
-             withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter
+                        (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id metadata, BOOL *stop))block
+             withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -3610,7 +3610,7 @@
  * allowing you to skip the serialization step for those rows you're not interested in.
 **/
 - (void)_enumerateRowsInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	[self _enumerateRowsInCollection:collection usingBlock:block withFilter:NULL];
 }
@@ -3624,8 +3624,8 @@
  * which avoids the cost associated with deserializing the object & metadata.
 **/
 - (void)_enumerateRowsInCollection:(NSString *)collection
-                        usingBlock:(void (^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block
-                        withFilter:(BOOL (^)(int64_t rowid, NSString *key))filter
+                        usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *key, id object, id metadata, BOOL *stop))block
+                        withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *key))filter
 {
 	if (block == NULL) return;
 	if (collection == nil) collection = @"";
@@ -3760,7 +3760,7 @@
  * allowing you to skip the serialization step for those rows you're not interested in.
 **/
 - (void)_enumerateRowsInCollections:(NSArray *)collections usingBlock:
-                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	[self _enumerateRowsInCollections:collections usingBlock:block withFilter:NULL];
 }
@@ -3774,8 +3774,8 @@
  * which avoids the cost associated with deserializing the object & metadata.
 **/
 - (void)_enumerateRowsInCollections:(NSArray *)collections
-     usingBlock:(void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
-     withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter
+     usingBlock:(void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+     withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	if ([collections count] == 0) return;
@@ -3923,7 +3923,7 @@
  * allowing you to skip the serialization step for those objects you're not interested in.
 **/
 - (void)_enumerateRowsInAllCollectionsUsingBlock:
-                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+                (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
 {
 	[self _enumerateRowsInAllCollectionsUsingBlock:block withFilter:NULL];
 }
@@ -3940,8 +3940,8 @@
  * which avoids the cost associated with deserializing the object.
 **/
 - (void)_enumerateRowsInAllCollectionsUsingBlock:
-                (void (^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
-     withFilter:(BOOL (^)(int64_t rowid, NSString *collection, NSString *key))filter
+                (void (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key, id object, id metadata, BOOL *stop))block
+     withFilter:(BOOL (NS_NOESCAPE^)(int64_t rowid, NSString *collection, NSString *key))filter
 {
 	if (block == NULL) return;
 	
@@ -4054,7 +4054,7 @@
 **/
 - (void)_enumerateRowidsForKeys:(NSArray *)keys
                    inCollection:(NSString *)collection
-            unorderedUsingBlock:(void (^)(NSUInteger keyIndex, int64_t rowid, BOOL *stop))block
+            unorderedUsingBlock:(void (NS_NOESCAPE^)(NSUInteger keyIndex, int64_t rowid, BOOL *stop))block
 {
 	if (block == NULL) return;
 	if (keys.count == 0) return;


### PR DESCRIPTION
Resolves: #175 

Objective-C closures are implicitly escaping, Swift closures are implicitly non-escaping 🤦‍♂️ 

For Swift projects using YapDB, if you create a func that has a closure argument, and that closure is then passed to a YapDB method (e.g. to synchronously enumerate something), you'll need to mark that closure as escaping, even though the method you're calling doesn't actually need it to be escaping.

Decorating the Objective-C block arguments w/ NS_NOESCAPE clarifies to the caller that no, the thing you're calling will not be hanging onto the closure you're passing it. Unless it's asynchronous, or the closure is actually stored (e.g. group blocks/sorting blocks/search handler blocks/etc), it doesn't need to be escaping.
