### PR TITLE
Fixes travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode11.3
 
 before_script:
   - export LANG=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ before_script:
   - export LANG=en_US.UTF-8
 script:
   - cd ./Testing/Xcode-desktop
+  - pod install
   - xcodebuild -workspace YapDatabaseTesting.xcworkspace -scheme YapDatabaseTesting clean
   - xcodebuild -workspace YapDatabaseTesting.xcworkspace -scheme YapDatabaseTesting -configuration release test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ osx_image: xcode9.2
 
 before_script:
   - export LANG=en_US.UTF-8
+  - gem install cocoapods -v '1.8.4'
 script:
   - cd ./Testing/Xcode-desktop
   - pod install


### PR DESCRIPTION
Fixes #506 

* Installs current stable version of `cocoapods` gem, 1.8.4. Running `pod install` with the pre-installed version of `cocoapods` fails immediately with this error message: `Unknown installation options: disable_input_output_paths`
* Updates Xcode version to 11.3. Running with the prior version, 9.2, the project failed to build due to tons of ambiguous type errors.
* Runs `pod install` after changing directories to the Xcode-Desktop dir.