### PR TITLE
Add option for setting SQLCipher cipher_compatibility version

### DIFF
--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -911,6 +911,16 @@ static int connectionBusyHandler(void *ptr, int count) {
             }
         }
         
+        if (options.cipherCompatability != YapDatabaseCipherCompatability_Default) {
+            char *errorMsg;
+            NSString *pragmaCommand = [NSString stringWithFormat:@"PRAGMA cipher_compatibility = %lu", (unsigned long)options.cipherCompatability];
+            if (sqlite3_exec(sqlite, [pragmaCommand UTF8String], NULL, NULL, &errorMsg) != SQLITE_OK)
+            {
+                YDBLogError(@"failed to set database cipher_compatibility: %s", errorMsg);
+                return NO;
+            }
+        }
+        
         if (options.cipherUnencryptedHeaderLength > 0 &&
             (options.cipherKeySpecBlock ||
              options.cipherSaltBlock)) {

--- a/YapDatabase/YapDatabaseOptions.h
+++ b/YapDatabase/YapDatabaseOptions.h
@@ -29,6 +29,12 @@ typedef NS_ENUM(NSInteger, YapDatabasePragmaSynchronous) {
 
 #ifdef SQLITE_HAS_CODEC
 typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
+
+typedef NS_ENUM(NSInteger, YapDatabaseCipherCompatability) {
+    YapDatabaseCipherCompatability_Default   = 0,
+    YapDatabaseCipherCompatability_Version3  = 3,
+    YapDatabaseCipherCompatability_Version4  = 4,
+};
 #endif
 
 @interface YapDatabaseOptions : NSObject <NSCopying>
@@ -170,6 +176,17 @@ typedef NSData *_Nonnull (^YapDatabaseCipherKeyBlock)(void);
  * Important: If you do not set a cipherKeyBlock the database will NOT be configured with encryption.
 **/
 @property (nonatomic, copy, readwrite) YapDatabaseCipherKeyBlock cipherKeyBlock;
+
+/**
+ * Databases created with SQLCipher 3.0 are not compatible with SQLCipher 4.0.
+ * Setting this flag to YapDatabaseCipherCompatability_Version3 will
+ * set "PRAGMA cipher_compatibility = 3" on the current database.
+ *
+ * For more information see https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_compatibility
+ *
+ * Default value is YapDatabaseCipherCompatability_Default which is a no-op.
+ **/
+@property (nonatomic, assign, readwrite) YapDatabaseCipherCompatability cipherCompatability;
 
 /**
  * Set the PBKDF2 iteration number for deriving the key to the SQLCipher database.

--- a/YapDatabase/YapDatabaseOptions.m
+++ b/YapDatabase/YapDatabaseOptions.m
@@ -27,7 +27,7 @@
 @synthesize cipherSaltBlock = cipherSaltBlock;
 @synthesize cipherKeySpecBlock = cipherKeySpecBlock;
 @synthesize cipherUnencryptedHeaderLength = cipherUnencryptedHeaderLength;
-
+@synthesize cipherCompatability = cipherCompatability;
 #endif
 @synthesize aggressiveWALTruncationSize = aggressiveWALTruncationSize;
 @synthesize enableMultiProcessSupport = enableMultiProcessSupport;
@@ -63,6 +63,7 @@
     copy->cipherSaltBlock = cipherSaltBlock;
     copy->cipherKeySpecBlock = cipherKeySpecBlock;
     copy->cipherUnencryptedHeaderLength = cipherUnencryptedHeaderLength;
+    copy->cipherCompatability = cipherCompatability;
 #endif
 	copy->aggressiveWALTruncationSize = aggressiveWALTruncationSize;
     copy->enableMultiProcessSupport = enableMultiProcessSupport;


### PR DESCRIPTION
Databases created with SQLCipher 3.x are not compatible with SQLCipher 4.x by default. 

For more details:
* https://discuss.zetetic.net/t/upgrading-to-sqlcipher-4/3283
* https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_compatibility