### PR TITLE
Restores support for setting default object & metadata policies

### DIFF
--- a/YapDatabase/Internal/YapDatabasePrivate.h
+++ b/YapDatabase/Internal/YapDatabasePrivate.h
@@ -122,6 +122,8 @@ static NSString *const ext_key_class = @"class";
 
 - (YapDatabaseCollectionConfig *)configForCollection:(nullable NSString *)collection;
 
+- (NSNumber *)getDefaultObjectPolicy;
+- (NSNumber *)getDefaultMetadataPolicy;
 - (void)getObjectPolicies:(NSDictionary<NSString*, NSNumber*> *_Nonnull *_Nonnull)objectPoliciesPtr
          metadataPolicies:(NSDictionary<NSString*, NSNumber*> *_Nonnull *_Nonnull)metadataPoliciesPtr;
 

--- a/YapDatabase/YapDatabase.h
+++ b/YapDatabase/YapDatabase.h
@@ -531,10 +531,34 @@ extern NSString *const YapDatabaseModifiedExternallyKey;
  * Allows you to opt-in to various performance improvements,
  * which is generally dependent on the object types you're storing in each collection.
  *
+ * This object policy will be used for all collections for which an explicit object
+ * policy has not been set.
+ *
+ * The Object-Policy is documented on the wiki here:
+ * https://github.com/yapstudios/YapDatabase/wiki/Object-Policy
+ */
+- (void)setDefaultObjectPolicy:(YapDatabasePolicy)policy;
+
+/**
+ * Allows you to opt-in to various performance improvements,
+ * which is generally dependent on the object types you're storing in each collection.
+ *
  * The Object-Policy is documented on the wiki here:
  * https://github.com/yapstudios/YapDatabase/wiki/Object-Policy
  */
 - (void)setMetadataPolicy:(YapDatabasePolicy)policy forCollection:(nullable NSString *)collection;
+
+/**
+ * Allows you to opt-in to various performance improvements,
+ * which is generally dependent on the object types you're storing in each collection.
+ *
+ * This metadata policy will be used for all collections for which an explicit metadata
+ * policy has not been set.
+ *
+ * The Object-Policy is documented on the wiki here:
+ * https://github.com/yapstudios/YapDatabase/wiki/Object-Policy
+*/
+- (void)setDefaultMetadataPolicy:(YapDatabasePolicy)policy;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Connections

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -4162,7 +4162,7 @@ static int connectionBusyHandler(void *ptr, int count)
 				else if (newObject != yapTouch)
 				{
 					YapDatabasePolicy objectPolicy = YapDatabasePolicyContainment;
-					NSNumber *op = objectPolicies[cacheKey.collection];
+          NSNumber *op = objectPolicies[cacheKey.collection] ?: [database getDefaultObjectPolicy];
 					if (op) {
 						objectPolicy = (YapDatabasePolicy)[op integerValue];
 					}
@@ -4284,7 +4284,7 @@ static int connectionBusyHandler(void *ptr, int count)
 				else if (newMetadata != yapTouch)
 				{
 					YapDatabasePolicy metadataPolicy = YapDatabasePolicyContainment;
-					NSNumber *mp = metadataPolicies[cacheKey.collection];
+					NSNumber *mp = metadataPolicies[cacheKey.collection] ?: [database getDefaultMetadataPolicy];
 					if (mp) {
 						metadataPolicy = (YapDatabasePolicy)[mp integerValue];
 					}


### PR DESCRIPTION
Resolves #502 

Adds a test confirming the correct policies are returned per collection when there is/is not an explicit default and when there is/is not an explicit collection policy set.