### PR TITLE
Fixed a nullability specifier in enumerateIndexedValuesInColumn:

### DIFF
--- a/YapDatabase/Extensions/SecondaryIndex/Swift/YapDatabaseSecondaryIndex.swift
+++ b/YapDatabase/Extensions/SecondaryIndex/Swift/YapDatabaseSecondaryIndex.swift
@@ -89,9 +89,9 @@ extension YapDatabaseSecondaryIndexTransaction {
 		return self.__enumerateRows(matching: query, using: enumBlock)
 	}
 	
-	public func iterateIndexedValues(inColumn column: String, matching query: YapDatabaseQuery, using block: (Any, inout Bool) -> Void) -> Bool {
+	public func iterateIndexedValues(inColumn column: String, matching query: YapDatabaseQuery, using block: (Any?, inout Bool) -> Void) -> Bool {
 		
-		let enumBlock = {(value: Any, outerStop: UnsafeMutablePointer<ObjCBool>) -> Void in
+		let enumBlock = {(value: Any?, outerStop: UnsafeMutablePointer<ObjCBool>) -> Void in
 			
 			var innerStop = false
 			block(value, &innerStop)

--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.h
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.h
@@ -61,7 +61,7 @@ NS_REFINED_FOR_SWIFT;
 
 - (BOOL)enumerateIndexedValuesInColumn:(NSString *)column
                          matchingQuery:(YapDatabaseQuery *)query
-                            usingBlock:(void (^NS_NOESCAPE)(id indexedValue, BOOL *stop))block
+                            usingBlock:(void (^NS_NOESCAPE)(__nullable id indexedValue, BOOL *stop))block
 NS_REFINED_FOR_SWIFT;
 
 /**


### PR DESCRIPTION
Unlike objects, column values can be nil, so the block signature should reflect this.