### PR TITLE
GNUstep / Android compatibility changes

### DIFF
--- a/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
+++ b/YapDatabase/Extensions/SecondaryIndex/YapDatabaseSecondaryIndexTransaction.m
@@ -499,7 +499,7 @@ static NSString *const ext_key_version_deprecated = @"version";
 				{
 					__unsafe_unretained NSNumber *number = (NSNumber *)columnValue;
 					
-					CFNumberType numberType = CFNumberGetType((CFNumberRef)number);
+					CFNumberType numberType = CFNumberGetType((__bridge CFNumberRef)number);
 					
 					if (numberType == kCFNumberFloat32Type ||
 						numberType == kCFNumberFloat64Type ||

--- a/YapDatabase/Internal/NSDictionary+YapDatabase.m
+++ b/YapDatabase/Internal/NSDictionary+YapDatabase.m
@@ -13,7 +13,7 @@
 **/
 - (BOOL)ydb_containsKey:(id)key
 {
-	return CFDictionaryContainsKey((CFDictionaryRef)self, (const void *)key);
+	return CFDictionaryContainsKey((__bridge CFDictionaryRef)self, (__bridge const void *)key);
 }
 
 @end

--- a/YapDatabase/Internal/YapDatabasePrivate.h
+++ b/YapDatabase/Internal/YapDatabasePrivate.h
@@ -463,7 +463,11 @@ static NSString *const ext_key_class = @"class";
 
 @interface YapDatabaseReadWriteTransaction () {
 @public
+#if OS_OBJECT_USE_OBJC
 	NSMutableArray<dispatch_queue_t> *completionQueueStack;
+#else
+	NSMutableArray *completionQueueStack;
+#endif
 	NSMutableArray<dispatch_block_t> *completionBlockStack;
 	
 	BOOL rollback;

--- a/YapDatabase/Utilities/YapBidirectionalCache.m
+++ b/YapDatabase/Utilities/YapBidirectionalCache.m
@@ -178,8 +178,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 					leastRecentCacheItem = leastRecentCacheItem->prev;
 					leastRecentCacheItem->next = nil;
 					
-					CFDictionaryRemoveValue(obj_key_dict, (const void *)(objToEvict)); // must be first
-					CFDictionaryRemoveValue(key_obj_dict, (const void *)(keyToEvict)); // must be second
+					CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)(objToEvict)); // must be first
+					CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)(keyToEvict)); // must be second
 					
 					evictedCacheItem->prev = nil;
 					evictedCacheItem->next = nil;
@@ -191,8 +191,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 					leastRecentCacheItem = leastRecentCacheItem->prev;
 					leastRecentCacheItem->next = nil;
 					
-					CFDictionaryRemoveValue(obj_key_dict, (const void *)(objToEvict)); // must be first
-					CFDictionaryRemoveValue(key_obj_dict, (const void *)(keyToEvict)); // must be second
+					CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)(objToEvict)); // must be first
+					CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)(keyToEvict)); // must be second
 				}
 				
 			#if YapBidirectionalCache_Enable_Statistics
@@ -209,7 +209,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	AssertAllowedKeyClass(key, allowedKeyClasses);
 #endif
 	
-	__unsafe_unretained YapBidirectionalCacheItem *item = CFDictionaryGetValue(key_obj_dict, (const void *)key);
+	__unsafe_unretained YapBidirectionalCacheItem *item = (__bridge YapBidirectionalCacheItem *)CFDictionaryGetValue(key_obj_dict, (__bridge const void *)key);
 	if (item)
 	{
 		if (item != mostRecentCacheItem)
@@ -257,7 +257,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	AssertAllowedKeyClass(key, allowedKeyClasses);
 #endif
 	
-	return CFDictionaryContainsKey(key_obj_dict, (const void *)key);
+	return CFDictionaryContainsKey(key_obj_dict, (__bridge const void *)key);
 }
 
 - (id)keyForObject:(id)object
@@ -266,7 +266,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	AssertAllowedObjectClass(object, allowedObjectClasses);
 #endif
 	
-	__unsafe_unretained YapBidirectionalCacheItem *item = CFDictionaryGetValue(obj_key_dict, (const void *)object);
+	__unsafe_unretained YapBidirectionalCacheItem *item = (__bridge YapBidirectionalCacheItem *)CFDictionaryGetValue(obj_key_dict, (__bridge const void *)object);
 	if (item)
 	{
 		if (item != mostRecentCacheItem)
@@ -314,7 +314,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	AssertAllowedObjectClass(object, allowedObjectClasses);
 #endif
 	
-	return CFDictionaryContainsKey(obj_key_dict, (const void *)object);
+	return CFDictionaryContainsKey(obj_key_dict, (__bridge const void *)object);
 }
 
 - (NSUInteger)count
@@ -329,20 +329,20 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	AssertAllowedObjectClass(object, allowedObjectClasses);
 	#endif
 	
-	__unsafe_unretained YapBidirectionalCacheItem *existingItem = CFDictionaryGetValue(key_obj_dict, (const void *)key);
+	__unsafe_unretained YapBidirectionalCacheItem *existingItem = (__bridge YapBidirectionalCacheItem *)CFDictionaryGetValue(key_obj_dict, (__bridge const void *)key);
 	if (existingItem)
 	{
 		// Update item value
 		if (!objCallBacks.equal((__bridge const void *)existingItem->obj, (__bridge const void *)object))
 		{
-			CFDictionaryRemoveValue(obj_key_dict, (const void *)existingItem->obj);
+			CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)existingItem->obj);
 			
 			if (objCallBacks.shouldCopy)
 				existingItem->obj = [object copy];
 			else
 				existingItem->obj = object;
 			
-			CFDictionarySetValue(obj_key_dict, (const void *)existingItem->obj, (const void *)existingItem);
+			CFDictionarySetValue(obj_key_dict, (__bridge const void *)existingItem->obj, (__bridge const void *)existingItem);
 		}
 		
 		if (existingItem != mostRecentCacheItem)
@@ -408,8 +408,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 		
 		// Add item to dicts
 		
-		CFDictionarySetValue(key_obj_dict, (const void *)newKey, (const void *)newItem);
-		CFDictionarySetValue(obj_key_dict, (const void *)newItem->obj, (const void *)newItem);
+		CFDictionarySetValue(key_obj_dict, (__bridge const void *)newKey, (__bridge const void *)newItem);
+		CFDictionarySetValue(obj_key_dict, (__bridge const void *)newItem->obj, (__bridge const void *)newItem);
 		
 		// Add item to beginning of linked-list
 		
@@ -436,8 +436,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 				leastRecentCacheItem = leastRecentCacheItem->prev;
 				leastRecentCacheItem->next = nil;
 				
-				CFDictionaryRemoveValue(obj_key_dict, (const void *)(objToEvict)); // must be first
-				CFDictionaryRemoveValue(key_obj_dict, (const void *)(keyToEvict)); // must be second
+				CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)(objToEvict)); // must be first
+				CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)(keyToEvict)); // must be second
 				
 				evictedCacheItem->prev = nil;
 				evictedCacheItem->next = nil;
@@ -449,8 +449,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 				leastRecentCacheItem = leastRecentCacheItem->prev;
 				leastRecentCacheItem->next = nil;
 				
-				CFDictionaryRemoveValue(obj_key_dict, (const void *)(objToEvict)); // must be first
-				CFDictionaryRemoveValue(key_obj_dict, (const void *)(keyToEvict)); // must be second
+				CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)(objToEvict)); // must be first
+				CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)(keyToEvict)); // must be second
 			}
 			
 			#if YapBidirectionalCache_Enable_Statistics
@@ -501,7 +501,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	AssertAllowedKeyClass(key, allowedKeyClasses);
 	#endif
 	
-	__unsafe_unretained YapBidirectionalCacheItem *item = CFDictionaryGetValue(key_obj_dict, (const void *)key);
+	__unsafe_unretained YapBidirectionalCacheItem *item = (__bridge YapBidirectionalCacheItem *)CFDictionaryGetValue(key_obj_dict, (__bridge const void *)key);
 	if (item)
 	{
 		if (item == mostRecentCacheItem)
@@ -514,8 +514,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 		else if (item->next)
 			item->next->prev = item->prev;
 		
-		CFDictionaryRemoveValue(obj_key_dict, (const void *)item->obj); // must be first
-		CFDictionaryRemoveValue(key_obj_dict, (const void *)item->key); // must be second
+		CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)item->obj); // must be first
+		CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)item->key); // must be second
 	}
 }
 
@@ -527,7 +527,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 		AssertAllowedKeyClass(key, allowedKeyClasses);
 		#endif
 		
-		__unsafe_unretained YapBidirectionalCacheItem *item = CFDictionaryGetValue(key_obj_dict, (const void *)key);
+		__unsafe_unretained YapBidirectionalCacheItem *item = (__bridge YapBidirectionalCacheItem *)CFDictionaryGetValue(key_obj_dict, (__bridge const void *)key);
 		if (item)
 		{
 			if (item == mostRecentCacheItem)
@@ -540,8 +540,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 			else if (item->next)
 				item->next->prev = item->prev;
 			
-			CFDictionaryRemoveValue(obj_key_dict, (const void *)item->obj); // must be first
-			CFDictionaryRemoveValue(key_obj_dict, (const void *)item->key); // must be second
+			CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)item->obj); // must be first
+			CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)item->key); // must be second
 		}
 	}
 }
@@ -552,7 +552,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 	AssertAllowedObjectClass(object, allowedObjectClasses);
 	#endif
 	
-	__unsafe_unretained YapBidirectionalCacheItem *item = CFDictionaryGetValue(obj_key_dict, (const void *)object);
+	__unsafe_unretained YapBidirectionalCacheItem *item = (__bridge YapBidirectionalCacheItem *)CFDictionaryGetValue(obj_key_dict, (__bridge const void *)object);
 	if (item)
 	{
 		if (item == mostRecentCacheItem)
@@ -565,8 +565,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 		else if (item->next)
 			item->next->prev = item->prev;
 		
-		CFDictionaryRemoveValue(obj_key_dict, (const void *)item->obj); // must be first
-		CFDictionaryRemoveValue(key_obj_dict, (const void *)item->key); // must be second
+		CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)item->obj); // must be first
+		CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)item->key); // must be second
 	}
 }
 
@@ -578,7 +578,7 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 		AssertAllowedObjectClass(object, allowedObjectClasses);
 		#endif
 		
-		__unsafe_unretained YapBidirectionalCacheItem *item = CFDictionaryGetValue(obj_key_dict, (const void *)object);
+		__unsafe_unretained YapBidirectionalCacheItem *item = (__bridge YapBidirectionalCacheItem *)CFDictionaryGetValue(obj_key_dict, (__bridge const void *)object);
 		if (item)
 		{
 			if (item == mostRecentCacheItem)
@@ -591,8 +591,8 @@ const YapBidirectionalCacheCallBacks kYapBidirectionalCacheDefaultCallBacks = (Y
 			else if (item->next)
 				item->next->prev = item->prev;
 			
-			CFDictionaryRemoveValue(obj_key_dict, (const void *)item->obj); // must be first
-			CFDictionaryRemoveValue(key_obj_dict, (const void *)item->key); // must be second
+			CFDictionaryRemoveValue(obj_key_dict, (__bridge const void *)item->obj); // must be first
+			CFDictionaryRemoveValue(key_obj_dict, (__bridge const void *)item->key); // must be second
 		}
 	}
 }

--- a/YapDatabase/Utilities/YapCache.m
+++ b/YapDatabase/Utilities/YapCache.m
@@ -152,7 +152,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 					leastRecentCacheItem->next = nil;
 				}
 				
-				CFDictionaryRemoveValue(cfdict, (const void *)(keyToEvict));
+				CFDictionaryRemoveValue(cfdict, (__bridge const void *)(keyToEvict));
 				
 				#if YapCache_Enable_Statistics
 				evictionCount++;
@@ -168,7 +168,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 	AssertAllowedKeyClass(key, allowedKeyClasses);
 	#endif
 	
-	__unsafe_unretained YapCacheItem *item = CFDictionaryGetValue(cfdict, (const void *)key);
+	__unsafe_unretained YapCacheItem *item = (__bridge YapCacheItem *)CFDictionaryGetValue(cfdict, (__bridge const void *)key);
 	if (item)
 	{
 		if (item != mostRecentCacheItem)
@@ -216,7 +216,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 	AssertAllowedKeyClass(key, allowedKeyClasses);
 	#endif
 	
-	return CFDictionaryContainsKey(cfdict, (const void *)key);
+	return CFDictionaryContainsKey(cfdict, (__bridge const void *)key);
 }
 
 - (void)setObject:(id)object forKey:(id)key
@@ -226,7 +226,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 	AssertAllowedObjectClass(object, allowedObjectClasses);
 	#endif
 	
-	__unsafe_unretained YapCacheItem *existingItem = CFDictionaryGetValue(cfdict, (const void *)key);
+	__unsafe_unretained YapCacheItem *existingItem = (__bridge YapCacheItem *)CFDictionaryGetValue(cfdict, (__bridge const void *)key);
 	if (existingItem)
 	{
 		// Update item value
@@ -283,7 +283,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 		}
 		
 		// Add item to set
-		CFDictionarySetValue(cfdict, (const void *)key, (const void *)newItem);
+		CFDictionarySetValue(cfdict, (__bridge const void *)key, (__bridge const void *)newItem);
 		
 		// Add item to beginning of linked-list
 		
@@ -320,7 +320,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 				leastRecentCacheItem->next = nil;
 			}
 			
-			CFDictionaryRemoveValue(cfdict, (const void *)(keyToEvict));
+			CFDictionaryRemoveValue(cfdict, (__bridge const void *)(keyToEvict));
 			
 			#if YapCache_Enable_Statistics
 			evictionCount++;
@@ -373,7 +373,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 	AssertAllowedKeyClass(key, allowedKeyClasses);
 	#endif
 	
-	__unsafe_unretained YapCacheItem *item = CFDictionaryGetValue(cfdict, (const void *)key);
+	__unsafe_unretained YapCacheItem *item = (__bridge YapCacheItem *)CFDictionaryGetValue(cfdict, (__bridge const void *)key);
 	if (item)
 	{
 		if (mostRecentCacheItem == item)
@@ -386,7 +386,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 		else if (item->next)
 			item->next->prev = item->prev;
 		
-		CFDictionaryRemoveValue(cfdict, (const void *)key);
+		CFDictionaryRemoveValue(cfdict, (__bridge const void *)key);
 	}
 }
 
@@ -398,7 +398,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 		AssertAllowedKeyClass(key, allowedKeyClasses);
 		#endif
 		
-		__unsafe_unretained YapCacheItem *item = CFDictionaryGetValue(cfdict, (const void *)key);
+		__unsafe_unretained YapCacheItem *item = (__bridge YapCacheItem *)CFDictionaryGetValue(cfdict, (__bridge const void *)key);
 		if (item)
 		{
 			if (mostRecentCacheItem == item)
@@ -411,7 +411,7 @@ static const NSUInteger YapCache_Default_CountLimit = 40;
 			else if (item->next)
 				item->next->prev = item->prev;
 			
-			CFDictionaryRemoveValue(cfdict, (const void *)key);
+			CFDictionaryRemoveValue(cfdict, (__bridge const void *)key);
 		}
 	}
 }

--- a/YapDatabase/Utilities/YapSet.m
+++ b/YapDatabase/Utilities/YapSet.m
@@ -42,7 +42,7 @@
 	if (set)
 		return [set containsObject:object];
 	else
-		return CFDictionaryContainsKey((__bridge CFDictionaryRef)dictionary, (const void *)object);
+		return CFDictionaryContainsKey((__bridge CFDictionaryRef)dictionary, (__bridge const void *)object);
 }
 
 - (BOOL)intersectsSet:(NSSet *)otherSet
@@ -55,7 +55,7 @@
 	{
 		for (id object in otherSet)
 		{
-			if (CFDictionaryContainsKey((__bridge CFDictionaryRef)dictionary, (const void *)object))
+			if (CFDictionaryContainsKey((__bridge CFDictionaryRef)dictionary, (__bridge const void *)object))
 				return YES;
 		}
 		

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -6042,7 +6042,7 @@ static int connectionBusyHandler(void *ptr, int count)
 	
 	// Loop through the backup process
 	
-	BOOL cancelled = progress.cancelled;
+	BOOL cancelled = progress.isCancelled;
 	if (!cancelled)
 	{
 		while ((status = sqlite3_backup_step(backup, nPages)) == SQLITE_OK)
@@ -6055,7 +6055,7 @@ static int connectionBusyHandler(void *ptr, int count)
 				progress.totalUnitCount = pagecount;
 				progress.completedUnitCount = (pagecount - remaining);
 				
-				cancelled = progress.cancelled;
+				cancelled = progress.isCancelled;
 				if (cancelled) break;
 			}
 		}

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -2024,7 +2024,11 @@ static int connectionBusyHandler(void *ptr, int count)
 				NSUInteger count = transaction->completionBlockStack.count;
 				for (NSUInteger i = 0; i < count; i++)
 				{
+#if OS_OBJECT_USE_OBJC
 					dispatch_queue_t stackItemQueue = transaction->completionQueueStack[i];
+#else
+					dispatch_queue_t stackItemQueue = (dispatch_queue_t)[transaction->completionQueueStack[i] pointerValue];
+#endif
 					dispatch_block_t stackItemBlock = transaction->completionBlockStack[i];
 					
 					dispatch_async(stackItemQueue, stackItemBlock);
@@ -2239,7 +2243,11 @@ static int connectionBusyHandler(void *ptr, int count)
 				NSUInteger count = transaction->completionBlockStack.count;
 				for (NSUInteger i = 0; i < count; i++)
 				{
+#if OS_OBJECT_USE_OBJC
 					dispatch_queue_t stackItemQueue = transaction->completionQueueStack[i];
+#else
+					dispatch_queue_t stackItemQueue = [transaction->completionQueueStack[i] pointerValue];
+#endif
 					dispatch_block_t stackItemBlock = transaction->completionBlockStack[i];
 					
 					dispatch_async(stackItemQueue, stackItemBlock);


### PR DESCRIPTION
A couple small changes needed to build YapDatabase with the [GNUstep Android toolchain](https://github.com/gnustep/tools-android):

- added `__bridge` annotations in various places (mainly to convert from/to `void` pointers) – these seem to be optional in these places with Apple’s toolchains (not sure why), but also make the code more explicit.
- added support for building without `OS_OBJECT_USE_OBJC`, i.e. when libdispatch objects are not bridged to ObjC objects.
- Use `isCancelled` getter for NSProgress’ `cancelled` property – both getters are supported on Apple platforms, but GNUstep only defines this one getter.

As most of these are fairly small changes I thought you might be willing to upstream these, but if not we’re also happy to keep using our branch.

We’ve been running YapDatabase with these changes on Android for a couple of months now for our app (currently in beta), and it’s been working great.