### PR TITLE
Adds support for Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CocoaLumberjack",
+        "repositoryURL": "git@github.com:CocoaLumberjack/CocoaLumberjack",
+        "state": {
+          "branch": null,
+          "revision": "ded5f5999c853e7fef61fc27db100b169db0e21f",
+          "version": "3.6.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,82 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "YapDatabase",
+  platforms: [
+    .iOS(.v8),
+    .macOS(.v10_10),
+    .tvOS(.v9),
+    .watchOS(.v2)
+  ],
+  products: [
+    .library(name: "YapDatabase", targets: ["YapDatabase"]),
+    .library(name: "YapDatabaseSwift", targets: ["YapDatabaseSwift"])
+  ],
+  dependencies: [
+    .package(url: "git@github.com:CocoaLumberjack/CocoaLumberjack", .exact("3.6.0"))
+  ],
+  targets: [
+    .target(
+      name: "YapDatabase",
+      dependencies: ["CocoaLumberjack"],
+      path: "YapDatabase",
+      exclude: [
+        "Swift",
+        "Extensions/ActionManager/Swift",
+        "Extensions/AutoView/Swift",
+        "Extensions/CloudCore/Swift",
+        "Extensions/CloudKit/Swift",
+        "Extensions/ConnectionPool/Swift",
+        "Extensions/ConnectionProxy/Swift",
+        "Extensions/CrossProcessNotification/Swift",
+        "Extensions/FilteredView/Swift",
+        "Extensions/FullTextSearch/Swift",
+        "Extensions/Hooks/Swift",
+        "Extensions/ManualView/Swift",
+        "Extensions/Protocol/Swift",
+        "Extensions/Relationships/Swift",
+        "Extensions/RTreeIndex/Swift",
+        "Extensions/SearchResultsView/Swift",
+        "Extensions/SecondaryIndex/Swift",
+        "Extensions/View/Swift"
+      ],
+      sources: ["Extensions", "Internal", "Utilities"],
+      cxxSettings: [
+        .headerSearchPath("./"),
+        .headerSearchPath("./Extensions/**"),
+        .headerSearchPath("./Internal/**"),
+        .headerSearchPath("./Utilities/**")
+      ]
+    ),
+    .target(
+      name: "YapDatabaseSwift",
+      dependencies: ["YapDatabase"],
+      path: "YapDatabase",
+      sources: [
+        "Swift",
+        "Extensions/ActionManager/Swift",
+        "Extensions/AutoView/Swift",
+        "Extensions/CloudCore/Swift",
+        "Extensions/CloudKit/Swift",
+        "Extensions/ConnectionPool/Swift",
+        "Extensions/ConnectionProxy/Swift",
+        "Extensions/CrossProcessNotification/Swift",
+        "Extensions/FilteredView/Swift",
+        "Extensions/FullTextSearch/Swift",
+        "Extensions/Hooks/Swift",
+        "Extensions/ManualView/Swift",
+        "Extensions/Protocol/Swift",
+        "Extensions/Relationships/Swift",
+        "Extensions/RTreeIndex/Swift",
+        "Extensions/SearchResultsView/Swift",
+        "Extensions/SecondaryIndex/Swift",
+        "Extensions/View/Swift"
+      ]
+    )
+  ],
+  cLanguageStandard: .gnu99,
+  cxxLanguageStandard: .gnucxx11
+)

--- a/YapDatabase.xcodeproj/project.pbxproj
+++ b/YapDatabase.xcodeproj/project.pbxproj
@@ -1560,6 +1560,13 @@
 			path = Internal;
 			sourceTree = "<group>";
 		};
+		B93B310F23897E6200710E07 /* include */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
 		DC1E7D041D80C901000721B8 /* watchOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -1624,6 +1631,7 @@
 		DC651F171BCEC77E00188E23 /* YapDatabase */ = {
 			isa = PBXGroup;
 			children = (
+				B93B310F23897E6200710E07 /* include */,
 				DC651F181BCEC77E00188E23 /* Extensions */,
 				DC651FBC1BCEC77E00188E23 /* Internal */,
 				DC651FD61BCEC77E00188E23 /* Utilities */,

--- a/YapDatabase/Extensions/ActionManager/Swift/YapDatabaseActionManager.swift
+++ b/YapDatabase/Extensions/ActionManager/Swift/YapDatabaseActionManager.swift
@@ -1,5 +1,7 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseActionManagerTransaction {
 
 }

--- a/YapDatabase/Extensions/AutoView/Swift/YapDatabaseAutoView.swift
+++ b/YapDatabase/Extensions/AutoView/Swift/YapDatabaseAutoView.swift
@@ -1,5 +1,7 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseAutoViewTransaction {
 
 }

--- a/YapDatabase/Extensions/CloudCore/Swift/YapDatabaseCloudCore.swift
+++ b/YapDatabase/Extensions/CloudCore/Swift/YapDatabaseCloudCore.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseCloudCoreTransaction {
 }

--- a/YapDatabase/Extensions/CloudKit/Swift/YapDatabaseCloudKit.swift
+++ b/YapDatabase/Extensions/CloudKit/Swift/YapDatabaseCloudKit.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseCloudKitTransaction {
 }

--- a/YapDatabase/Extensions/CrossProcessNotification/Swift/YapDatabaseCrossProcessNotification.swift
+++ b/YapDatabase/Extensions/CrossProcessNotification/Swift/YapDatabaseCrossProcessNotification.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseCrossProcessNotificationTransaction {
 }

--- a/YapDatabase/Extensions/FilteredView/Swift/YapDatabaseFilteredView.swift
+++ b/YapDatabase/Extensions/FilteredView/Swift/YapDatabaseFilteredView.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseFilteredViewTransaction {
 }

--- a/YapDatabase/Extensions/FullTextSearch/Swift/YapDatabaseFullTextSearch.swift
+++ b/YapDatabase/Extensions/FullTextSearch/Swift/YapDatabaseFullTextSearch.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseFullTextSearchTransaction {
 }

--- a/YapDatabase/Extensions/Hooks/Swift/YapDatabaseHooks.swift
+++ b/YapDatabase/Extensions/Hooks/Swift/YapDatabaseHooks.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseHooks {
 }

--- a/YapDatabase/Extensions/ManualView/Swift/YapDatabaseManualView.swift
+++ b/YapDatabase/Extensions/ManualView/Swift/YapDatabaseManualView.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseManualViewTransaction {
 }

--- a/YapDatabase/Extensions/RTreeIndex/Swift/YapDatabaseRTreeIndex.swift
+++ b/YapDatabase/Extensions/RTreeIndex/Swift/YapDatabaseRTreeIndex.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseRTreeIndexTransaction {
 }

--- a/YapDatabase/Extensions/Relationships/Swift/YapDatabaseRelationship.swift
+++ b/YapDatabase/Extensions/Relationships/Swift/YapDatabaseRelationship.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseRelationshipTransaction {
 }

--- a/YapDatabase/Extensions/SearchResultsView/Swift/YapDatabaseSearchResultsView.swift
+++ b/YapDatabase/Extensions/SearchResultsView/Swift/YapDatabaseSearchResultsView.swift
@@ -1,4 +1,6 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseSearchResultsViewTransaction {
 }

--- a/YapDatabase/Extensions/SecondaryIndex/Swift/YapDatabaseSecondaryIndex.swift
+++ b/YapDatabase/Extensions/SecondaryIndex/Swift/YapDatabaseSecondaryIndex.swift
@@ -1,5 +1,7 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseSecondaryIndexTransaction {
 	
 	/// Iterates matches from the secondary index using the given query.

--- a/YapDatabase/Extensions/View/Swift/YapDatabaseView.swift
+++ b/YapDatabase/Extensions/View/Swift/YapDatabaseView.swift
@@ -1,5 +1,7 @@
 /// Add Swift extensions here
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseViewConnection {
 	
 	public func getChanges(forNotifications notifications: [Notification], withMappings mappings: YapDatabaseViewMappings) -> (sectionChanges: [YapDatabaseViewSectionChange], rowChanges: [YapDatabaseViewRowChange]) {

--- a/YapDatabase/SPM.h
+++ b/YapDatabase/SPM.h
@@ -1,0 +1,1 @@
+#import "YapDatabase.h"

--- a/YapDatabase/Swift/YapDatabase.swift
+++ b/YapDatabase/Swift/YapDatabase.swift
@@ -1,5 +1,7 @@
 import Foundation
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabase {
 	
 	/// Creates and returns a `YapDatabaseSerializer` that works with Codable types,

--- a/YapDatabase/Swift/YapDatabaseQuery.swift
+++ b/YapDatabase/Swift/YapDatabaseQuery.swift
@@ -1,5 +1,7 @@
 import Foundation
-
+#if SWIFT_PACKAGE
+import YapDatabase
+#endif
 extension YapDatabaseQuery {
 	
 	convenience init(string queryString: String) {

--- a/YapDatabase/include/YDBCKChangeSet.h
+++ b/YapDatabase/include/YDBCKChangeSet.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/Utilities/YDBCKChangeSet.h

--- a/YapDatabase/include/YDBCKMergeInfo.h
+++ b/YapDatabase/include/YDBCKMergeInfo.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/Utilities/YDBCKMergeInfo.h

--- a/YapDatabase/include/YDBCKRecord.h
+++ b/YapDatabase/include/YDBCKRecord.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/Utilities/YDBCKRecord.h

--- a/YapDatabase/include/YDBCKRecordInfo.h
+++ b/YapDatabase/include/YDBCKRecordInfo.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/Utilities/YDBCKRecordInfo.h

--- a/YapDatabase/include/YDBLogMessage.h
+++ b/YapDatabase/include/YDBLogMessage.h
@@ -1,0 +1,1 @@
+../Utilities/YDBLogMessage.h

--- a/YapDatabase/include/YapActionItem.h
+++ b/YapDatabase/include/YapActionItem.h
@@ -1,0 +1,1 @@
+../Extensions/ActionManager/YapActionItem.h

--- a/YapDatabase/include/YapActionable.h
+++ b/YapDatabase/include/YapActionable.h
@@ -1,0 +1,1 @@
+../Extensions/ActionManager/YapActionable.h

--- a/YapDatabase/include/YapBidirectionalCache.h
+++ b/YapDatabase/include/YapBidirectionalCache.h
@@ -1,0 +1,1 @@
+../Utilities/YapBidirectionalCache.h

--- a/YapDatabase/include/YapCache.h
+++ b/YapDatabase/include/YapCache.h
@@ -1,0 +1,1 @@
+../Utilities/YapCache.h

--- a/YapDatabase/include/YapCollectionKey.h
+++ b/YapDatabase/include/YapCollectionKey.h
@@ -1,0 +1,1 @@
+../Utilities/YapCollectionKey.h

--- a/YapDatabase/include/YapDatabase
+++ b/YapDatabase/include/YapDatabase
@@ -1,0 +1,1 @@
+YapDatabase

--- a/YapDatabase/include/YapDatabase.h
+++ b/YapDatabase/include/YapDatabase.h
@@ -1,0 +1,1 @@
+../YapDatabase.h

--- a/YapDatabase/include/YapDatabaseActionManager.h
+++ b/YapDatabase/include/YapDatabaseActionManager.h
@@ -1,0 +1,1 @@
+../Extensions/ActionManager/YapDatabaseActionManager.h

--- a/YapDatabase/include/YapDatabaseActionManagerConnection.h
+++ b/YapDatabase/include/YapDatabaseActionManagerConnection.h
@@ -1,0 +1,1 @@
+../Extensions/ActionManager/YapDatabaseActionManagerConnection.h

--- a/YapDatabase/include/YapDatabaseActionManagerTransaction.h
+++ b/YapDatabase/include/YapDatabaseActionManagerTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/ActionManager/YapDatabaseActionManagerTransaction.h

--- a/YapDatabase/include/YapDatabaseAtomic.h
+++ b/YapDatabase/include/YapDatabaseAtomic.h
@@ -1,0 +1,1 @@
+../Utilities/YapDatabaseAtomic.h

--- a/YapDatabase/include/YapDatabaseAutoView.h
+++ b/YapDatabase/include/YapDatabaseAutoView.h
@@ -1,0 +1,1 @@
+../Extensions/AutoView/YapDatabaseAutoView.h

--- a/YapDatabase/include/YapDatabaseAutoViewConnection.h
+++ b/YapDatabase/include/YapDatabaseAutoViewConnection.h
@@ -1,0 +1,1 @@
+../Extensions/AutoView/YapDatabaseAutoViewConnection.h

--- a/YapDatabase/include/YapDatabaseAutoViewTransaction.h
+++ b/YapDatabase/include/YapDatabaseAutoViewTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/AutoView/YapDatabaseAutoViewTransaction.h

--- a/YapDatabase/include/YapDatabaseCloudCore.h
+++ b/YapDatabase/include/YapDatabaseCloudCore.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/YapDatabaseCloudCore.h

--- a/YapDatabase/include/YapDatabaseCloudCoreConnection.h
+++ b/YapDatabase/include/YapDatabaseCloudCoreConnection.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/YapDatabaseCloudCoreConnection.h

--- a/YapDatabase/include/YapDatabaseCloudCoreGraph.h
+++ b/YapDatabase/include/YapDatabaseCloudCoreGraph.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Utilities/Execution/YapDatabaseCloudCoreGraph.h

--- a/YapDatabase/include/YapDatabaseCloudCoreGraphPrivate.h
+++ b/YapDatabase/include/YapDatabaseCloudCoreGraphPrivate.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Internal/YapDatabaseCloudCoreGraphPrivate.h

--- a/YapDatabase/include/YapDatabaseCloudCoreOperation.h
+++ b/YapDatabase/include/YapDatabaseCloudCoreOperation.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Utilities/Operations/YapDatabaseCloudCoreOperation.h

--- a/YapDatabase/include/YapDatabaseCloudCoreOperationPrivate.h
+++ b/YapDatabase/include/YapDatabaseCloudCoreOperationPrivate.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Internal/YapDatabaseCloudCoreOperationPrivate.h

--- a/YapDatabase/include/YapDatabaseCloudCoreOptions.h
+++ b/YapDatabase/include/YapDatabaseCloudCoreOptions.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/YapDatabaseCloudCoreOptions.h

--- a/YapDatabase/include/YapDatabaseCloudCorePipeline.h
+++ b/YapDatabase/include/YapDatabaseCloudCorePipeline.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Utilities/Execution/YapDatabaseCloudCorePipeline.h

--- a/YapDatabase/include/YapDatabaseCloudCorePipelineDelegate.h
+++ b/YapDatabase/include/YapDatabaseCloudCorePipelineDelegate.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Utilities/Execution/YapDatabaseCloudCorePipelineDelegate.h

--- a/YapDatabase/include/YapDatabaseCloudCorePipelinePrivate.h
+++ b/YapDatabase/include/YapDatabaseCloudCorePipelinePrivate.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Internal/YapDatabaseCloudCorePipelinePrivate.h

--- a/YapDatabase/include/YapDatabaseCloudCorePrivate.h
+++ b/YapDatabase/include/YapDatabaseCloudCorePrivate.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Internal/YapDatabaseCloudCorePrivate.h

--- a/YapDatabase/include/YapDatabaseCloudCoreTransaction.h
+++ b/YapDatabase/include/YapDatabaseCloudCoreTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/YapDatabaseCloudCoreTransaction.h

--- a/YapDatabase/include/YapDatabaseCloudKit.h
+++ b/YapDatabase/include/YapDatabaseCloudKit.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/YapDatabaseCloudKit.h

--- a/YapDatabase/include/YapDatabaseCloudKitConnection.h
+++ b/YapDatabase/include/YapDatabaseCloudKitConnection.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/YapDatabaseCloudKitConnection.h

--- a/YapDatabase/include/YapDatabaseCloudKitOptions.h
+++ b/YapDatabase/include/YapDatabaseCloudKitOptions.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/YapDatabaseCloudKitOptions.h

--- a/YapDatabase/include/YapDatabaseCloudKitTransaction.h
+++ b/YapDatabase/include/YapDatabaseCloudKitTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/YapDatabaseCloudKitTransaction.h

--- a/YapDatabase/include/YapDatabaseCloudKitTypes.h
+++ b/YapDatabase/include/YapDatabaseCloudKitTypes.h
@@ -1,0 +1,1 @@
+../Extensions/CloudKit/YapDatabaseCloudKitTypes.h

--- a/YapDatabase/include/YapDatabaseCollectionConfig.h
+++ b/YapDatabase/include/YapDatabaseCollectionConfig.h
@@ -1,0 +1,1 @@
+../Internal/YapDatabaseCollectionConfig.h

--- a/YapDatabase/include/YapDatabaseConnection.h
+++ b/YapDatabase/include/YapDatabaseConnection.h
@@ -1,0 +1,1 @@
+../YapDatabaseConnection.h

--- a/YapDatabase/include/YapDatabaseConnectionConfig.h
+++ b/YapDatabase/include/YapDatabaseConnectionConfig.h
@@ -1,0 +1,1 @@
+../Utilities/YapDatabaseConnectionConfig.h

--- a/YapDatabase/include/YapDatabaseConnectionPool.h
+++ b/YapDatabase/include/YapDatabaseConnectionPool.h
@@ -1,0 +1,1 @@
+../Extensions/ConnectionPool/YapDatabaseConnectionPool.h

--- a/YapDatabase/include/YapDatabaseConnectionProxy.h
+++ b/YapDatabase/include/YapDatabaseConnectionProxy.h
@@ -1,0 +1,1 @@
+../Extensions/ConnectionProxy/YapDatabaseConnectionProxy.h

--- a/YapDatabase/include/YapDatabaseCrossProcessNotification.h
+++ b/YapDatabase/include/YapDatabaseCrossProcessNotification.h
@@ -1,0 +1,1 @@
+../Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotification.h

--- a/YapDatabase/include/YapDatabaseCrossProcessNotificationConnection.h
+++ b/YapDatabase/include/YapDatabaseCrossProcessNotificationConnection.h
@@ -1,0 +1,1 @@
+../Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotificationConnection.h

--- a/YapDatabase/include/YapDatabaseCrossProcessNotificationTransaction.h
+++ b/YapDatabase/include/YapDatabaseCrossProcessNotificationTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/CrossProcessNotification/YapDatabaseCrossProcessNotificationTransaction.h

--- a/YapDatabase/include/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/include/YapDatabaseCryptoUtils.h
@@ -1,0 +1,1 @@
+../Utilities/YapDatabaseCryptoUtils.h

--- a/YapDatabase/include/YapDatabaseExtension.h
+++ b/YapDatabase/include/YapDatabaseExtension.h
@@ -1,0 +1,1 @@
+../Extensions/Protocol/YapDatabaseExtension.h

--- a/YapDatabase/include/YapDatabaseExtensionConnection.h
+++ b/YapDatabase/include/YapDatabaseExtensionConnection.h
@@ -1,0 +1,1 @@
+../Extensions/Protocol/YapDatabaseExtensionConnection.h

--- a/YapDatabase/include/YapDatabaseExtensionPrivate.h
+++ b/YapDatabase/include/YapDatabaseExtensionPrivate.h
@@ -1,0 +1,1 @@
+../Extensions/Protocol/Internal/YapDatabaseExtensionPrivate.h

--- a/YapDatabase/include/YapDatabaseExtensionTransaction.h
+++ b/YapDatabase/include/YapDatabaseExtensionTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/Protocol/YapDatabaseExtensionTransaction.h

--- a/YapDatabase/include/YapDatabaseExtensionTypes.h
+++ b/YapDatabase/include/YapDatabaseExtensionTypes.h
@@ -1,0 +1,1 @@
+../Extensions/Protocol/YapDatabaseExtensionTypes.h

--- a/YapDatabase/include/YapDatabaseFilteredView.h
+++ b/YapDatabase/include/YapDatabaseFilteredView.h
@@ -1,0 +1,1 @@
+../Extensions/FilteredView/YapDatabaseFilteredView.h

--- a/YapDatabase/include/YapDatabaseFilteredViewConnection.h
+++ b/YapDatabase/include/YapDatabaseFilteredViewConnection.h
@@ -1,0 +1,1 @@
+../Extensions/FilteredView/YapDatabaseFilteredViewConnection.h

--- a/YapDatabase/include/YapDatabaseFilteredViewTransaction.h
+++ b/YapDatabase/include/YapDatabaseFilteredViewTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/FilteredView/YapDatabaseFilteredViewTransaction.h

--- a/YapDatabase/include/YapDatabaseFilteredViewTypes.h
+++ b/YapDatabase/include/YapDatabaseFilteredViewTypes.h
@@ -1,0 +1,1 @@
+../Extensions/FilteredView/YapDatabaseFilteredViewTypes.h

--- a/YapDatabase/include/YapDatabaseFullTextSearch.h
+++ b/YapDatabase/include/YapDatabaseFullTextSearch.h
@@ -1,0 +1,1 @@
+../Extensions/FullTextSearch/YapDatabaseFullTextSearch.h

--- a/YapDatabase/include/YapDatabaseFullTextSearchConnection.h
+++ b/YapDatabase/include/YapDatabaseFullTextSearchConnection.h
@@ -1,0 +1,1 @@
+../Extensions/FullTextSearch/YapDatabaseFullTextSearchConnection.h

--- a/YapDatabase/include/YapDatabaseFullTextSearchHandler.h
+++ b/YapDatabase/include/YapDatabaseFullTextSearchHandler.h
@@ -1,0 +1,1 @@
+../Extensions/FullTextSearch/YapDatabaseFullTextSearchHandler.h

--- a/YapDatabase/include/YapDatabaseFullTextSearchSnippetOptions.h
+++ b/YapDatabase/include/YapDatabaseFullTextSearchSnippetOptions.h
@@ -1,0 +1,1 @@
+../Extensions/FullTextSearch/YapDatabaseFullTextSearchSnippetOptions.h

--- a/YapDatabase/include/YapDatabaseFullTextSearchTransaction.h
+++ b/YapDatabase/include/YapDatabaseFullTextSearchTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/FullTextSearch/YapDatabaseFullTextSearchTransaction.h

--- a/YapDatabase/include/YapDatabaseHooks.h
+++ b/YapDatabase/include/YapDatabaseHooks.h
@@ -1,0 +1,1 @@
+../Extensions/Hooks/YapDatabaseHooks.h

--- a/YapDatabase/include/YapDatabaseHooksConnection.h
+++ b/YapDatabase/include/YapDatabaseHooksConnection.h
@@ -1,0 +1,1 @@
+../Extensions/Hooks/YapDatabaseHooksConnection.h

--- a/YapDatabase/include/YapDatabaseHooksTransaction.h
+++ b/YapDatabase/include/YapDatabaseHooksTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/Hooks/YapDatabaseHooksTransaction.h

--- a/YapDatabase/include/YapDatabaseManualView.h
+++ b/YapDatabase/include/YapDatabaseManualView.h
@@ -1,0 +1,1 @@
+../Extensions/ManualView/YapDatabaseManualView.h

--- a/YapDatabase/include/YapDatabaseManualViewConnection.h
+++ b/YapDatabase/include/YapDatabaseManualViewConnection.h
@@ -1,0 +1,1 @@
+../Extensions/ManualView/YapDatabaseManualViewConnection.h

--- a/YapDatabase/include/YapDatabaseManualViewTransaction.h
+++ b/YapDatabase/include/YapDatabaseManualViewTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/ManualView/YapDatabaseManualViewTransaction.h

--- a/YapDatabase/include/YapDatabaseOptions.h
+++ b/YapDatabase/include/YapDatabaseOptions.h
@@ -1,0 +1,1 @@
+../YapDatabaseOptions.h

--- a/YapDatabase/include/YapDatabaseQuery.h
+++ b/YapDatabase/include/YapDatabaseQuery.h
@@ -1,0 +1,1 @@
+../Utilities/YapDatabaseQuery.h

--- a/YapDatabase/include/YapDatabaseRTreeIndex.h
+++ b/YapDatabase/include/YapDatabaseRTreeIndex.h
@@ -1,0 +1,1 @@
+../Extensions/RTreeIndex/YapDatabaseRTreeIndex.h

--- a/YapDatabase/include/YapDatabaseRTreeIndexConnection.h
+++ b/YapDatabase/include/YapDatabaseRTreeIndexConnection.h
@@ -1,0 +1,1 @@
+../Extensions/RTreeIndex/YapDatabaseRTreeIndexConnection.h

--- a/YapDatabase/include/YapDatabaseRTreeIndexHandler.h
+++ b/YapDatabase/include/YapDatabaseRTreeIndexHandler.h
@@ -1,0 +1,1 @@
+../Extensions/RTreeIndex/YapDatabaseRTreeIndexHandler.h

--- a/YapDatabase/include/YapDatabaseRTreeIndexOptions.h
+++ b/YapDatabase/include/YapDatabaseRTreeIndexOptions.h
@@ -1,0 +1,1 @@
+../Extensions/RTreeIndex/YapDatabaseRTreeIndexOptions.h

--- a/YapDatabase/include/YapDatabaseRTreeIndexSetup.h
+++ b/YapDatabase/include/YapDatabaseRTreeIndexSetup.h
@@ -1,0 +1,1 @@
+../Extensions/RTreeIndex/YapDatabaseRTreeIndexSetup.h

--- a/YapDatabase/include/YapDatabaseRTreeIndexTransaction.h
+++ b/YapDatabase/include/YapDatabaseRTreeIndexTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/RTreeIndex/YapDatabaseRTreeIndexTransaction.h

--- a/YapDatabase/include/YapDatabaseRelationship.h
+++ b/YapDatabase/include/YapDatabaseRelationship.h
@@ -1,0 +1,1 @@
+../Extensions/Relationships/YapDatabaseRelationship.h

--- a/YapDatabase/include/YapDatabaseRelationshipConnection.h
+++ b/YapDatabase/include/YapDatabaseRelationshipConnection.h
@@ -1,0 +1,1 @@
+../Extensions/Relationships/YapDatabaseRelationshipConnection.h

--- a/YapDatabase/include/YapDatabaseRelationshipEdge.h
+++ b/YapDatabase/include/YapDatabaseRelationshipEdge.h
@@ -1,0 +1,1 @@
+../Extensions/Relationships/YapDatabaseRelationshipEdge.h

--- a/YapDatabase/include/YapDatabaseRelationshipNode.h
+++ b/YapDatabase/include/YapDatabaseRelationshipNode.h
@@ -1,0 +1,1 @@
+../Extensions/Relationships/YapDatabaseRelationshipNode.h

--- a/YapDatabase/include/YapDatabaseRelationshipOptions.h
+++ b/YapDatabase/include/YapDatabaseRelationshipOptions.h
@@ -1,0 +1,1 @@
+../Extensions/Relationships/YapDatabaseRelationshipOptions.h

--- a/YapDatabase/include/YapDatabaseRelationshipTransaction.h
+++ b/YapDatabase/include/YapDatabaseRelationshipTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/Relationships/YapDatabaseRelationshipTransaction.h

--- a/YapDatabase/include/YapDatabaseSearchQueue.h
+++ b/YapDatabase/include/YapDatabaseSearchQueue.h
@@ -1,0 +1,1 @@
+../Extensions/SearchResultsView/YapDatabaseSearchQueue.h

--- a/YapDatabase/include/YapDatabaseSearchResultsView.h
+++ b/YapDatabase/include/YapDatabaseSearchResultsView.h
@@ -1,0 +1,1 @@
+../Extensions/SearchResultsView/YapDatabaseSearchResultsView.h

--- a/YapDatabase/include/YapDatabaseSearchResultsViewConnection.h
+++ b/YapDatabase/include/YapDatabaseSearchResultsViewConnection.h
@@ -1,0 +1,1 @@
+../Extensions/SearchResultsView/YapDatabaseSearchResultsViewConnection.h

--- a/YapDatabase/include/YapDatabaseSearchResultsViewOptions.h
+++ b/YapDatabase/include/YapDatabaseSearchResultsViewOptions.h
@@ -1,0 +1,1 @@
+../Extensions/SearchResultsView/YapDatabaseSearchResultsViewOptions.h

--- a/YapDatabase/include/YapDatabaseSearchResultsViewTransaction.h
+++ b/YapDatabase/include/YapDatabaseSearchResultsViewTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/SearchResultsView/YapDatabaseSearchResultsViewTransaction.h

--- a/YapDatabase/include/YapDatabaseSecondaryIndex.h
+++ b/YapDatabase/include/YapDatabaseSecondaryIndex.h
@@ -1,0 +1,1 @@
+../Extensions/SecondaryIndex/YapDatabaseSecondaryIndex.h

--- a/YapDatabase/include/YapDatabaseSecondaryIndexConnection.h
+++ b/YapDatabase/include/YapDatabaseSecondaryIndexConnection.h
@@ -1,0 +1,1 @@
+../Extensions/SecondaryIndex/YapDatabaseSecondaryIndexConnection.h

--- a/YapDatabase/include/YapDatabaseSecondaryIndexHandler.h
+++ b/YapDatabase/include/YapDatabaseSecondaryIndexHandler.h
@@ -1,0 +1,1 @@
+../Extensions/SecondaryIndex/YapDatabaseSecondaryIndexHandler.h

--- a/YapDatabase/include/YapDatabaseSecondaryIndexOptions.h
+++ b/YapDatabase/include/YapDatabaseSecondaryIndexOptions.h
@@ -1,0 +1,1 @@
+../Extensions/SecondaryIndex/YapDatabaseSecondaryIndexOptions.h

--- a/YapDatabase/include/YapDatabaseSecondaryIndexSetup.h
+++ b/YapDatabase/include/YapDatabaseSecondaryIndexSetup.h
@@ -1,0 +1,1 @@
+../Extensions/SecondaryIndex/YapDatabaseSecondaryIndexSetup.h

--- a/YapDatabase/include/YapDatabaseSecondaryIndexTransaction.h
+++ b/YapDatabase/include/YapDatabaseSecondaryIndexTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.h

--- a/YapDatabase/include/YapDatabaseTransaction.h
+++ b/YapDatabase/include/YapDatabaseTransaction.h
@@ -1,0 +1,1 @@
+../YapDatabaseTransaction.h

--- a/YapDatabase/include/YapDatabaseTypes.h
+++ b/YapDatabase/include/YapDatabaseTypes.h
@@ -1,0 +1,1 @@
+../YapDatabaseTypes.h

--- a/YapDatabase/include/YapDatabaseView.h
+++ b/YapDatabase/include/YapDatabaseView.h
@@ -1,0 +1,1 @@
+../Extensions/View/YapDatabaseView.h

--- a/YapDatabase/include/YapDatabaseViewChange.h
+++ b/YapDatabase/include/YapDatabaseViewChange.h
@@ -1,0 +1,1 @@
+../Extensions/View/Utilities/YapDatabaseViewChange.h

--- a/YapDatabase/include/YapDatabaseViewConnection.h
+++ b/YapDatabase/include/YapDatabaseViewConnection.h
@@ -1,0 +1,1 @@
+../Extensions/View/YapDatabaseViewConnection.h

--- a/YapDatabase/include/YapDatabaseViewMappings.h
+++ b/YapDatabase/include/YapDatabaseViewMappings.h
@@ -1,0 +1,1 @@
+../Extensions/View/Utilities/YapDatabaseViewMappings.h

--- a/YapDatabase/include/YapDatabaseViewOptions.h
+++ b/YapDatabase/include/YapDatabaseViewOptions.h
@@ -1,0 +1,1 @@
+../Extensions/View/YapDatabaseViewOptions.h

--- a/YapDatabase/include/YapDatabaseViewRangeOptions.h
+++ b/YapDatabase/include/YapDatabaseViewRangeOptions.h
@@ -1,0 +1,1 @@
+../Extensions/View/Utilities/YapDatabaseViewRangeOptions.h

--- a/YapDatabase/include/YapDatabaseViewTransaction.h
+++ b/YapDatabase/include/YapDatabaseViewTransaction.h
@@ -1,0 +1,1 @@
+../Extensions/View/YapDatabaseViewTransaction.h

--- a/YapDatabase/include/YapDatabaseViewTypes.h
+++ b/YapDatabase/include/YapDatabaseViewTypes.h
@@ -1,0 +1,1 @@
+../Extensions/AutoView/YapDatabaseViewTypes.h

--- a/YapDatabase/include/YapDirtyDictionary.h
+++ b/YapDatabase/include/YapDirtyDictionary.h
@@ -1,0 +1,1 @@
+../Utilities/YapDirtyDictionary.h

--- a/YapDatabase/include/YapManyToManyCache.h
+++ b/YapDatabase/include/YapManyToManyCache.h
@@ -1,0 +1,1 @@
+../Extensions/CloudCore/Utilities/YapManyToManyCache.h

--- a/YapDatabase/include/YapMurmurHash.h
+++ b/YapDatabase/include/YapMurmurHash.h
@@ -1,0 +1,1 @@
+../Utilities/YapMurmurHash.h

--- a/YapDatabase/include/YapMutationStack.h
+++ b/YapDatabase/include/YapMutationStack.h
@@ -1,0 +1,1 @@
+../Utilities/YapMutationStack.h

--- a/YapDatabase/include/YapProxyObject.h
+++ b/YapDatabase/include/YapProxyObject.h
@@ -1,0 +1,1 @@
+../Utilities/YapProxyObject.h

--- a/YapDatabase/include/YapReachability.h
+++ b/YapDatabase/include/YapReachability.h
@@ -1,0 +1,1 @@
+../Extensions/ActionManager/Utilities/YapReachability.h

--- a/YapDatabase/include/YapSet.h
+++ b/YapDatabase/include/YapSet.h
@@ -1,0 +1,1 @@
+../Utilities/YapSet.h

--- a/YapDatabase/include/YapWhitelistBlacklist.h
+++ b/YapDatabase/include/YapWhitelistBlacklist.h
@@ -1,0 +1,1 @@
+../Utilities/YapWhitelistBlacklist.h


### PR DESCRIPTION
Resolves #497 

~~**NOTE: This is based off my fix for #496** since I'm assuming that will get merged before this. I can separate it out if necessary, but having a working Xcode project does make confirming this doesn't break the non-swift-package build a bit easier though.~~ Went ahead and ripped #496 out.

SPM really wants all the public header files to be in one place, an `includes/[packagename]` folder. Moving the header files seemed ridiculous so I created an `includes` folder, a symlink to itself named `YapDatabase`, and then symlinks for every last public header file. Yes, that's also ridiculous, but seemed preferable to moving the headers to a single folder. 

Apple's documentation suggests that you should be able to just include a `module.modulemap` file in the `include` folder, but I got nowhere with this approach. It would be nice if we could get this working since there are already some module maps in the repo.

**I fully expect to** have to modify the `Package.swift` file to provide the same type of granularity as the podspec, but figured I'd start with the minimum to get it working to get some feedback or bright ideas regarding the public header files.